### PR TITLE
[CHK-584] Get payment request info given notice code and tax code

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -26,7 +26,7 @@ steps:
       extraProperties: |
         sonar.projectKey=$(SONARCLOUD_PROJECT_KEY)
         sonar.projectName=$(SONARCLOUD_PROJECT_NAME)
-        sonar.coverage.exclusions=**/config/*,**/*Mock*,**/model/*
+        sonar.coverage.exclusions=**/config/*,**/*Mock*,**/model/*,**/utils/soap/*
         sonar.coverage.jacoco.xmlReportPaths=./target/site/jacoco/jacoco.xml
         sonar.junit.reportPaths=target/surefire-reports/
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ pagopa-ecommerce-transactions-service-pagopa-ecommerce-transactions-1  | 2022-04
 When running with the Docker container you can check data persisted to either Mongo or Redis with their respective web interfaces (Mongo express/Redis Insight). To do so, go to:
  * http://localhost:8001 for Redis Insight
  * http://localhost:8081 for Mongo Express
+
+## Run the application with `springboot-plugin`
+
+Create your environment:
+```sh
+export $(grep -v '^#' .env.local | xargs)
+``` 
+
+Then from current project directory run :
+```sh
+ mvn spring-boot:run
+```

--- a/api-spec/payment-requests-api.yaml
+++ b/api-spec/payment-requests-api.yaml
@@ -98,246 +98,112 @@ components:
         - paymentContextCode
     ValidationFaultPaymentProblemJson:
       description: |-
-        A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
+        A PaymentProblemJson-like type specific for the GetPayment operations.
         Possible values of `detail_v2` are limited to faults pertaining to validation errors.
       type: object
       properties:
-        type:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the problem type. When dereferenced,
-            it SHOULD provide human-readable documentation for the problem type
-            (e.g., using HTML).
-          default: about:blank
-          example: https://example.com/problem/constraint-violation
         title:
           type: string
           description: |-
             A short, summary of the problem type. Written in english and readable
             for engineers (usually not suited for non technical stakeholders and
             not localized); example: Service Unavailable
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 600
-          exclusiveMaximum: true
-        category:
+        faultCodeCategory:
           $ref: '#/components/schemas/FaultCategory'
-        detail:
+        faultCodeDetail:
           $ref: '#/components/schemas/ValidationFault'
-        instance:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the specific occurrence of the problem.
-            It may or may not yield further information if dereferenced.
       required:
-        - category
-        - detail
+        - faultCodeCategory
+        - faultCodeDetail
     PaymentStatusFaultPaymentProblemJson:
       description: |-
         A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
         Possible values of `detail_v2` are limited to faults pertaining to Nodo errors related to payment status conflicts.
       type: object
       properties:
-        type:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the problem type. When dereferenced,
-            it SHOULD provide human-readable documentation for the problem type
-            (e.g., using HTML).
-          default: about:blank
-          example: https://example.com/problem/constraint-violation
         title:
           type: string
           description: |-
             A short, summary of the problem type. Written in english and readable
             for engineers (usually not suited for non technical stakeholders and
             not localized); example: Service Unavailable
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 600
-          exclusiveMaximum: true
-        category:
+        faultCodeCategory:
           $ref: '#/components/schemas/FaultCategory'
-        detail:
+        faultCodeDetail:
           $ref: '#/components/schemas/PaymentStatusFault'
-        instance:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the specific occurrence of the problem.
-            It may or may not yield further information if dereferenced.
       required:
-        - category
-        - detail
+        - faultCodeCategory
+        - faultCodeDetail
     GatewayFaultPaymentProblemJson:
       description: |-
         A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
         Possible values of `detail_v2` are limited to faults pertaining to Nodo errors.
       type: object
       properties:
-        type:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the problem type. When dereferenced,
-            it SHOULD provide human-readable documentation for the problem type
-            (e.g., using HTML).
-          default: about:blank
-          example: https://example.com/problem/constraint-violation
         title:
           type: string
           description: |-
             A short, summary of the problem type. Written in english and readable
             for engineers (usually not suited for non technical stakeholders and
             not localized); example: Service Unavailable
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 600
-          exclusiveMaximum: true
-        category:
+        faultCodeCategory:
           $ref: '#/components/schemas/FaultCategory'
-        detail:
+        faultCodeDetail:
           $ref: '#/components/schemas/GatewayFault'
-        instance:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the specific occurrence of the problem.
-            It may or may not yield further information if dereferenced.
       required:
-        - category
-        - detail
+        - faultCodeCategory
+        - faultCodeDetail
     PartyConfigurationFaultPaymentProblemJson:
       description: |-
-        A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
-        Possible values of `detail_v2` are limited to faults pertaining to EC fatal errors.
+        A PaymentProblemJson-like type specific for the GetPayment
       type: object
       properties:
-        type:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the problem type. When dereferenced,
-            it SHOULD provide human-readable documentation for the problem type
-            (e.g., using HTML).
-          default: about:blank
-          example: https://example.com/problem/constraint-violation
         title:
           type: string
           description: |-
             A short, summary of the problem type. Written in english and readable
             for engineers (usually not suited for non technical stakeholders and
             not localized); example: Service Unavailable
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 600
-          exclusiveMaximum: true
-        category:
+        faultCodeCategory:
           $ref: '#/components/schemas/FaultCategory'
-        detail:
+        faultCodeDetail:
           $ref: '#/components/schemas/PartyConfigurationFault'
-        instance:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the specific occurrence of the problem.
-            It may or may not yield further information if dereferenced.
       required:
-        - category
-        - detail
+        - faultCodeCategory
+        - faultCodeDetail
     PartyTimeoutFaultPaymentProblemJson:
       description: |-
-        A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.
-        Possible values of `detail_v2` are limited to faults pertaining to EC timeouts.
+        A PaymentProblemJson-like type specific for the GetPayment an operations.
       type: object
       properties:
-        type:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the problem type. When dereferenced,
-            it SHOULD provide human-readable documentation for the problem type
-            (e.g., using HTML).
-          default: about:blank
-          example: https://example.com/problem/constraint-violation
+        faultCodeCategory:
+          $ref: '#/components/schemas/FaultCategory'
+        faultCodeDetail:
+          $ref: '#/components/schemas/PartyTimeoutFault'
         title:
           type: string
           description: |-
             A short, summary of the problem type. Written in english and readable
             for engineers (usually not suited for non technical stakeholders and
             not localized); example: Service Unavailable
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 600
-          exclusiveMaximum: true
-        category:
-          $ref: '#/components/schemas/FaultCategory'
-        detail:
-          $ref: '#/components/schemas/PartyTimeoutFault'
-        instance:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the specific occurrence of the problem.
-            It may or may not yield further information if dereferenced.
       required:
-        - category
-        - detail
-    HttpStatusCode:
-      type: integer
-      format: int32
-      description: |-
-        The HTTP status code generated by the origin server for this occurrence
-          of the problem.
-      minimum: 100
-      maximum: 600
-      exclusiveMaximum: true
-      example: 200
+        - faultCodeCategory
+        - faultCodeCategory
     ProblemJson:
       type: object
       properties:
-        type:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the problem type. When dereferenced,
-            it SHOULD provide human-readable documentation for the problem type
-            (e.g., using HTML).
-          default: about:blank
-          example: https://example.com/problem/constraint-violation
         title:
           type: string
           description: |-
             A short, summary of the problem type. Written in english and readable
             for engineers (usually not suited for non technical stakeholders and
             not localized); example: Service Unavailable
-        status:
-          $ref: '#/components/schemas/HttpStatusCode'
         detail:
           type: string
           description: |-
             A human readable explanation specific to this occurrence of the
             problem.
           example: There was an error processing the request
-        instance:
-          type: string
-          format: uri
-          description: |-
-            An absolute URI that identifies the specific occurrence of the problem.
-            It may or may not yield further information if dereferenced.
     FaultCategory:
       description: |-
         Fault code categorization for the PagoPA Verifica and Attiva operations.
@@ -351,7 +217,7 @@ components:
         - `PAYMENT_CANCELED`
         - `GENERIC_ERROR`
       type: string
-      x-extensible-enum:
+      enum:
         - PAYMENT_DUPLICATED
         - PAYMENT_ONGOING
         - PAYMENT_EXPIRED
@@ -373,7 +239,7 @@ components:
         - `PAA_PAGAMENTO_DUPLICATO`
         - `PAA_PAGAMENTO_SCADUTO`
       type: string
-      x-extensible-enum:
+      enum:
         - PPT_PAGAMENTO_IN_CORSO
         - PAA_PAGAMENTO_IN_CORSO
         - PPT_PAGAMENTO_DUPLICATO
@@ -391,7 +257,7 @@ components:
         - `PPT_STAZIONE_INT_PA_SCONOSCIUTA`
         - `PAA_PAGAMENTO_ANNULLATO`
       type: string
-      x-extensible-enum:
+      enum:
         - PAA_PAGAMENTO_SCONOSCIUTO
         - PPT_DOMINIO_SCONOSCIUTO
         - PPT_INTERMEDIARIO_PA_SCONOSCIUTO
@@ -419,7 +285,7 @@ components:
         - `PPT_SYSTEM_ERROR`
         - `PAA_SYSTEM_ERROR`
       type: string
-      x-extensible-enum:
+      enum:
         - GENERIC_ERROR
         - PPT_SINTASSI_EXTRAXSD
         - PPT_SINTASSI_XSD
@@ -454,7 +320,7 @@ components:
         - `PAA_STAZIONE_INT_ERRATA`
         - `PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO`
       type: string
-      x-extensible-enum:
+      enum:
         - PPT_DOMINIO_DISABILITATO
         - PPT_INTERMEDIARIO_PA_DISABILITATO
         - PPT_STAZIONE_INT_PA_DISABILITATA
@@ -477,7 +343,7 @@ components:
         - `PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO`
         - `GENERIC_ERROR`
       type: string
-      x-extensible-enum:
+      enum:
         - PPT_STAZIONE_INT_PA_TIMEOUT
         - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE
         - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO

--- a/api-spec/payment-requests-api.yaml
+++ b/api-spec/payment-requests-api.yaml
@@ -188,7 +188,7 @@ components:
             not localized); example: Service Unavailable
       required:
         - faultCodeCategory
-        - faultCodeCategory
+        - faultCodeDetail
     ProblemJson:
       type: object
       properties:

--- a/api-spec/payment-requests-api.yaml
+++ b/api-spec/payment-requests-api.yaml
@@ -63,8 +63,23 @@ components:
     PaymentRequestsGetResponse:
       type: object
       title: PaymentRequestsGetResponse
-      description: Respone with payment request information
+      description: Response with payment request information
       properties:
+        rptId:
+          type: string
+          pattern: '([a-zA-Z\d]{1,35})|(RF\d{2}[a-zA-Z\d]{1,21})'
+        paTaxCode:
+          type: string
+          minLength: 11
+          maxLength: 11
+        paName:
+          type: string
+          minLength: 1
+          maxLength: 70
+        description:
+          type: string
+          minLength: 1
+          maxLength: 140
         amount:
           type: integer
           minimum: 0
@@ -73,22 +88,6 @@ components:
           type: string
           minLength: 32
           maxLength: 32
-        reason:
-          type: string
-          minLength: 1
-          maxLength: 140
-        PAId:
-          type: string
-          minLength: 1
-          maxLength: 35
-        PAName:
-          type: string
-          minLength: 1
-          maxLength: 35
-        denominazioneBeneficiario:
-          type: string
-          minLength: 1
-          maxLength: 70
         dueDate:
           type: string
           pattern:  >-
@@ -97,7 +96,6 @@ components:
       required:
         - amount
         - paymentContextCode
-        - PAId
     ValidationFaultPaymentProblemJson:
       description: |-
         A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.

--- a/nodo-wsdl/nodoPerPsp.wsdl
+++ b/nodo-wsdl/nodoPerPsp.wsdl
@@ -1,0 +1,1084 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Questo WSDL rappresenta l'interfaccia esposta dal Nodo dei Pagamenti Telematici
+  per la verifica dei pagamenti in attesa verso i PSP.
+-->
+<wsdl:definitions name="PPT"
+                  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+                  xmlns:ppt="http://ws.pagamenti.telematici.gov/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:tns="http://PuntoAccessoPSP.spcoop.gov.it/servizi/PagamentiTelematiciPspNodo"
+                  targetNamespace="http://PuntoAccessoPSP.spcoop.gov.it/servizi/PagamentiTelematiciPspNodo">
+
+    <wsdl:types>
+
+        <xsd:schema version="1.0" targetNamespace="http://ws.pagamenti.telematici.gov/">
+            <xsd:simpleType name="stCF">
+                <xsd:restriction base="xsd:string">
+                    <xsd:length value="11"/>
+                    <xsd:pattern value="[0-9]{11}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stAuxDigit">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="0"/>
+                    <xsd:enumeration value="1"/>
+                    <xsd:enumeration value="2"/>
+                    <xsd:enumeration value="3"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stCodStazPA">
+                <xsd:restriction base="xsd:string">
+                    <xsd:length value="2"/>
+                    <xsd:pattern value="[0-9]{2}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stCodIUV">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[0-9]{15}|[0-9]{17}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:complexType name="nodoTipoCodiceIdRPT">
+                <xsd:choice minOccurs="1" maxOccurs="1" >
+                    <xsd:element name="QrCode">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element type="ppt:stCF" name="CF" minOccurs="1"/>
+                                <xsd:element type="ppt:stCodStazPA" name="CodStazPA" minOccurs="0"/>
+                                <xsd:element type="ppt:stAuxDigit" name="AuxDigit" minOccurs="1"/>
+                                <xsd:element type="ppt:stCodIUV" name="CodIUV" minOccurs="1"/>
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
+            </xsd:complexType>
+
+            <!-- **** BEGIN: tipi semplici  ****-->
+
+            <xsd:simpleType name="stISODate">
+                <xsd:restriction base="xsd:date"/>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stISODateTime">
+                <xsd:restriction base="xsd:dateTime"/>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stText16">
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1"/>
+                    <xsd:maxLength value="16"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stText35">
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1"/>
+                    <xsd:maxLength value="35"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stText70">
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1"/>
+                    <xsd:maxLength value="70"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stText140">
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1"/>
+                    <xsd:maxLength value="140"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stAutenticazioneSoggetto">
+                <xsd:restriction base="xsd:string">
+                    <xsd:maxLength value="4"/>
+                    <xsd:enumeration value="CNS"/>
+                    <!-- CIE/CNS -->
+                    <xsd:enumeration value="USR"/>
+                    <!-- Userid e passaword -->
+                    <xsd:enumeration value="OTH"/>
+                    <!-- Altro -->
+                    <xsd:enumeration value="N/A"/>
+                    <!-- Non applicabile -->
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stCodiceEsitoPagamento">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[0-9]{1,1}"/>
+                    <xsd:enumeration value="0"/>
+                    <!-- Pagamento eseguito -->
+                    <xsd:enumeration value="1"/>
+                    <!-- Pagamento non eseguito -->
+                    <xsd:enumeration value="2"/>
+                    <!-- Pagamento parzialmente eseguito -->
+                    <xsd:enumeration value="3"/>
+                    <!-- Decorrenza termini -->
+                    <xsd:enumeration value="4"/>
+                    <!-- Decorrenza termini parziale -->
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stImporto">
+                <xsd:restriction base="xsd:decimal">
+                    <xsd:minInclusive value="0.00"/>
+                    <xsd:maxInclusive value="99999999.99"/>
+                    <xsd:fractionDigits value="2"/>
+                    <xsd:totalDigits value="12"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stNazioneProvincia">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[A-Z]{2,2}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stTipoVersamento">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BBT"/>
+                    <!-- Bonifico Bancario di Tesoreria -->
+                    <xsd:enumeration value="BP"/>
+                    <!--- Bollettino Postale -->
+                    <xsd:enumeration value="AD"/>
+                    <!--- Addebito Diretto -->
+                    <xsd:enumeration value="CP"/>
+                    <!--- Carta di Pagamento -->
+                    <xsd:enumeration value="PO"/>
+                    <!--- Pagamento attivato presso PSP -->
+                    <xsd:enumeration value="OBEP"/>
+                    <!--- On-line Banking E-Payment -->
+                    <xsd:enumeration value="OTH"/>
+                    <!-- Altre forme di versamento -->
+                    <xsd:maxLength value="4"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stDatiSpecificiRiscossione">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[0129]{1}/\S{3,138}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stIBANIdentifier">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[a-zA-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stFirmaRicevuta">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="0"/>
+                    <!-- Firma non richiesta -->
+                    <xsd:enumeration value="1"/>
+                    <!-- CaDes -->
+                    <xsd:enumeration value="3"/>
+                    <!-- XaDes -->
+                    <xsd:enumeration value="4"/>
+                    <!-- Elettronica avanzata -->
+                    <xsd:length value="1"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stTipoIdentificativoUnivoco">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="G"/>
+                    <!-- Persona Giuridica -->
+                    <xsd:enumeration value="A"/>
+                    <!-- Codice ABI -->
+                    <xsd:enumeration value="B"/>
+                    <!-- Codice BIC -->
+                    <xsd:length value="1"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stTipoIdentificativoUnivocoPersFG">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="F"/>
+                    <!-- Persona Fisica -->
+                    <xsd:enumeration value="G"/>
+                    <!-- Persona Giuridica -->
+                    <xsd:length value="1"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stTipoIdentificativoUnivocoPersG">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="G"/>
+                    <!-- Persona Giuridica -->
+                    <xsd:length value="1"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stBICIdentifier">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stEMail">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="[A-Za-z0-9_]+([\-\+\.'][A-Za-z0-9_]+)*@[A-Za-z0-9_]+([\-\.][A-Za-z0-9_]+)*\.[A-Za-z0-9_]+([\-\.][A-Za-z0-9_]+)*"/>
+                    <xsd:maxLength value="256"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stTipoBollo">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="01"/>
+                    <!-- Imposta di bollo -->
+                    <xsd:length value="2"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stTipoAllegatoRicevuta">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ES"/>
+                    <!-- Esito originario pagamento (come ricevuto da PSP) -->
+                    <xsd:enumeration value="BD"/>
+                    <!-- Marca da bollo digitale  -->
+                    <xsd:length value="2"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stBase64">
+                <xsd:restriction base="xsd:base64Binary">
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <!-- **** END: tipi semplici  ****-->
+
+            <!-- **** BEGIN: tipi complessi  ****-->
+
+            <!-- Dominio -->
+            <xsd:complexType name="ctDominio">
+                <xsd:sequence>
+                    <xsd:element name="identificativoDominio" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico contenente il codice fiscale della struttura che invia la richiesta di pagamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="identificativoStazioneRichiedente" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifica la stazione richiedente il pagamento. Nella fattispecie assume il codice del PdA richiedente o quello del Portale del ministero.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="ctDatiMarcaBolloDigitale">
+                <xsd:sequence>
+                    <xsd:element name="tipoBollo" type="ppt:stTipoBollo" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la tipologia di Bollo Digitale.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="hashDocumento" type="ppt:stText70" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene l’impronta informatica (digest), rappresentata in “base 64 binary”, del documento informatico o della segnatura di protocollo cui è associata la marca da bollo digitale</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="provinciaResidenza" type="ppt:stNazioneProvincia" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Sigla automobilistica della provincia di residenza del soggetto pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="ctAllegatoRicevuta">
+                <xsd:sequence>
+                    <xsd:element name="tipoAllegatoRicevuta" type="ppt:stTipoAllegatoRicevuta" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifica il tipo di allegato trasportato con la RT.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="testoAllegato" type="ppt:stBase64" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene l’allegato vero e proprio, il cui significato è indicato dal dato tipoAllegatoRicevuta.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- **** BEGIN: Identificativi univoci dei soggetti -->
+            <xsd:complexType name="ctIdentificativoUnivoco">
+                <xsd:sequence>
+                    <xsd:element name="tipoIdentificativoUnivoco" type="ppt:stTipoIdentificativoUnivoco" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico che indica la natura del soggetto,  può assumere i seguenti valori:</xsd:documentation>
+                            <xsd:documentation>G - Persona Giuridica</xsd:documentation>
+                            <xsd:documentation>A - Codice ABI</xsd:documentation>
+                            <xsd:documentation>B - Codice BIC</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="codiceIdentificativoUnivoco" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico che può contenere il codice fiscale o la partita IVA del soggetto o il codice ABI o il codice BIC</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="ctIdentificativoUnivocoPersonaFG">
+                <xsd:sequence>
+                    <xsd:element name="tipoIdentificativoUnivoco" type="ppt:stTipoIdentificativoUnivocoPersFG" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico che indica la natura del soggetto,  può assumere i seguenti valori:</xsd:documentation>
+                            <xsd:documentation>F - Persona Fisica</xsd:documentation>
+                            <xsd:documentation>G - Persona Giuridica</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="codiceIdentificativoUnivoco" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico che può contenere il codice fiscale o, in alternativa, la partita IVA del soggetto.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="ctIdentificativoUnivocoPersonaG">
+                <xsd:sequence>
+                    <xsd:element name="tipoIdentificativoUnivoco" type="ppt:stTipoIdentificativoUnivocoPersG" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico che indica la natura del soggetto,  può assumere i seguenti valori:</xsd:documentation>
+                            <xsd:documentation>G - Persona Giuridica</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="codiceIdentificativoUnivoco" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo alfanumerico che può contenere il codice fiscale o, in alternativa, la partita IVA del soggetto.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- **** END: Identificativi univoci dei soggetti-->
+
+            <!-- **** BEGIN: Soggetti-->
+            <!-- Soggetto Versante-->
+            <xsd:complexType name="ctSoggettoVersante">
+                <xsd:sequence>
+                    <xsd:element name="identificativoUnivocoVersante" type="ppt:ctIdentificativoUnivocoPersonaFG" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione che riporta le informazioni concernenti l’identificazione fiscale del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="anagraficaVersante" type="ppt:stText70" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il nominativo o la ragione sociale del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="indirizzoVersante" type="ppt:stText70" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica l’indirizzo del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="civicoVersante" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il numero civico del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="capVersante" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il CAP del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="localitaVersante" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la località del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="provinciaVersante" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la provincia del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="nazioneVersante" type="ppt:stNazioneProvincia" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il codice nazione del versante secondo lo standard ISO 3166.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="e-mailVersante" type="ppt:stEMail" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indirizzo di posta elettronica del versante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Soggetto Pagatore-->
+            <xsd:complexType name="ctSoggettoPagatore">
+                <xsd:sequence>
+                    <xsd:element name="identificativoUnivocoPagatore" type="ppt:ctIdentificativoUnivocoPersonaFG" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione che riporta le informazioni concernenti l’identificazione fiscale del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="anagraficaPagatore" type="ppt:stText70" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il nominativo o la ragione sociale del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="indirizzoPagatore" type="ppt:stText70" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica l’indirizzo del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="civicoPagatore" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il numero civico del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="capPagatore" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il CAP del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="localitaPagatore" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la località del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="provinciaPagatore" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la provincia del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="nazionePagatore" type="ppt:stNazioneProvincia" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il codice nazione del pagatore secondo lo standard ISO 3166.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="e-mailPagatore" type="ppt:stEMail" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indirizzo di posta elettronica del pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Ente Beneficiario-->
+            <xsd:complexType name="ctEnteBeneficiario">
+                <xsd:sequence>
+                    <xsd:element name="identificativoUnivocoBeneficiario" type="ppt:ctIdentificativoUnivocoPersonaG" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione che riporta le informazioni concernenti l’identificazione fiscale dell’ente beneficiario.</xsd:documentation>
+                            <xsd:documentation>tipo_identificativo_univoco - se presente deve assumere il valore ‘G’, Persona Giuridica.</xsd:documentation>
+                            <xsd:documentation>codice_identificativo_univoco - contenente il codice fiscale dell’amministrazione destinataria del pagamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="denominazioneBeneficiario" type="ppt:stText70" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la denominazione della PA.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="codiceUnitOperBeneficiario" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il codice dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="denomUnitOperBeneficiario" type="ppt:stText70" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la denominazione dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="indirizzoBeneficiario" type="ppt:stText70" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica l’indirizzo dell’ente beneficiario.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="civicoBeneficiario" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il numero civico del beneficiario.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="capBeneficiario" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il CAP dell’ente beneficiario.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="localitaBeneficiario" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la località dell’ente beneficiario.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="provinciaBeneficiario" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la provincia del beneficiario.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="nazioneBeneficiario" type="ppt:stNazioneProvincia" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il codice nazione dell’ente beneficiario secondo lo standard ISO 3166.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa destinataria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Istituto Attestante-->
+            <xsd:complexType name="ctIstitutoAttestante">
+                <xsd:sequence>
+                    <xsd:element name="identificativoUnivocoAttestante" type="ppt:ctIdentificativoUnivoco" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione che riporta le informazioni concernenti l’identificazione fiscale dell’Istituto attestante il pagamento.</xsd:documentation>
+                            <xsd:documentation>tipo_identificativo_univoco - deve assumere il valore ‘G’, Persona Giuridica.</xsd:documentation>
+                            <xsd:documentation>codice_identificativo_univoco - Campo alfanumerico che può contenere il codice fiscale o, in alternativa, la partita IVA dell’Istituto attestante il pagamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="denominazioneAttestante" type="ppt:stText70" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la denominazione dell’Istituto  finanziario  che emette il documento di attestazione dell’avvenuto versamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="codiceUnitOperAttestante" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il codice dell’unità operativa che rilascia la quietanza.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="denomUnitOperAttestante" type="ppt:stText70" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la denominazione dell’unità operativa attestante.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="indirizzoAttestante" type="ppt:stText70" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica l’indirizzo dell’attestante.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa che rilascia la ricevuta</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="civicoAttestante" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il numero civico dell'attestante.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa che rilascia la ricevuta</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="capAttestante" type="ppt:stText16" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il CAP dell’attestante.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa che rilascia la ricevuta</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="localitaAttestante" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la località dell’attestante.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa che rilascia la ricevuta</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="provinciaAttestante" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la provincia dell’attestante.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa che rilascia la ricevuta</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="nazioneAttestante" type="ppt:stNazioneProvincia" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica il codice nazione dell’attestante secondo lo standard ISO 3166.</xsd:documentation>
+                            <xsd:documentation>Può coincidere con quello dell’unità operativa che rilascia la ricevuta</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- **** END: Soggetti -->
+
+            <!-- Dati singolo versamento della Richiesta Pagamento Telematico (RPT) -->
+            <xsd:complexType name="ctDatiSingoloVersamentoRPT">
+                <xsd:sequence>
+                    <xsd:element name="importoSingoloVersamento" type="ppt:stImporto" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto “.”), indicante l’importo relativo alla somma da versare. Deve essere diverso da “0.00”.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="commissioneCaricoPA" type="ppt:stImporto" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto “.”), indicante l’importo relativo alla somma da versare. Il data è riportato a solo titolo indicativo e non comporta attività a carico del PSP. Se presente deve essere diverso da “0.00”.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ibanAccredito" type="ppt:stIBANIdentifier" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifica l’International Bank Account Number, definito secondo lo standard ISO 13616, del conto da accreditare presso la Banca di accredito indicata dall’ente creditore, di norma la Banca Tesoriera. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="bicAccredito" type="ppt:stBICIdentifier" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Bank Identifier Code definito secondo lo standard ISO 9362.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ibanAppoggio" type="ppt:stIBANIdentifier" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifica l’International Bank Account Number,, definito secondo lo standard ISO 13616, del conto da accreditare presso un PSP che provvederà a trasferire, nei tempi previsti dal DM, i fondi incassati sul conto indicato nell’elemento ibanAccredito.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="bicAppoggio" type="ppt:stBICIdentifier" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Bank Identifier Code definito secondo lo standard ISO 9362 dell’elemento ibanAppoggio</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="credenzialiPagatore" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Eventuali credenziali richieste dal Prestatore di servizi di Pagamento necessarie per completare l’operazione (ad esempio: un codice bilaterale utilizzabile una sola volta).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="causaleVersamento" type="ppt:stText140" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Rappresenta la descrizione estesa della causale del versamento. Può assumere i seguenti valori:</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datiSpecificiRiscossione" type="ppt:stDatiSpecificiRiscossione" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Rappresenta l’indicazione dell’imputazione della specifica entrata ed è così articolato:</xsd:documentation>
+                            <xsd:documentation>"tipo contabilità"/"codice contabilità", dove "tipo contabilità" può assumere i seguenti valori :</xsd:documentation>
+                            <xsd:documentation>0 Capitolo e articolo di Entrata del Bilancio dello stato </xsd:documentation>
+                            <xsd:documentation>1 Numero della contabilità speciale </xsd:documentation>
+                            <xsd:documentation>2 Codice SIOPE</xsd:documentation>
+                            <xsd:documentation>9 Altro codice ad uso dell’amministrazione</xsd:documentation>
+                            <xsd:documentation>Esempio: 0/3321.00 per indicare il Contributo Unificato delle spese di giustizia</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datiMarcaBolloDigitale" type="ppt:ctDatiMarcaBolloDigitale" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione che contiene le informazioni necessarie al PSP per generare la marca da bollo digitale.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Dati versamento della Richiesta Pagamento Telematico (RPT) -->
+            <xsd:complexType name="ctDatiVersamentoRPT">
+                <xsd:sequence>
+                    <xsd:element name="dataEsecuzionePagamento" type="ppt:stISODate" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la data in cui si richiede che venga effettuato il pagamento secondo il formato ISO 8601 [YYYY]-[MM]-[DD].</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="importoTotaleDaVersare" type="ppt:stImporto" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto “.”), indicante l’importo totale della somma da versare.</xsd:documentation>
+                            <xsd:documentation>Deve essere diverso da “0.00”.</xsd:documentation>
+                            <xsd:documentation>Deve uguale alla somma delle varie occorrenze (da 1 a 5) del dato importoSingoloVersamento presente nella struttura DatiSingoloVersamento</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="tipoVersamento" type="ppt:stTipoVersamento" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Forma tecnica di versamento delle somme dovute presso la Tesoreria Statale. Può assumere i seguenti valori:</xsd:documentation>
+                            <xsd:documentation>- BBT - Bonifico Bancario di Tesoreria.</xsd:documentation>
+                            <xsd:documentation>- BP  - Bonifico Postale.</xsd:documentation>
+                            <xsd:documentation>- AD  - Addebito diretto.</xsd:documentation>
+                            <xsd:documentation>- CP  - Carta di Pagamento.</xsd:documentation>
+                            <xsd:documentation>- PO  - Pagamento attivato presso PSP.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="identificativoUnivocoVersamento" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Riferimento univoco assegnato al versamento dall’ente beneficiario, utilizzato ai fini specifici della rendicontazione e riconciliazione eseguita sui conti di tesoreria.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="codiceContestoPagamento" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Codice univoco necessario a definire il contesto nel quale viene effettuato il versamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ibanAddebito" type="ppt:stIBANIdentifier" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifica l’International Bank Account Number del conto da addebitare riferito al soggetto pagatore, definito secondo lo standard ISO 13616.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="bicAddebito" type="ppt:stBICIdentifier" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Bank Identifier Code della banca ordinante, definito secondo lo standard ISO 9362.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="firmaRicevuta" type="ppt:stFirmaRicevuta" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Codice del tipo di firma digitale  o elettronica qualificata  o elettronica avanzata cui deve essere sottoposto il messaggio di Ricevuta Telematica, secondo le tipologie di firma previste dalle Regole Tecniche sulla firma digitale.</xsd:documentation>
+                            <xsd:documentation>0  Firma non richiesta</xsd:documentation>
+                            <xsd:documentation>1  CaDes </xsd:documentation>
+                            <xsd:documentation>3  XaDes </xsd:documentation>
+                            <xsd:documentation>4  Elettronica avanzata </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datiSingoloVersamento" type="ppt:ctDatiSingoloVersamentoRPT" minOccurs="1" maxOccurs="5">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “dati dei singoli versamenti”, da un minimo di uno ad un massimo di 5 occorrenze di versamento, facenti capo ad un unico identificativoUnivocoVersamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Dati singoli pagamenti della Ricevuta Telematica (RT)-->
+            <xsd:complexType name="ctDatiSingoloPagamentoRT">
+                <xsd:sequence>
+                    <xsd:element name="singoloImportoPagato" type="ppt:stImporto" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto “.”), indicante l’importo relativo alla somma versata.</xsd:documentation>
+                            <xsd:documentation>Se il singolo versamento non è stato effettuato l’importo deve essere impostato a 0.00.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="esitoSingoloPagamento" type="ppt:stText35" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la descrizione in formato testo dell’esito del singolo pagamento.</xsd:documentation>
+                            <xsd:documentation>Obbligatorio nel caso che l’elemento singoloImportoVersato sia 0.00.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="dataEsitoSingoloPagamento" type="ppt:stISODate" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la data di esecuzione o di rifiuto del pagamento, nel formato iso 8601 [YYYY]-[MM]-[DD].</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="identificativoUnivocoRiscossione" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Riferimento univoco dell’operazione assegnato al versamento dal Prestatore dei servizi di Pagamento. Può coincidere con il CRO nel caso di Bonifico Bancario o con il CODELINE nel caso di bollettino postale.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="causaleVersamento" type="ppt:stText140" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Il dato deve essere riportato invariato, a cura del PSP, così come presente nella Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datiSpecificiRiscossione" type="ppt:stDatiSpecificiRiscossione" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Il dato, se presente, deve essere riportato invariato, a cura del Psp, così come presente nella Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="commissioniApplicatePSP" type="ppt:stImporto" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto “.”), indicante l’importo della commissione applicata dal PSP al proprio cliente (soggetto versante o soggetto pagatore).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="allegatoRicevuta" type="ppt:ctAllegatoRicevuta" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione contenente l'allegato al singolo pagamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Dati versamento della Ricevuta Telematica (RT)-->
+            <xsd:complexType name="ctDatiVersamentoRT">
+                <xsd:sequence>
+                    <xsd:element name="codiceEsitoPagamento" type="ppt:stCodiceEsitoPagamento" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico indicante l’esito del pagamento.</xsd:documentation>
+                            <xsd:documentation>Può assumere i seguenti valori:</xsd:documentation>
+                            <xsd:documentation>0 - Pagamento eseguito</xsd:documentation>
+                            <xsd:documentation>1 - Pagamento non eseguito</xsd:documentation>
+                            <xsd:documentation>2 - Pagamento parzialmente  eseguito</xsd:documentation>
+                            <xsd:documentation>3 - Decorrenza termini</xsd:documentation>
+                            <xsd:documentation>4 - Decorrenza termini parziale</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="importoTotalePagato" type="ppt:stImporto" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto “.”), indicante l’importo relativo alla somma versata.</xsd:documentation>
+                            <xsd:documentation>Deve essere uguale alla somma delle varie occorrenze (da 1 a 5) dell’informazione singoloImportoVersato presente nella struttura DatiSingoloPagamento.</xsd:documentation>
+                            <xsd:documentation>Se il versamento non è stato effettuato l’importo deve essere impostato a 0.00</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="identificativoUnivocoVersamento" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Il dato deve essere riportato invariato, a cura del prestatore di servizi di pagamento, così come presente nella Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="CodiceContestoPagamento" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Il dato deve essere riportato invariato, a cura del prestatore di servizi di pagamento, così come presente nella Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datiSingoloPagamento" type="ppt:ctDatiSingoloPagamentoRT" minOccurs="0" maxOccurs="5">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “dati dei singoli versamenti”, da un minimo di uno ad un massimo di 5 occorrenze di versamento, facenti capo ad un unico identificativoUnivocoVersamento.</xsd:documentation>
+                            <xsd:documentation>Obbligatorio nel caso che l’elemento codiceEsitoPagamento sia 0 o 2 </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Richiesta Pagamento Telematico (RPT)-->
+            <xsd:complexType name="ctRichiestaPagamentoTelematico">
+                <xsd:sequence>
+                    <xsd:element name="versioneOggetto" type="ppt:stText16" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Versione che identifica l’oggetto scambiato.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="dominio" type="ppt:ctDominio" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “dominio” che riporta le informazioni che consentono di individuare univocamente l’ambito di applicazione della richiesta.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="identificativoMessaggioRichiesta" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Identificativo legato alla trasmissione della richiesta di pagamento.</xsd:documentation>
+                            <xsd:documentation>Deve essere univoco nell’ambito della stessa data definita da Data_Ora_ messaggio_richiesta.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="dataOraMessaggioRichiesta" type="ppt:stISODateTime" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la data e l’ora di generazione del messaggio di richiesta di pagamento secondo il formato ISO 8601</xsd:documentation>
+                            <xsd:documentation>[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="autenticazioneSoggetto" type="ppt:stAutenticazioneSoggetto" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Contiene la modalità di identificazione  applicata  al soggetto che deve essere addebitato per il pagamento</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="soggettoVersante" type="ppt:ctSoggettoVersante" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “versante” che riporta le informazioni concernenti il soggetto che effettua il pagamento per conto del soggetto Pagatore.</xsd:documentation>
+                            <xsd:documentation>Se coincide con il soggetto Pagatore deve essere omesso.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="soggettoPagatore" type="ppt:ctSoggettoPagatore" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “soggetto pagatore” che riporta le informazioni concernenti il soggetto che effettua il pagamento.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="enteBeneficiario" type="ppt:ctEnteBeneficiario" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “ente beneficiario” creditore di somme nei confronti del soggetto pagatore.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datiVersamento" type="ppt:ctDatiVersamentoRPT" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione “dati del versamento”.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- Ricevuta Telematica (RT)-->
+            <xsd:complexType name="ctRicevutaTelematica">
+                <xsd:sequence>
+                    <xsd:element name="versioneOggetto" type="ppt:stText16" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Riporta la stessa informazione presente  nel dato  “versioneOggetto” della Richiesta di Pagamento Telematico (RPT).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="dominio" type="ppt:ctDominio" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Riporta le stesse informazioni presenti nel blocco “Dominio” della Richiesta di Pagamento Telematico (RPT)</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="identificativoMessaggioRicevuta" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Identificativo legato alla trasmissione della quietanza telematica.</xsd:documentation>
+                            <xsd:documentation>Deve essere univoco nell’ambito della stessa data riferita all’elemento dataMessaggioRicevuta.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="dataOraMessaggioRicevuta" type="ppt:stISODateTime" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la data del messaggio di quietanza, secondo il formato ISO 8601</xsd:documentation>
+                            <xsd:documentation>[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="riferimentoMessaggioRichiesta" type="ppt:stText35" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Con riferimento al messaggio di Ricevuta Telematica (RT) l’elemento contiene il dato identificativoMessaggioRichiesta legato alla trasmissione della Richiesta di Pagamento Telematico (RPT).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="riferimentoDataRichiesta" type="ppt:stISODate" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indica la data secondo il formato ISO 8601 [YYYY]-[MM]-[DD] cui si riferisce la generazione del dato riferimentoMessaggioRichiesta.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="istitutoAttestante" type="ppt:ctIstitutoAttestante" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Aggregazione relativa al soggetto Prestatore dei servizi di Pagamento che emette il documento di attestazione dell’avvenuto versamento. </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="enteBeneficiario" type="ppt:ctEnteBeneficiario" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Riporta le stesse informazioni presenti nel blocco “Ente Beneficiario” della Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="soggettoVersante" type="ppt:ctSoggettoVersante" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Riporta le stesse informazioni presenti nel blocco “Soggetto Versante” della Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="soggettoPagatore" type="ppt:ctSoggettoPagatore" minOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Riporta le stesse informazioni presenti nel blocco “Soggetto Pagatore” della Richiesta di Pagamento Telematico (RPT) cui si riferisce il messaggio di Ricevuta Telematica.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <!-- **** END: tipi complessi  ****-->
+
+
+            <!-- **** BEGIN: elementi  ****-->
+            <xsd:element name="RPT" type="ppt:ctRichiestaPagamentoTelematico">
+                <xsd:annotation>
+                    <xsd:documentation>Richiesta Pagamento Telematico (RPT)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="RT" type="ppt:ctRicevutaTelematica">
+                <xsd:annotation>
+                    <xsd:documentation>Ricevuta Telematica (RT)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <!-- **** END: elementi  ****-->
+
+            <xsd:simpleType name="stText25">
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1" />
+                    <xsd:maxLength value="25" />
+                </xsd:restriction>
+            </xsd:simpleType>
+
+
+            <xsd:complexType name="ctSpezzoniCausaleVersamento">
+                <xsd:sequence>
+                    <xsd:any minOccurs="0" maxOccurs="6" namespace="##any" />
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="ctSpezzoneStrutturatoCausaleVersamento">
+                <xsd:sequence>
+                    <xsd:element type="ppt:stText25" name="causaleSpezzone" minOccurs="1" />
+                    <xsd:element type="ppt:stImporto" name="importoSpezzone" minOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:simpleType name="stPassword">
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="8" />
+                    <xsd:maxLength value="15" />
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:simpleType name="stForzaControlloSegno">
+                <xsd:restriction base="xsd:int">
+                    <xsd:enumeration value="0"/>
+                    <xsd:enumeration value="1"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <!-- Element Definition -->
+            <xsd:complexType name="risposta">
+                <xsd:sequence>
+                    <xsd:element name="fault" type="ppt:faultBean" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="faultBean">
+                <xsd:sequence>
+                    <xsd:element name="faultCode" type="xsd:string" />
+                    <xsd:element name="faultString" type="xsd:string" />
+                    <xsd:element name="id" type="xsd:string" />
+                    <xsd:element name="description" type="xsd:string" minOccurs="0" />
+                    <xsd:element name="serial" type="xsd:int" minOccurs="0" />
+                    <xsd:element name="originalFaultCode" type="xsd:string" minOccurs="0" />
+                    <xsd:element name="originalFaultString" type="xsd:string" minOccurs="0" />
+                    <xsd:element name="originalDescription" type="xsd:string" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="nodoTipoDatiPagamentoPA">
+                <xsd:sequence>
+                    <xsd:element name="importoSingoloVersamento" type="ppt:stImporto" minOccurs="1">
+                    </xsd:element>
+                    <xsd:element name="ibanAccredito" type="ppt:stIBANIdentifier" minOccurs="0">
+                    </xsd:element>
+                    <xsd:element name="bicAccredito" type="ppt:stBICIdentifier" minOccurs="0">
+                    </xsd:element>
+                    <xsd:element name="enteBeneficiario" type="ppt:ctEnteBeneficiario" minOccurs="0" />
+                    <xsd:element name="credenzialiPagatore" type="ppt:stText35" minOccurs="0">
+                    </xsd:element>
+                    <xsd:choice minOccurs="1">
+                        <xsd:element name="causaleVersamento" type="ppt:stText140" />
+                        <xsd:element name="spezzoniCausaleVersamento" type="ppt:ctSpezzoniCausaleVersamento" />
+                    </xsd:choice>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="nodoVerificaRPT">
+                <xsd:sequence>
+                    <xsd:element name="identificativoPSP" type="ppt:stText35" />
+                    <xsd:element name="identificativoIntermediarioPSP" type="ppt:stText35" />
+                    <xsd:element name="identificativoCanale" type="ppt:stText35" />
+                    <xsd:element name="password" type="ppt:stPassword" />
+                    <xsd:element name="codiceContestoPagamento" type="ppt:stText35" />
+                    <xsd:element name="codificaInfrastrutturaPSP" type="xsd:string" />
+                    <xsd:element name="codiceIdRPT" type="ppt:nodoTipoCodiceIdRPT" />
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:complexType name="nodoVerificaRPTRisposta">
+                <xsd:sequence>
+                    <xsd:element name="nodoVerificaRPTRisposta" type="ppt:esitoNodoVerificaRPTRisposta" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="esitoNodoVerificaRPTRisposta">
+                <xsd:complexContent>
+                    <xsd:extension base="ppt:risposta">
+                        <xsd:sequence>
+                            <xsd:element name="esito" type="xsd:string" minOccurs="0" />
+                            <xsd:element name="datiPagamentoPA" type="ppt:nodoTipoDatiPagamentoPA" minOccurs="0" />
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+
+            <!-- Wrapper Elements -->
+            <xsd:element name="nodoVerificaRPT" type="ppt:nodoVerificaRPT" />
+            <xsd:element name="nodoVerificaRPTRisposta" type="ppt:nodoVerificaRPTRisposta" />
+
+        </xsd:schema>
+    </wsdl:types>
+
+    <!-- wsdl messages -->
+
+    <wsdl:message name="nodoVerificaRPT">
+        <wsdl:part name="bodyrichiesta" element="ppt:nodoVerificaRPT" />
+    </wsdl:message>
+    <wsdl:message name="nodoVerificaRPTResponse">
+        <wsdl:part name="bodyrisposta" element="ppt:nodoVerificaRPTRisposta" />
+    </wsdl:message>
+
+    <!-- wsdl operation -->
+
+    <wsdl:portType name="PagamentiTelematiciPspNodo">
+        <wsdl:operation name="nodoVerificaRPT">
+            <wsdl:input message="tns:nodoVerificaRPT" wsam:Action="http://ws.pagamenti.telematici.gov/PPT/nodoVerificaRPTRichiesta" />
+            <wsdl:output message="tns:nodoVerificaRPTResponse" wsam:Action="http://ws.pagamenti.telematici.gov/PPT/nodoVerificaRPTRisposta" />
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <!-- wsdl binding -->
+
+    <wsdl:binding name="PagamentiTelematiciPspNodobinding" type="tns:PagamentiTelematiciPspNodo">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="nodoVerificaRPT">
+            <soap:operation soapAction="nodoVerificaRPT" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+
+    <wsdl:service name="PagamentiTelematiciPspNodoservice">
+        <wsdl:port name="PPTPort" binding="tns:PagamentiTelematiciPspNodobinding">
+            <soap:address location="http://PuntoAccessoPSP.spcoop.gov.it/" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
                             <schemas>
                                 <schema>
                                     <url>
-                                        https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/api/nodopagamenti_api/nodoPerPsp/v1/nodoPerPsp.wsdl
+                                        ${project.basedir}/nodo-wsdl/nodoPerPsp.wsdl
                                     </url>
                                 </schema>
                             </schemas>

--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--enable-preview</argLine>
+                    <argLine>${argLine} --enable-preview</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <compilerArgs>--enable-preview</compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
+++ b/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
@@ -1,6 +1,9 @@
 package it.pagopa.transactions.configurations;
 
+import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
+import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
 import it.pagopa.transactions.utils.NodoConnectionString;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +13,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Configuration
 public class NodoConfig {
 
+    @Autowired
+    private it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp;
+
+    @Autowired
+    private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
+
     @Bean
     public NodoConnectionString nodoConnectionString(
             @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
@@ -17,4 +26,35 @@ public class NodoConfig {
 
         return new ObjectMapper().readValue(nodoConnectionParamsAsString, NodoConnectionString.class);
     }
+
+    @Bean
+    public NodoVerificaRPT baseNodoVerificaRPTRequest(
+            @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
+            throws JsonProcessingException {
+
+        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
+
+        NodoVerificaRPT request = objectFactoryNodoPerPsp.createNodoVerificaRPT();
+        request.setIdentificativoPSP(nodoConnectionParams.getIdPSP());
+        request.setIdentificativoCanale(nodoConnectionParams.getIdChannel());
+        request.setIdentificativoIntermediarioPSP(nodoConnectionParams.getIdBrokerPSP());
+        request.setPassword(nodoConnectionParams.getPassword());
+        return request;
+    }
+
+    @Bean
+    public VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq(
+            @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
+            throws JsonProcessingException {
+
+        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
+
+        VerifyPaymentNoticeReq request = objectFactoryNodeForPsp.createVerifyPaymentNoticeReq();
+        request.setIdPSP(nodoConnectionParams.getIdPSP());
+        request.setIdChannel(nodoConnectionParams.getIdChannel());
+        request.setIdBrokerPSP(nodoConnectionParams.getIdBrokerPSP());
+        request.setPassword(nodoConnectionParams.getPassword());
+        return request;
+    }
+
 }

--- a/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
+++ b/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
@@ -13,48 +13,43 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Configuration
 public class NodoConfig {
 
-    @Autowired
-    private it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp;
+  @Bean
+  public NodoConnectionString nodoConnectionString(
+      @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
+      throws JsonProcessingException {
 
-    @Autowired
-    private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
+    return new ObjectMapper().readValue(nodoConnectionParamsAsString, NodoConnectionString.class);
+  }
 
-    @Bean
-    public NodoConnectionString nodoConnectionString(
-            @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
-            throws JsonProcessingException {
+  @Bean
+  public NodoVerificaRPT baseNodoVerificaRPTRequest(
+      @Value("${nodo.connection.string}") String nodoConnectionParamsAsString,
+      it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp)
+      throws JsonProcessingException {
 
-        return new ObjectMapper().readValue(nodoConnectionParamsAsString, NodoConnectionString.class);
-    }
+    NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
 
-    @Bean
-    public NodoVerificaRPT baseNodoVerificaRPTRequest(
-            @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
-            throws JsonProcessingException {
+    NodoVerificaRPT request = objectFactoryNodoPerPsp.createNodoVerificaRPT();
+    request.setIdentificativoPSP(nodoConnectionParams.getIdPSP());
+    request.setIdentificativoCanale(nodoConnectionParams.getIdChannel());
+    request.setIdentificativoIntermediarioPSP(nodoConnectionParams.getIdBrokerPSP());
+    request.setPassword(nodoConnectionParams.getPassword());
+    return request;
+  }
 
-        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
+  @Bean
+  public VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq(
+      @Value("${nodo.connection.string}") String nodoConnectionParamsAsString,
+      it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp)
+      throws JsonProcessingException {
 
-        NodoVerificaRPT request = objectFactoryNodoPerPsp.createNodoVerificaRPT();
-        request.setIdentificativoPSP(nodoConnectionParams.getIdPSP());
-        request.setIdentificativoCanale(nodoConnectionParams.getIdChannel());
-        request.setIdentificativoIntermediarioPSP(nodoConnectionParams.getIdBrokerPSP());
-        request.setPassword(nodoConnectionParams.getPassword());
-        return request;
-    }
+    NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
 
-    @Bean
-    public VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq(
-            @Value("${nodo.connection.string}") String nodoConnectionParamsAsString)
-            throws JsonProcessingException {
-
-        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
-
-        VerifyPaymentNoticeReq request = objectFactoryNodeForPsp.createVerifyPaymentNoticeReq();
-        request.setIdPSP(nodoConnectionParams.getIdPSP());
-        request.setIdChannel(nodoConnectionParams.getIdChannel());
-        request.setIdBrokerPSP(nodoConnectionParams.getIdBrokerPSP());
-        request.setPassword(nodoConnectionParams.getPassword());
-        return request;
-    }
-
+    VerifyPaymentNoticeReq request = objectFactoryNodeForPsp.createVerifyPaymentNoticeReq();
+    request.setIdPSP(nodoConnectionParams.getIdPSP());
+    request.setIdChannel(nodoConnectionParams.getIdChannel());
+    request.setIdBrokerPSP(nodoConnectionParams.getIdBrokerPSP());
+    request.setPassword(nodoConnectionParams.getPassword());
+    return request;
+  }
 }

--- a/src/main/java/it/pagopa/transactions/configurations/WebClientsConfig.java
+++ b/src/main/java/it/pagopa/transactions/configurations/WebClientsConfig.java
@@ -8,7 +8,6 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import it.pagopa.generated.ecommerce.gateway.v1.api.PaymentTransactionsControllerApi;
 import it.pagopa.generated.ecommerce.sessions.v1.ApiClient;
 import it.pagopa.generated.ecommerce.sessions.v1.api.DefaultApi;
-import it.pagopa.generated.transactions.model.ObjectFactory;
 import it.pagopa.transactions.utils.soap.Jaxb2SoapDecoder;
 import it.pagopa.transactions.utils.soap.Jaxb2SoapEncoder;
 import org.springframework.beans.factory.annotation.Value;
@@ -110,7 +109,12 @@ public class WebClientsConfig {
     }
 
     @Bean
-    public ObjectFactory objectFactory() {
-        return new ObjectFactory();
+    public  it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp() {
+        return new  it.pagopa.generated.transactions.model.ObjectFactory();
+    }
+
+    @Bean
+    public  it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPSP() {
+        return new  it.pagopa.generated.nodoperpsp.model.ObjectFactory();
     }
 }

--- a/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
@@ -2,9 +2,10 @@ package it.pagopa.transactions.controllers;
 
 import io.lettuce.core.RedisConnectionException;
 import it.pagopa.generated.payment.requests.api.PaymentRequestsApi;
-import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
+import it.pagopa.generated.payment.requests.model.*;
 import it.pagopa.generated.transactions.server.model.ProblemJsonDto;
 import it.pagopa.transactions.exceptions.BadGatewayException;
+import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.exceptions.UnsatisfiablePspRequestException;
 import it.pagopa.transactions.services.PaymentRequestsService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.random.RandomGenerator;
 
 @RestController
 public class PaymentRequestsController implements PaymentRequestsApi {
@@ -38,5 +43,41 @@ public class PaymentRequestsController implements PaymentRequestsApi {
   private ResponseEntity<ProblemJsonDto> genericBadGatewayHandler(RuntimeException exception) {
     return new ResponseEntity<>(
         new ProblemJsonDto().status(502).title("Bad gateway"), HttpStatus.BAD_GATEWAY);
+  }
+
+  @ExceptionHandler({
+    NodoErrorException.class,
+  })
+  private ResponseEntity<?> nodoErrorHandler(NodoErrorException exception) {
+
+    return switch (exception.getFaultCode()) {
+       case String s && Arrays.stream(PartyConfigurationFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
+               new PartyConfigurationFaultPaymentProblemJsonDto()
+                       .title("EC error")
+                       .faultCodeCategory(FaultCategoryDto.PAYMENT_UNAVAILABLE)
+                       .faultCodeDetail(PartyConfigurationFaultDto.fromValue(s)), HttpStatus.BAD_GATEWAY);
+      case String s && Arrays.stream(ValidationFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
+              new ValidationFaultPaymentProblemJsonDto()
+                      .title("Validation Fault")
+                      .faultCodeCategory(FaultCategoryDto.PAYMENT_UNKNOWN)
+                      .faultCodeDetail(ValidationFaultDto.fromValue(s)), HttpStatus.NOT_FOUND);
+      case String s && Arrays.stream(GatewayFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
+              new GatewayFaultPaymentProblemJsonDto()
+                      .title("Payment unavailable")
+                      .faultCodeCategory(FaultCategoryDto.GENERIC_ERROR)
+                      .faultCodeDetail(GatewayFaultDto.fromValue(s)), HttpStatus.BAD_GATEWAY);
+      case String s && Arrays.stream(GatewayFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
+              new PartyTimeoutFaultPaymentProblemJsonDto()
+                      .title("Gateway Timeout")
+                      .faultCodeCategory(FaultCategoryDto.GENERIC_ERROR)
+                      .faultCodeDetail(PartyTimeoutFaultDto.fromValue(s)), HttpStatus.GATEWAY_TIMEOUT);
+      case String s && Arrays.stream(PaymentStatusFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
+              new PaymentStatusFaultPaymentProblemJsonDto()
+                      .title("Payment Status Fault")
+                      .faultCodeCategory(FaultCategoryDto.GENERIC_ERROR)
+                      .faultCodeDetail(PaymentStatusFaultDto.fromValue(s)), HttpStatus.GATEWAY_TIMEOUT);
+       default -> new ResponseEntity<>(
+               new ProblemJsonDto().title("Bad gateway"), HttpStatus.BAD_GATEWAY);
+    };
   }
 }

--- a/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
@@ -62,7 +62,7 @@ public class PaymentRequestsController implements PaymentRequestsApi {
                       .title("Payment unavailable")
                       .faultCodeCategory(FaultCategoryDto.GENERIC_ERROR)
                       .faultCodeDetail(GatewayFaultDto.fromValue(s)), HttpStatus.BAD_GATEWAY);
-      case String s && Arrays.stream(GatewayFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
+      case String s && Arrays.stream(PartyTimeoutFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
               new PartyTimeoutFaultPaymentProblemJsonDto()
                       .title("Gateway Timeout")
                       .faultCodeCategory(FaultCategoryDto.GENERIC_ERROR)
@@ -70,8 +70,8 @@ public class PaymentRequestsController implements PaymentRequestsApi {
       case String s && Arrays.stream(PaymentStatusFaultDto.values()).anyMatch( z -> z.getValue().equals(s)) -> new ResponseEntity<>(
               new PaymentStatusFaultPaymentProblemJsonDto()
                       .title("Payment Status Fault")
-                      .faultCodeCategory(FaultCategoryDto.GENERIC_ERROR)
-                      .faultCodeDetail(PaymentStatusFaultDto.fromValue(s)), HttpStatus.GATEWAY_TIMEOUT);
+                      .faultCodeCategory(FaultCategoryDto.PAYMENT_UNAVAILABLE)
+                      .faultCodeDetail(PaymentStatusFaultDto.fromValue(s)), HttpStatus.CONFLICT);
        default -> new ResponseEntity<>(
                new ProblemJsonDto().title("Bad gateway"), HttpStatus.BAD_GATEWAY);
     };

--- a/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
@@ -2,6 +2,8 @@ package it.pagopa.transactions.controllers;
 
 import it.pagopa.generated.payment.requests.api.PaymentRequestsApi;
 import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
+import it.pagopa.transactions.services.PaymentRequestsService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
@@ -9,8 +11,14 @@ import reactor.core.publisher.Mono;
 
 @RestController
 public class PaymentRequestsController implements PaymentRequestsApi {
-    @Override
-    public Mono<ResponseEntity<PaymentRequestsGetResponseDto>> getPaymentRequestInfo(String rptId, ServerWebExchange exchange) {
-        return Mono.just(ResponseEntity.ok().build());
-    }
+
+  @Autowired private PaymentRequestsService paymentRequestsService;
+
+  @Override
+  public Mono<ResponseEntity<PaymentRequestsGetResponseDto>> getPaymentRequestInfo(
+      String rptId, ServerWebExchange exchange) {
+    return Mono.just(rptId)
+        .flatMap(paymentRequestsService::getPaymentRequestInfo)
+        .map(ResponseEntity::ok);
+  }
 }

--- a/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
@@ -1,11 +1,19 @@
 package it.pagopa.transactions.controllers;
 
+import io.lettuce.core.RedisConnectionException;
 import it.pagopa.generated.payment.requests.api.PaymentRequestsApi;
 import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
+import it.pagopa.generated.transactions.server.model.ProblemJsonDto;
+import it.pagopa.transactions.exceptions.BadGatewayException;
+import it.pagopa.transactions.exceptions.UnsatisfiablePspRequestException;
 import it.pagopa.transactions.services.PaymentRequestsService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -20,5 +28,15 @@ public class PaymentRequestsController implements PaymentRequestsApi {
     return Mono.just(rptId)
         .flatMap(paymentRequestsService::getPaymentRequestInfo)
         .map(ResponseEntity::ok);
+  }
+
+  @ExceptionHandler({
+    RedisSystemException.class,
+    RedisConnectionException.class,
+    WebClientRequestException.class
+  })
+  private ResponseEntity<ProblemJsonDto> genericBadGatewayHandler(RuntimeException exception) {
+    return new ResponseEntity<>(
+        new ProblemJsonDto().status(502).title("Bad gateway"), HttpStatus.BAD_GATEWAY);
   }
 }

--- a/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/PaymentRequestsController.java
@@ -4,9 +4,7 @@ import io.lettuce.core.RedisConnectionException;
 import it.pagopa.generated.payment.requests.api.PaymentRequestsApi;
 import it.pagopa.generated.payment.requests.model.*;
 import it.pagopa.generated.transactions.server.model.ProblemJsonDto;
-import it.pagopa.transactions.exceptions.BadGatewayException;
 import it.pagopa.transactions.exceptions.NodoErrorException;
-import it.pagopa.transactions.exceptions.UnsatisfiablePspRequestException;
 import it.pagopa.transactions.services.PaymentRequestsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.RedisSystemException;
@@ -19,8 +17,6 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
-import java.util.Random;
-import java.util.random.RandomGenerator;
 
 @RestController
 public class PaymentRequestsController implements PaymentRequestsApi {

--- a/src/main/java/it/pagopa/transactions/exceptions/NodoErrorException.java
+++ b/src/main/java/it/pagopa/transactions/exceptions/NodoErrorException.java
@@ -1,0 +1,17 @@
+package it.pagopa.transactions.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_GATEWAY)
+public class NodoErrorException extends RuntimeException {
+  private final String faultCode;
+
+  public NodoErrorException(String faultCode) {
+    this.faultCode = faultCode;
+  }
+
+  public String getFaultCode() {
+    return faultCode;
+  }
+}

--- a/src/main/java/it/pagopa/transactions/repositories/PaymentRequestInfo.java
+++ b/src/main/java/it/pagopa/transactions/repositories/PaymentRequestInfo.java
@@ -1,0 +1,21 @@
+package it.pagopa.transactions.repositories;
+
+import it.pagopa.transactions.domain.IdempotencyKey;
+import it.pagopa.transactions.domain.RptId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.redis.core.RedisHash;
+
+import javax.validation.constraints.Pattern;
+import java.math.BigDecimal;
+
+@RedisHash(value = "keys", timeToLive = 10 * 60)
+public record PaymentRequestInfo(@Id RptId id, String paTaxCode, String paName,
+                                 String description, BigDecimal amount,
+                                 @Pattern(regexp = "([a-zA-Z\\d]{1,35})|(RF\\d{2}[a-zA-Z\\d]{1,21})")
+                                 String dueDate,
+                                 Boolean isNM3) {
+    @PersistenceConstructor
+    public PaymentRequestInfo {
+    }
+}

--- a/src/main/java/it/pagopa/transactions/repositories/PaymentRequestInfo.java
+++ b/src/main/java/it/pagopa/transactions/repositories/PaymentRequestInfo.java
@@ -1,6 +1,5 @@
 package it.pagopa.transactions.repositories;
 
-import it.pagopa.transactions.domain.IdempotencyKey;
 import it.pagopa.transactions.domain.RptId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;

--- a/src/main/java/it/pagopa/transactions/repositories/PaymentRequestsInfoRepository.java
+++ b/src/main/java/it/pagopa/transactions/repositories/PaymentRequestsInfoRepository.java
@@ -1,0 +1,8 @@
+package it.pagopa.transactions.repositories;
+
+import it.pagopa.transactions.domain.RptId;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PaymentRequestsInfoRepository extends CrudRepository<PaymentRequestInfo
+        , RptId> {
+}

--- a/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
+++ b/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
@@ -57,9 +57,9 @@ public class PaymentRequestsService {
                         .doOnNext(
                             paymentRequestFromNodo ->
                                 log.info(
-                                    "PaymentRequestInfo from nodo pagoPA for {}: {}",
+                                    "PaymentRequestInfo from nodo pagoPA for {}, isNM3 {}",
                                     rptId,
-                                    paymentRequestFromNodo != null))
+                                    paymentRequestFromNodo.isNM3()))
                         .doOnSuccess(
                             paymenRequestInfo ->
                                 paymentRequestsInfoRepository.save(paymenRequestInfo))))

--- a/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
+++ b/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
@@ -9,6 +9,7 @@ import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.client.NodoPerPspClient;
 import it.pagopa.transactions.domain.RptId;
 import it.pagopa.transactions.exceptions.BadGatewayException;
+import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.repositories.PaymentRequestInfo;
 import it.pagopa.transactions.repositories.PaymentRequestsInfoRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -114,7 +115,7 @@ public class PaymentRequestsService {
 
               return StOutcome.KO.value().equals(outcome) && !isNM3
                   ? Mono.error(
-                      new BadGatewayException(nodoVerificaRPTRResponse.getFault().getFaultCode()))
+                      new NodoErrorException(nodoVerificaRPTRResponse.getFault().getFaultCode()))
                   : Mono.just(Tuples.of(nodoVerificaRPTRResponse, isNM3));
             })
         .flatMap(

--- a/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
+++ b/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
@@ -81,7 +81,7 @@ public class PaymentRequestsService {
 
     Optional<PaymentRequestInfo> paymentRequestInfoOptional =
         paymentRequestsInfoRepository.findById(rptId);
-    return paymentRequestInfoOptional.map(Mono::just).orElseGet(() -> Mono.empty());
+    return paymentRequestInfoOptional.map(Mono::just).orElseGet(Mono::empty);
   }
 
   private Mono<PaymentRequestInfo> getPaymentInfoFromNodo(RptId rptId) {
@@ -113,7 +113,7 @@ public class PaymentRequestsService {
                       && "PPT_MULTI_BENEFICIARIO"
                           .equals(nodoVerificaRPTRResponse.getFault().getFaultCode());
 
-              return StOutcome.KO.value().equals(outcome) && !isNM3
+              return StOutcome.KO.value().equals(outcome) && Boolean.FALSE.equals(isNM3)
                   ? Mono.error(
                       new NodoErrorException(nodoVerificaRPTRResponse.getFault().getFaultCode()))
                   : Mono.just(Tuples.of(nodoVerificaRPTRResponse, isNM3));
@@ -125,7 +125,7 @@ public class PaymentRequestsService {
 
               Mono<PaymentRequestInfo> paymentRequestInfo = null;
 
-              if (isNM3) {
+              if (Boolean.TRUE.equals(isNM3)) {
 
                 VerifyPaymentNoticeReq verifyPaymentNoticeReq = baseVerifyPaymentNoticeReq;
                 CtQrCode qrCode = new CtQrCode();

--- a/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
+++ b/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
@@ -1,0 +1,180 @@
+package it.pagopa.transactions.services;
+
+import it.pagopa.generated.nodoperpsp.model.*;
+import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
+import it.pagopa.generated.transactions.model.CtQrCode;
+import it.pagopa.generated.transactions.model.StOutcome;
+import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
+import it.pagopa.transactions.client.NodeForPspClient;
+import it.pagopa.transactions.client.NodoPerPspClient;
+import it.pagopa.transactions.domain.RptId;
+import it.pagopa.transactions.exceptions.BadGatewayException;
+import it.pagopa.transactions.repositories.PaymentRequestInfo;
+import it.pagopa.transactions.repositories.PaymentRequestsInfoRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class PaymentRequestsService {
+
+  @Autowired private PaymentRequestsInfoRepository paymentRequestsInfoRepository;
+
+  @Autowired private NodoPerPspClient nodoPerPspClient;
+
+  @Autowired private NodeForPspClient nodeForPspClient;
+
+  @Autowired private it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp;
+
+  @Autowired private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
+
+  @Autowired private NodoVerificaRPT baseNodoVerificaRPTRequest;
+
+  @Autowired private VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq;
+
+  public Mono<PaymentRequestsGetResponseDto> getPaymentRequestInfo(String rptId) {
+
+    final String paymentContextCode = UUID.randomUUID().toString();
+    final RptId rptIdRecord = new RptId(rptId);
+
+    return getPaymentInfoFromCache(rptIdRecord)
+        .switchIfEmpty(
+            Mono.defer(
+                () ->
+                    getPaymentInfoFromNodo(rptIdRecord)
+                        .doOnSuccess(
+                            paymenRequestInfo ->
+                                paymentRequestsInfoRepository.save(paymenRequestInfo))))
+        .map(
+            paymentInfo ->
+                new PaymentRequestsGetResponseDto()
+                    .rptId(paymentInfo.id().value())
+                    .paTaxCode(paymentInfo.paTaxCode())
+                    .paName(paymentInfo.paName())
+                    .description(paymentInfo.description())
+                    .dueDate(paymentInfo.dueDate())
+                    .paymentContextCode(paymentContextCode));
+  }
+
+  private Mono<PaymentRequestInfo> getPaymentInfoFromCache(RptId rptId) {
+
+    Optional<PaymentRequestInfo> paymentRequestInfoOptional =
+        paymentRequestsInfoRepository.findById(rptId);
+    return paymentRequestInfoOptional.map(Mono::just).orElseGet(() -> Mono.empty());
+  }
+
+  private Mono<PaymentRequestInfo> getPaymentInfoFromNodo(RptId rptId) {
+
+    return Mono.just(rptId)
+        .flatMap(
+            request -> {
+              NodoVerificaRPT nodoVerificaRPTRequest = baseNodoVerificaRPTRequest;
+              NodoTipoCodiceIdRPT nodoTipoCodiceIdRPT =
+                  objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT();
+              NodoTipoCodiceIdRPT.QrCode qrCode = new NodoTipoCodiceIdRPT.QrCode();
+              qrCode.setCF(rptId.getFiscalCode());
+              qrCode.setCodIUV(rptId.getNoticeId().substring(1));
+              qrCode.setAuxDigit(rptId.getNoticeId().substring(0, 1));
+              nodoTipoCodiceIdRPT.setQrCode(qrCode);
+
+              nodoVerificaRPTRequest.setCodiceIdRPT(nodoTipoCodiceIdRPT);
+
+              return nodoPerPspClient.verificaRPT(
+                  objectFactoryNodoPerPsp.createNodoVerificaRPT(nodoVerificaRPTRequest));
+            })
+        .flatMap(
+            nodoVerificaRPTResponse -> {
+              final EsitoNodoVerificaRPTRisposta nodoVerificaRPTRResponse =
+                  nodoVerificaRPTResponse.getNodoVerificaRPTRisposta();
+              final String outcome = nodoVerificaRPTRResponse.getEsito();
+              final Boolean isNM3 =
+                  StOutcome.KO.value().equals(outcome)
+                      && "PPT_MULTI_BENEFICIARIO"
+                          .equals(nodoVerificaRPTRResponse.getFault().getFaultCode());
+
+              return StOutcome.KO.value().equals(outcome) && !isNM3
+                  ? Mono.error(
+                      new BadGatewayException(nodoVerificaRPTRResponse.getFault().getFaultCode()))
+                  : Mono.just(Tuples.of(nodoVerificaRPTRResponse, isNM3));
+            })
+        .flatMap(
+            args -> {
+              final EsitoNodoVerificaRPTRisposta nodoVerificaRPTRResponse = args.getT1();
+              final Boolean isNM3 = args.getT2();
+
+              Mono<PaymentRequestInfo> paymentRequestInfo = null;
+
+              if (isNM3) {
+
+                VerifyPaymentNoticeReq verifyPaymentNoticeReq = baseVerifyPaymentNoticeReq;
+                CtQrCode qrCode = new CtQrCode();
+                qrCode.setFiscalCode(rptId.getFiscalCode());
+                qrCode.setNoticeNumber(rptId.getNoticeId());
+                verifyPaymentNoticeReq.setQrCode(qrCode);
+
+                paymentRequestInfo =
+                    nodeForPspClient
+                        .verifyPaymentNotice(
+                            objectFactoryNodeForPsp.createVerifyPaymentNoticeReq(
+                                verifyPaymentNoticeReq))
+                        .map(
+                            verifyPaymentNoticeRes ->
+                                new PaymentRequestInfo(
+                                    rptId,
+                                    verifyPaymentNoticeRes.getFiscalCodePA(),
+                                    verifyPaymentNoticeRes.getCompanyName(),
+                                    verifyPaymentNoticeRes.getPaymentDescription(),
+                                    verifyPaymentNoticeRes
+                                        .getPaymentList()
+                                        .getPaymentOptionDescription()
+                                        .get(0)
+                                        .getAmount(),
+                                    verifyPaymentNoticeRes
+                                                .getPaymentList()
+                                                .getPaymentOptionDescription()
+                                                .get(0)
+                                                .getDueDate()
+                                            != null
+                                        ? verifyPaymentNoticeRes
+                                            .getPaymentList()
+                                            .getPaymentOptionDescription()
+                                            .get(0)
+                                            .getDueDate()
+                                            .toString()
+                                        : null,
+                                    true));
+
+              } else {
+
+                final CtEnteBeneficiario enteBeneficiario =
+                    nodoVerificaRPTRResponse.getDatiPagamentoPA().getEnteBeneficiario();
+
+                paymentRequestInfo =
+                    Mono.just(
+                        new PaymentRequestInfo(
+                            rptId,
+                            enteBeneficiario != null
+                                ? enteBeneficiario
+                                    .getIdentificativoUnivocoBeneficiario()
+                                    .getCodiceIdentificativoUnivoco()
+                                : null,
+                            enteBeneficiario != null
+                                ? enteBeneficiario.getDenominazioneBeneficiario()
+                                : null,
+                            nodoVerificaRPTRResponse.getDatiPagamentoPA().getCausaleVersamento(),
+                            nodoVerificaRPTRResponse
+                                .getDatiPagamentoPA()
+                                .getImportoSingoloVersamento(),
+                            null,
+                            false));
+              }
+              return paymentRequestInfo;
+            });
+  }
+}

--- a/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
+++ b/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
@@ -70,6 +70,7 @@ public class PaymentRequestsService {
                     .paTaxCode(paymentInfo.paTaxCode())
                     .paName(paymentInfo.paName())
                     .description(paymentInfo.description())
+                    .amount(paymentInfo.amount().intValue())
                     .dueDate(paymentInfo.dueDate())
                     .paymentContextCode(UUID.randomUUID().toString()))
         .doOnNext(

--- a/src/main/java/it/pagopa/transactions/utils/soap/JaxbContextContainer.java
+++ b/src/main/java/it/pagopa/transactions/utils/soap/JaxbContextContainer.java
@@ -7,20 +7,20 @@ import javax.xml.bind.Unmarshaller;
 
 final class JaxbContextContainer {
 
-    private static final String PACKAGE_NODE_FOR_PSP = "it.pagopa.generated.transactions.model";
+  private static final String PACKAGE_NODE =
+      "it.pagopa.generated.transactions.model:it.pagopa.generated.nodoperpsp.model";
 
-    private static JAXBContext jaxbContext = null;
+  private static JAXBContext jaxbContext = null;
 
-    public Marshaller createMarshaller() throws JAXBException {
-        return getJaxbContext().createMarshaller();
-    }
+  public Marshaller createMarshaller() throws JAXBException {
+    return getJaxbContext().createMarshaller();
+  }
 
-    public Unmarshaller createUnmarshaller() throws JAXBException {
-        return getJaxbContext().createUnmarshaller();
-    }
+  public Unmarshaller createUnmarshaller() throws JAXBException {
+    return getJaxbContext().createUnmarshaller();
+  }
 
-    private JAXBContext getJaxbContext() throws JAXBException {
-        return jaxbContext  == null ? JAXBContext.newInstance(PACKAGE_NODE_FOR_PSP) : jaxbContext;
-    }
-
+  private JAXBContext getJaxbContext() throws JAXBException {
+    return jaxbContext == null ? JAXBContext.newInstance(PACKAGE_NODE) : jaxbContext;
+  }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,4 +27,7 @@ azurestorage.connectionstring=${ECOMMERCE_STORAGE_CONNECTION_STRING}
 azurestorage.queues.transactionauthrequestedtevents.name=${TRANSACTION_AUTHORIZATION_REQUESTED_EVENT_QUEUE_NAME}
 azurestorage.queues.transactionauthrequestedtevents.visibilityTimeout=${TRANSACTION_AUTHORIZATION_REQUESTED_EVENT_QUEUE_VISIBILITY_TIMEOUT}
 
+paymentrequests.cache.ttl=${PAYMENT_REQUESTS_CACHE_TTL}
+
 spring.devtools.restart.enabled=false
+server.error.include-stacktrace=never

--- a/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
+++ b/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
@@ -4,21 +4,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
 import it.pagopa.generated.transactions.model.ObjectFactory;
 import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
-import it.pagopa.transactions.utils.soap.Jaxb2SoapEncoder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.xml.bind.Marshaller;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class NodoConfigTest {
+class NodoConfigTest {
 
   @InjectMocks private NodoConfig nodoConfig;
 
@@ -33,7 +28,7 @@ public class NodoConfigTest {
     NodoVerificaRPT nodoVerificaRPT =
         nodoConfig.baseNodoVerificaRPTRequest(
             nodoConnectionString, new it.pagopa.generated.nodoperpsp.model.ObjectFactory());
-    assertEquals(nodoVerificaRPT != null, Boolean.TRUE);
+    assertEquals(Boolean.TRUE, nodoVerificaRPT != null);
   }
 
   @Test
@@ -43,6 +38,6 @@ public class NodoConfigTest {
 
     VerifyPaymentNoticeReq verifyPaymentNoticeReq =
         nodoConfig.baseVerifyPaymentNoticeReq(nodoConnectionString, new ObjectFactory());
-    assertEquals(verifyPaymentNoticeReq != null, Boolean.TRUE);
+    assertEquals(Boolean.TRUE, verifyPaymentNoticeReq != null);
   }
 }

--- a/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
+++ b/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
@@ -1,0 +1,48 @@
+package it.pagopa.transactions.configurations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
+import it.pagopa.generated.transactions.model.ObjectFactory;
+import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
+import it.pagopa.transactions.utils.soap.Jaxb2SoapEncoder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.xml.bind.Marshaller;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class NodoConfigTest {
+
+  @InjectMocks private NodoConfig nodoConfig;
+
+  private final String nodoConnectionString =
+      "{\"idPSP\":\"idPsp\",\"idChannel\":\"idChannel\",\"idBrokerPSP\":\"idBrokerPsp\",\"password\":\"password\"}";
+
+  @Test
+  void shouldReturnValidVerificaRPTBaseRequest()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+          JsonProcessingException {
+
+    NodoVerificaRPT nodoVerificaRPT =
+        nodoConfig.baseNodoVerificaRPTRequest(
+            nodoConnectionString, new it.pagopa.generated.nodoperpsp.model.ObjectFactory());
+    assertEquals(nodoVerificaRPT != null, Boolean.TRUE);
+  }
+
+  @Test
+  void shouldReturnValidVerifyPaymentNoticeBaseRequest()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+          JsonProcessingException {
+
+    VerifyPaymentNoticeReq verifyPaymentNoticeReq =
+        nodoConfig.baseVerifyPaymentNoticeReq(nodoConnectionString, new ObjectFactory());
+    assertEquals(verifyPaymentNoticeReq != null, Boolean.TRUE);
+  }
+}

--- a/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
@@ -177,4 +177,21 @@ class PaymentRequestsControllerTest {
         PaymentStatusFaultDto.PAA_PAGAMENTO_IN_CORSO.getValue(),
         responseEntity.getBody().getFaultCodeDetail().getValue());
   }
+
+  @Test
+  void shouldReturnResponseEntityWithGenericGatewayFault()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "nodoErrorHandler", NodoErrorException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<ProblemJsonDto> responseEntity =
+        (ResponseEntity<ProblemJsonDto>)
+            method.invoke(paymentRequestsController, new NodoErrorException("UKNOWK_ERROR"));
+
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.BAD_GATEWAY, responseEntity.getStatusCode());
+  }
 }

--- a/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
@@ -2,9 +2,11 @@ package it.pagopa.transactions.controllers;
 
 import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
 import it.pagopa.generated.transactions.server.model.*;
+import it.pagopa.transactions.services.PaymentRequestsService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -13,20 +15,28 @@ import reactor.core.publisher.Mono;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentRequestsControllerTest {
 
-    @InjectMocks
-    private PaymentRequestsController paymentRequestsController;
+  @InjectMocks private PaymentRequestsController paymentRequestsController;
 
-    @Test
-    void shouldGetOk() {
-        String RPTID = "77777777777302016723749670035";
+  @Mock private PaymentRequestsService paymentRequestsService;
 
-        ResponseEntity<PaymentRequestsGetResponseDto> responseEntity = paymentRequestsController
-                .getPaymentRequestInfo(RPTID, null).block();
+  @Test
+  void shouldGetPaymentInfoGivenValidRptid() {
+    String RPTID = "77777777777302016723749670035";
 
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-    }
+    PaymentRequestsGetResponseDto response = new PaymentRequestsGetResponseDto();
+    response.setRptId(RPTID);
+    response.amount(1000);
+    response.setDescription("Payment test");
+    when(paymentRequestsService.getPaymentRequestInfo(RPTID)).thenReturn(Mono.just(response));
+
+    ResponseEntity<PaymentRequestsGetResponseDto> responseEntity =
+        paymentRequestsController.getPaymentRequestInfo(RPTID, null).block();
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+  }
 }

--- a/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
@@ -1,17 +1,20 @@
 package it.pagopa.transactions.controllers;
 
-import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
-import it.pagopa.generated.transactions.server.model.*;
+import it.pagopa.generated.payment.requests.model.*;
+import it.pagopa.generated.transactions.server.model.ProblemJsonDto;
+import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.services.PaymentRequestsService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,5 +41,140 @@ class PaymentRequestsControllerTest {
         paymentRequestsController.getPaymentRequestInfo(RPTID, null).block();
 
     assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+  }
+
+  @Test
+  void shouldGenericBadGatewayResponse()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "genericBadGatewayHandler", RuntimeException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<ProblemJsonDto> responseEntity =
+        (ResponseEntity<ProblemJsonDto>)
+            method.invoke(paymentRequestsController, new RuntimeException());
+
+    assertEquals(responseEntity != null, Boolean.TRUE);
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_GATEWAY);
+  }
+
+  @Test
+  void shouldReturnResponseEntityWithPartyConfigurationFault()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "nodoErrorHandler", NodoErrorException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<PartyConfigurationFaultPaymentProblemJsonDto> responseEntity =
+        (ResponseEntity<PartyConfigurationFaultPaymentProblemJsonDto>)
+            method.invoke(
+                paymentRequestsController,
+                new NodoErrorException(
+                    PartyConfigurationFaultDto.PPT_DOMINIO_DISABILITATO.getValue()));
+
+    assertEquals(responseEntity != null, Boolean.TRUE);
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_GATEWAY);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.PAYMENT_UNAVAILABLE);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeDetail().getValue(),
+        PartyConfigurationFaultDto.PPT_DOMINIO_DISABILITATO.getValue());
+  }
+
+  @Test
+  void shouldReturnResponseEntityWithValidationFault()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "nodoErrorHandler", NodoErrorException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<ValidationFaultPaymentProblemJsonDto> responseEntity =
+        (ResponseEntity<ValidationFaultPaymentProblemJsonDto>)
+            method.invoke(
+                paymentRequestsController,
+                new NodoErrorException(ValidationFaultDto.PPT_DOMINIO_SCONOSCIUTO.getValue()));
+
+    assertEquals(responseEntity != null, Boolean.TRUE);
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.NOT_FOUND);
+    assertEquals(responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.PAYMENT_UNKNOWN);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeDetail().getValue(),
+        ValidationFaultDto.PPT_DOMINIO_SCONOSCIUTO.getValue());
+  }
+
+  @Test
+  void shouldReturnResponseEntityWithGatewayFault()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "nodoErrorHandler", NodoErrorException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<GatewayFaultPaymentProblemJsonDto> responseEntity =
+        (ResponseEntity<GatewayFaultPaymentProblemJsonDto>)
+            method.invoke(
+                paymentRequestsController,
+                new NodoErrorException(GatewayFaultDto.PAA_SYSTEM_ERROR.getValue()));
+
+    assertEquals(responseEntity != null, Boolean.TRUE);
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_GATEWAY);
+    assertEquals(responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.GENERIC_ERROR);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeDetail().getValue(),
+        GatewayFaultDto.PAA_SYSTEM_ERROR.getValue());
+  }
+
+  @Test
+  void shouldReturnResponseEntityWithPartyTimeoutFault()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "nodoErrorHandler", NodoErrorException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<PartyTimeoutFaultPaymentProblemJsonDto> responseEntity =
+        (ResponseEntity<PartyTimeoutFaultPaymentProblemJsonDto>)
+            method.invoke(
+                paymentRequestsController,
+                new NodoErrorException(
+                    PartyTimeoutFaultDto.PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE.getValue()));
+
+    assertEquals(responseEntity != null, Boolean.TRUE);
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.GATEWAY_TIMEOUT);
+    assertEquals(responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.GENERIC_ERROR);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeDetail().getValue(),
+        PartyTimeoutFaultDto.PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE.getValue());
+  }
+
+  @Test
+  void shouldReturnResponseEntityWithPaymentStatusFault()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    Method method =
+        PaymentRequestsController.class.getDeclaredMethod(
+            "nodoErrorHandler", NodoErrorException.class);
+    method.setAccessible(true);
+
+    ResponseEntity<PaymentStatusFaultPaymentProblemJsonDto> responseEntity =
+        (ResponseEntity<PaymentStatusFaultPaymentProblemJsonDto>)
+            method.invoke(
+                paymentRequestsController,
+                new NodoErrorException(PaymentStatusFaultDto.PAA_PAGAMENTO_IN_CORSO.getValue()));
+
+    assertEquals(responseEntity != null, Boolean.TRUE);
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.CONFLICT);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.PAYMENT_UNAVAILABLE);
+    assertEquals(
+        responseEntity.getBody().getFaultCodeDetail().getValue(),
+        PaymentStatusFaultDto.PAA_PAGAMENTO_IN_CORSO.getValue());
   }
 }

--- a/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/PaymentRequestsControllerTest.java
@@ -55,8 +55,8 @@ class PaymentRequestsControllerTest {
         (ResponseEntity<ProblemJsonDto>)
             method.invoke(paymentRequestsController, new RuntimeException());
 
-    assertEquals(responseEntity != null, Boolean.TRUE);
-    assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_GATEWAY);
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.BAD_GATEWAY, responseEntity.getStatusCode());
   }
 
   @Test
@@ -75,13 +75,13 @@ class PaymentRequestsControllerTest {
                 new NodoErrorException(
                     PartyConfigurationFaultDto.PPT_DOMINIO_DISABILITATO.getValue()));
 
-    assertEquals(responseEntity != null, Boolean.TRUE);
-    assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_GATEWAY);
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.BAD_GATEWAY, responseEntity.getStatusCode());
     assertEquals(
-        responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.PAYMENT_UNAVAILABLE);
+        FaultCategoryDto.PAYMENT_UNAVAILABLE, responseEntity.getBody().getFaultCodeCategory());
     assertEquals(
-        responseEntity.getBody().getFaultCodeDetail().getValue(),
-        PartyConfigurationFaultDto.PPT_DOMINIO_DISABILITATO.getValue());
+        PartyConfigurationFaultDto.PPT_DOMINIO_DISABILITATO.getValue(),
+        responseEntity.getBody().getFaultCodeDetail().getValue());
   }
 
   @Test
@@ -99,12 +99,12 @@ class PaymentRequestsControllerTest {
                 paymentRequestsController,
                 new NodoErrorException(ValidationFaultDto.PPT_DOMINIO_SCONOSCIUTO.getValue()));
 
-    assertEquals(responseEntity != null, Boolean.TRUE);
-    assertEquals(responseEntity.getStatusCode(), HttpStatus.NOT_FOUND);
-    assertEquals(responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.PAYMENT_UNKNOWN);
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+    assertEquals(FaultCategoryDto.PAYMENT_UNKNOWN, responseEntity.getBody().getFaultCodeCategory());
     assertEquals(
-        responseEntity.getBody().getFaultCodeDetail().getValue(),
-        ValidationFaultDto.PPT_DOMINIO_SCONOSCIUTO.getValue());
+        ValidationFaultDto.PPT_DOMINIO_SCONOSCIUTO.getValue(),
+        responseEntity.getBody().getFaultCodeDetail().getValue());
   }
 
   @Test
@@ -122,12 +122,12 @@ class PaymentRequestsControllerTest {
                 paymentRequestsController,
                 new NodoErrorException(GatewayFaultDto.PAA_SYSTEM_ERROR.getValue()));
 
-    assertEquals(responseEntity != null, Boolean.TRUE);
-    assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_GATEWAY);
-    assertEquals(responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.GENERIC_ERROR);
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.BAD_GATEWAY, responseEntity.getStatusCode());
+    assertEquals(FaultCategoryDto.GENERIC_ERROR, responseEntity.getBody().getFaultCodeCategory());
     assertEquals(
-        responseEntity.getBody().getFaultCodeDetail().getValue(),
-        GatewayFaultDto.PAA_SYSTEM_ERROR.getValue());
+        GatewayFaultDto.PAA_SYSTEM_ERROR.getValue(),
+        responseEntity.getBody().getFaultCodeDetail().getValue());
   }
 
   @Test
@@ -146,12 +146,12 @@ class PaymentRequestsControllerTest {
                 new NodoErrorException(
                     PartyTimeoutFaultDto.PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE.getValue()));
 
-    assertEquals(responseEntity != null, Boolean.TRUE);
-    assertEquals(responseEntity.getStatusCode(), HttpStatus.GATEWAY_TIMEOUT);
-    assertEquals(responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.GENERIC_ERROR);
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.GATEWAY_TIMEOUT, responseEntity.getStatusCode());
+    assertEquals(FaultCategoryDto.GENERIC_ERROR, responseEntity.getBody().getFaultCodeCategory());
     assertEquals(
-        responseEntity.getBody().getFaultCodeDetail().getValue(),
-        PartyTimeoutFaultDto.PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE.getValue());
+        PartyTimeoutFaultDto.PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE.getValue(),
+        responseEntity.getBody().getFaultCodeDetail().getValue());
   }
 
   @Test
@@ -169,12 +169,12 @@ class PaymentRequestsControllerTest {
                 paymentRequestsController,
                 new NodoErrorException(PaymentStatusFaultDto.PAA_PAGAMENTO_IN_CORSO.getValue()));
 
-    assertEquals(responseEntity != null, Boolean.TRUE);
-    assertEquals(responseEntity.getStatusCode(), HttpStatus.CONFLICT);
+    assertEquals(Boolean.TRUE, responseEntity != null);
+    assertEquals(HttpStatus.CONFLICT, responseEntity.getStatusCode());
     assertEquals(
-        responseEntity.getBody().getFaultCodeCategory(), FaultCategoryDto.PAYMENT_UNAVAILABLE);
+        FaultCategoryDto.PAYMENT_UNAVAILABLE, responseEntity.getBody().getFaultCodeCategory());
     assertEquals(
-        responseEntity.getBody().getFaultCodeDetail().getValue(),
-        PaymentStatusFaultDto.PAA_PAGAMENTO_IN_CORSO.getValue());
+        PaymentStatusFaultDto.PAA_PAGAMENTO_IN_CORSO.getValue(),
+        responseEntity.getBody().getFaultCodeDetail().getValue());
   }
 }

--- a/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
@@ -117,7 +117,7 @@ class PaymentRequestsServiceTest {
     /** Assertions */
     assertEquals(responseDto.getRptId(), rptIdAsString);
     assertEquals(responseDto.getDescription(), description);
-    assertEquals(responseDto.getDueDate(), null);
+    assertEquals(null, responseDto.getDueDate());
     assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
   }
 
@@ -166,7 +166,7 @@ class PaymentRequestsServiceTest {
     /** Assertions */
     assertEquals(responseDto.getRptId(), rptIdAsString);
     assertEquals(responseDto.getDescription(), description);
-    assertEquals(responseDto.getDueDate(), null);
+    assertEquals(null, responseDto.getDueDate());
     assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
   }
 

--- a/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
@@ -2,10 +2,13 @@ package it.pagopa.transactions.services;
 
 import it.pagopa.generated.nodoperpsp.model.*;
 import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
+import it.pagopa.generated.payment.requests.model.PaymentStatusFaultDto;
+import it.pagopa.generated.payment.requests.model.ValidationFaultDto;
 import it.pagopa.generated.transactions.model.*;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.client.NodoPerPspClient;
 import it.pagopa.transactions.domain.RptId;
+import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.repositories.PaymentRequestInfo;
 import it.pagopa.transactions.repositories.PaymentRequestsInfoRepository;
 import org.junit.jupiter.api.Test;
@@ -16,9 +19,18 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
@@ -119,7 +131,7 @@ class PaymentRequestsServiceTest {
     final BigDecimal amount = BigDecimal.valueOf(1000);
 
     PaymentRequestInfo paymentRequestInfo =
-            new PaymentRequestInfo(rptIdAsObject, paTaxCode, paName, description, amount, null, true);
+        new PaymentRequestInfo(rptIdAsObject, paTaxCode, paName, description, amount, null, true);
 
     NodoVerificaRPTRisposta verificaRPTRIsposta = new NodoVerificaRPTRisposta();
     EsitoNodoVerificaRPTRisposta esitoVerificaRPT = new EsitoNodoVerificaRPTRisposta();
@@ -140,21 +152,126 @@ class PaymentRequestsServiceTest {
 
     /** Preconditions */
     Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
-            .thenReturn(Optional.empty());
+        .thenReturn(Optional.empty());
     Mockito.when(objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT())
-            .thenReturn(new NodoTipoCodiceIdRPT());
+        .thenReturn(new NodoTipoCodiceIdRPT());
     Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
-            .thenReturn(Mono.just(verificaRPTRIsposta));
+        .thenReturn(Mono.just(verificaRPTRIsposta));
     Mockito.when(nodeForPspClient.verifyPaymentNotice(Mockito.any()))
-            .thenReturn(Mono.just(verifyPaymentNotice));
+        .thenReturn(Mono.just(verifyPaymentNotice));
     /** Test */
     PaymentRequestsGetResponseDto responseDto =
-            paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block();
+        paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block();
 
     /** Assertions */
     assertEquals(responseDto.getRptId(), rptIdAsString);
     assertEquals(responseDto.getDescription(), description);
     assertEquals(responseDto.getDueDate(), null);
+    assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
+  }
+
+  @Test
+  void shouldReturnPaymentOngoingFromNodoVerificaRPT() {
+    final String rptIdAsString = "77777777777302016723749670035";
+    final RptId rptIdAsObject = new RptId(rptIdAsString);
+
+    NodoVerificaRPTRisposta verificaRPTRIsposta = new NodoVerificaRPTRisposta();
+    EsitoNodoVerificaRPTRisposta esitoVerificaRPT = new EsitoNodoVerificaRPTRisposta();
+    esitoVerificaRPT.setEsito(StOutcome.KO.value());
+    FaultBean fault = new FaultBean();
+    fault.setFaultCode(PaymentStatusFaultDto.PPT_PAGAMENTO_IN_CORSO.getValue());
+    esitoVerificaRPT.setFault(fault);
+    verificaRPTRIsposta.setNodoVerificaRPTRisposta(esitoVerificaRPT);
+
+    /** Preconditions */
+    Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
+        .thenReturn(Optional.empty());
+    Mockito.when(objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT())
+        .thenReturn(new NodoTipoCodiceIdRPT());
+    Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
+        .thenReturn(Mono.just(verificaRPTRIsposta));
+
+    /** Test */
+    assertThatThrownBy(() -> paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block())
+        .isInstanceOf(NodoErrorException.class);
+  }
+
+  @Test
+  void shouldReturnPaymentUnknowFromNodoVerificaRPT() {
+    final String rptIdAsString = "77777777777302016723749670035";
+    final RptId rptIdAsObject = new RptId(rptIdAsString);
+
+    NodoVerificaRPTRisposta verificaRPTRIsposta = new NodoVerificaRPTRisposta();
+    EsitoNodoVerificaRPTRisposta esitoVerificaRPT = new EsitoNodoVerificaRPTRisposta();
+    esitoVerificaRPT.setEsito(StOutcome.KO.value());
+    FaultBean fault = new FaultBean();
+    fault.setFaultCode(ValidationFaultDto.PPT_DOMINIO_SCONOSCIUTO.getValue());
+    esitoVerificaRPT.setFault(fault);
+    verificaRPTRIsposta.setNodoVerificaRPTRisposta(esitoVerificaRPT);
+
+    /** Preconditions */
+    Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
+        .thenReturn(Optional.empty());
+    Mockito.when(objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT())
+        .thenReturn(new NodoTipoCodiceIdRPT());
+    Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
+        .thenReturn(Mono.just(verificaRPTRIsposta));
+
+    /** Test */
+    assertThatThrownBy(() -> paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block())
+        .isInstanceOf(NodoErrorException.class);
+  }
+
+  @Test
+  void shouldReturnPaymentInfoRequestFromNodoVerifyPaymentNoticeWithDueDate()
+      throws ParseException, DatatypeConfigurationException {
+    final String rptIdAsString = "77777777777302016723749670035";
+    final RptId rptIdAsObject = new RptId(rptIdAsString);
+    final String paTaxCode = "77777777777";
+    final String paName = "Pa Name";
+    final String description = "Payment request description";
+    final BigDecimal amount = BigDecimal.valueOf(1000);
+
+    DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+    Date date = format.parse("2022-04-24");
+    XMLGregorianCalendar dueDate =
+        DatatypeFactory.newInstance().newXMLGregorianCalendar(format.format(date));
+
+    NodoVerificaRPTRisposta verificaRPTRIsposta = new NodoVerificaRPTRisposta();
+    EsitoNodoVerificaRPTRisposta esitoVerificaRPT = new EsitoNodoVerificaRPTRisposta();
+    esitoVerificaRPT.setEsito(StOutcome.KO.value());
+    FaultBean fault = new FaultBean();
+    fault.setFaultCode("PPT_MULTI_BENEFICIARIO");
+    esitoVerificaRPT.setFault(fault);
+    verificaRPTRIsposta.setNodoVerificaRPTRisposta(esitoVerificaRPT);
+
+    VerifyPaymentNoticeRes verifyPaymentNotice = new VerifyPaymentNoticeRes();
+    verifyPaymentNotice.setOutcome(StOutcome.OK);
+    verifyPaymentNotice.setPaymentDescription(description);
+    CtPaymentOptionsDescriptionList paymentList = new CtPaymentOptionsDescriptionList();
+    CtPaymentOptionDescription paymentDescription = new CtPaymentOptionDescription();
+    paymentDescription.setAmount(amount);
+    paymentDescription.setDueDate(dueDate);
+    paymentList.getPaymentOptionDescription().add(paymentDescription);
+    verifyPaymentNotice.setPaymentList(paymentList);
+
+    /** Preconditions */
+    Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
+        .thenReturn(Optional.empty());
+    Mockito.when(objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT())
+        .thenReturn(new NodoTipoCodiceIdRPT());
+    Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
+        .thenReturn(Mono.just(verificaRPTRIsposta));
+    Mockito.when(nodeForPspClient.verifyPaymentNotice(Mockito.any()))
+        .thenReturn(Mono.just(verifyPaymentNotice));
+    /** Test */
+    PaymentRequestsGetResponseDto responseDto =
+        paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block();
+
+    /** Assertions */
+    assertEquals(responseDto.getRptId(), rptIdAsString);
+    assertEquals(responseDto.getDescription(), description);
+    assertEquals("2022-04-24", responseDto.getDueDate());
     assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
   }
 }

--- a/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
@@ -11,6 +11,7 @@ import it.pagopa.transactions.domain.RptId;
 import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.repositories.PaymentRequestInfo;
 import it.pagopa.transactions.repositories.PaymentRequestsInfoRepository;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -237,8 +238,9 @@ class PaymentRequestsServiceTest {
         .thenReturn(Mono.just(verificaRPTRIsposta));
 
     /** Test */
-    assertThatThrownBy(() -> paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block())
-        .isInstanceOf(NodoErrorException.class);
+    Assert.assertThrows(
+        NodoErrorException.class,
+        () -> paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block());
   }
 
   @Test
@@ -263,8 +265,9 @@ class PaymentRequestsServiceTest {
         .thenReturn(Mono.just(verificaRPTRIsposta));
 
     /** Test */
-    assertThatThrownBy(() -> paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block())
-        .isInstanceOf(NodoErrorException.class);
+    Assert.assertThrows(
+        NodoErrorException.class,
+        () -> paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block());
   }
 
   @Test

--- a/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
@@ -1,0 +1,160 @@
+package it.pagopa.transactions.services;
+
+import it.pagopa.generated.nodoperpsp.model.*;
+import it.pagopa.generated.payment.requests.model.PaymentRequestsGetResponseDto;
+import it.pagopa.generated.transactions.model.*;
+import it.pagopa.transactions.client.NodeForPspClient;
+import it.pagopa.transactions.client.NodoPerPspClient;
+import it.pagopa.transactions.domain.RptId;
+import it.pagopa.transactions.repositories.PaymentRequestInfo;
+import it.pagopa.transactions.repositories.PaymentRequestsInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentRequestsServiceTest {
+
+  @InjectMocks private PaymentRequestsService paymentRequestsService;
+
+  @Mock private PaymentRequestsInfoRepository paymentRequestsInfoRepository;
+
+  @Mock private NodoPerPspClient nodoPerPspClient;
+
+  @Mock private NodeForPspClient nodeForPspClient;
+
+  @Mock private it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp;
+
+  @Mock private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
+
+  @Mock private NodoVerificaRPT baseNodoVerificaRPTRequest;
+
+  @Mock private VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq;
+
+  @Test
+  void shouldReturnPaymentInfoRequestFromCache() {
+    final String rptIdAsString = "77777777777302016723749670035";
+    final RptId rptIdAsObject = new RptId(rptIdAsString);
+    final String paTaxCode = "77777777777";
+    final String paName = "Pa Name";
+    final String description = "Payment request description";
+    final BigDecimal amount = BigDecimal.valueOf(1000);
+
+    PaymentRequestInfo paymentRequestInfo =
+        new PaymentRequestInfo(rptIdAsObject, paTaxCode, paName, description, amount, null, true);
+
+    /** Preconditions */
+    Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
+        .thenReturn(Optional.of(paymentRequestInfo));
+
+    /** Test */
+    PaymentRequestsGetResponseDto responseDto =
+        paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block();
+
+    /** Assertions */
+    assertEquals(responseDto.getRptId(), rptIdAsString);
+    assertEquals(responseDto.getDescription(), description);
+    assertEquals(responseDto.getDueDate(), null);
+    assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
+    assertEquals(responseDto.getPaName(), paName);
+    assertEquals(responseDto.getPaTaxCode(), paTaxCode);
+  }
+
+  @Test
+  void shouldReturnPaymentInfoRequestFromNodoVerificaRPT() {
+    final String rptIdAsString = "77777777777302016723749670035";
+    final RptId rptIdAsObject = new RptId(rptIdAsString);
+    final String paTaxCode = "77777777777";
+    final String paName = "Pa Name";
+    final String description = "Payment request description";
+    final BigDecimal amount = BigDecimal.valueOf(1000);
+
+    PaymentRequestInfo paymentRequestInfo =
+        new PaymentRequestInfo(rptIdAsObject, paTaxCode, paName, description, amount, null, true);
+
+    NodoVerificaRPTRisposta verificaRPTRIsposta = new NodoVerificaRPTRisposta();
+    EsitoNodoVerificaRPTRisposta esitoVerificaRPT = new EsitoNodoVerificaRPTRisposta();
+    esitoVerificaRPT.setEsito(StOutcome.OK.value());
+    NodoTipoDatiPagamentoPA datiPagamento = new NodoTipoDatiPagamentoPA();
+    datiPagamento.setCausaleVersamento(description);
+    datiPagamento.setImportoSingoloVersamento(amount);
+    esitoVerificaRPT.setDatiPagamentoPA(datiPagamento);
+    verificaRPTRIsposta.setNodoVerificaRPTRisposta(esitoVerificaRPT);
+
+    /** Preconditions */
+    Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
+        .thenReturn(Optional.empty());
+    Mockito.when(objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT())
+        .thenReturn(new NodoTipoCodiceIdRPT());
+    Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
+        .thenReturn(Mono.just(verificaRPTRIsposta));
+
+    /** Test */
+    PaymentRequestsGetResponseDto responseDto =
+        paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block();
+
+    /** Assertions */
+    assertEquals(responseDto.getRptId(), rptIdAsString);
+    assertEquals(responseDto.getDescription(), description);
+    assertEquals(responseDto.getDueDate(), null);
+    assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
+  }
+
+  @Test
+  void shouldReturnPaymentInfoRequestFromNodoVerifyPaymentNotice() {
+    final String rptIdAsString = "77777777777302016723749670035";
+    final RptId rptIdAsObject = new RptId(rptIdAsString);
+    final String paTaxCode = "77777777777";
+    final String paName = "Pa Name";
+    final String description = "Payment request description";
+    final BigDecimal amount = BigDecimal.valueOf(1000);
+
+    PaymentRequestInfo paymentRequestInfo =
+            new PaymentRequestInfo(rptIdAsObject, paTaxCode, paName, description, amount, null, true);
+
+    NodoVerificaRPTRisposta verificaRPTRIsposta = new NodoVerificaRPTRisposta();
+    EsitoNodoVerificaRPTRisposta esitoVerificaRPT = new EsitoNodoVerificaRPTRisposta();
+    esitoVerificaRPT.setEsito(StOutcome.KO.value());
+    FaultBean fault = new FaultBean();
+    fault.setFaultCode("PPT_MULTI_BENEFICIARIO");
+    esitoVerificaRPT.setFault(fault);
+    verificaRPTRIsposta.setNodoVerificaRPTRisposta(esitoVerificaRPT);
+
+    VerifyPaymentNoticeRes verifyPaymentNotice = new VerifyPaymentNoticeRes();
+    verifyPaymentNotice.setOutcome(StOutcome.OK);
+    verifyPaymentNotice.setPaymentDescription(description);
+    CtPaymentOptionsDescriptionList paymentList = new CtPaymentOptionsDescriptionList();
+    CtPaymentOptionDescription paymentDescription = new CtPaymentOptionDescription();
+    paymentDescription.setAmount(amount);
+    paymentList.getPaymentOptionDescription().add(paymentDescription);
+    verifyPaymentNotice.setPaymentList(paymentList);
+
+    /** Preconditions */
+    Mockito.when(paymentRequestsInfoRepository.findById(rptIdAsObject))
+            .thenReturn(Optional.empty());
+    Mockito.when(objectFactoryNodoPerPsp.createNodoTipoCodiceIdRPT())
+            .thenReturn(new NodoTipoCodiceIdRPT());
+    Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
+            .thenReturn(Mono.just(verificaRPTRIsposta));
+    Mockito.when(nodeForPspClient.verifyPaymentNotice(Mockito.any()))
+            .thenReturn(Mono.just(verifyPaymentNotice));
+    /** Test */
+    PaymentRequestsGetResponseDto responseDto =
+            paymentRequestsService.getPaymentRequestInfo(rptIdAsString).block();
+
+    /** Assertions */
+    assertEquals(responseDto.getRptId(), rptIdAsString);
+    assertEquals(responseDto.getDescription(), description);
+    assertEquals(responseDto.getDueDate(), null);
+    assertEquals(BigDecimal.valueOf(responseDto.getAmount()), amount);
+  }
+}

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 
 @WebFluxTest
 @TestPropertySource(locations = "classpath:application-tests.properties")
-@Import({TransactionsService.class, TransactionRequestAuthorizationHandler.class, TransactionsProjectionHandler.class, AuthorizationRequestProjectionHandler.class})
+@Import({TransactionsService.class, PaymentRequestsService.class, TransactionRequestAuthorizationHandler.class, TransactionsProjectionHandler.class, AuthorizationRequestProjectionHandler.class})
 public class TransactionServiceTests {
 	@MockBean
 	private TransactionsViewRepository repository;
@@ -79,7 +79,10 @@ public class TransactionServiceTests {
 
 	@MockBean
 	private TransactionUpdateProjectionHandler transactionUpdateProjectionHandler;
-	
+
+	@MockBean
+	private PaymentRequestsService paymentRequestsService;
+
 	final String PAYMENT_TOKEN = "aaa";
 	final String TRANSACION_ID = "833d303a-f857-11ec-b939-0242ac120002";
 

--- a/src/test/java/it/pagopa/transactions/util/Jaxb2SoapEncoderTest.java
+++ b/src/test/java/it/pagopa/transactions/util/Jaxb2SoapEncoderTest.java
@@ -1,0 +1,31 @@
+package it.pagopa.transactions.util;
+
+import it.pagopa.transactions.controllers.TransactionsController;
+import it.pagopa.transactions.utils.soap.Jaxb2SoapEncoder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.xml.bind.Marshaller;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class Jaxb2SoapEncoderTest {
+
+  @InjectMocks private Jaxb2SoapEncoder jaxb2SoapEncoder = new Jaxb2SoapEncoder();
+
+  @Test
+  void shouldConstructTransactionAmount()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method method = Jaxb2SoapEncoder.class.getDeclaredMethod("getMarshaller");
+    method.setAccessible(true);
+
+    Marshaller marshaller = (Marshaller) method.invoke(jaxb2SoapEncoder);
+
+    assertEquals(marshaller != null, Boolean.TRUE);
+  }
+}

--- a/src/test/java/it/pagopa/transactions/utils/soap/Jaxb2SoapEncoderTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/soap/Jaxb2SoapEncoderTest.java
@@ -13,7 +13,7 @@ import java.lang.reflect.Method;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class Jaxb2SoapEncoderTest {
+class Jaxb2SoapEncoderTest {
 
   @InjectMocks private Jaxb2SoapEncoder jaxb2SoapEncoder = new Jaxb2SoapEncoder();
 
@@ -25,6 +25,6 @@ public class Jaxb2SoapEncoderTest {
 
     Marshaller marshaller = (Marshaller) method.invoke(jaxb2SoapEncoder);
 
-    assertEquals(marshaller != null, Boolean.TRUE);
+    assertEquals(Boolean.TRUE, marshaller != null);
   }
 }

--- a/src/test/java/it/pagopa/transactions/utils/soap/Jaxb2SoapEncoderTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/soap/Jaxb2SoapEncoderTest.java
@@ -1,6 +1,5 @@
-package it.pagopa.transactions.util;
+package it.pagopa.transactions.utils.soap;
 
-import it.pagopa.transactions.controllers.TransactionsController;
 import it.pagopa.transactions.utils.soap.Jaxb2SoapEncoder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- add new nodoPerPsp.wsdl to generate client fo _nodoVerificaRPT_;
- update nodo client configuration to generate client according to `nodeForPsp.wsdl` and `nodoPerPsp.wsdl`;
- retrive paymentRequestInfo with _nodoVerificaRPT_ or _verifyPaymentNotice_ according to payment model (NM3);
- redis cache for paymentRequestInfo with TTL 10 min;

#### Motivation and Context

The goal of this PR is to create a new API to retrive the information related to payment request, using the _nodoVerificaRPT_ or _verifyPaymentNotice_  and a cache with payment request info and isNM3 flag. For more details https://pagopa.atlassian.net/wiki/spaces/I/pages/492339720/eCommerce+pagoPA+Design+Review#RF-1.-Come-client-di-eCommerce-voglio-poter-recuperare-le-informazione-di-un-avviso-pagoPA;

#### How Has This Been Tested?

unit test & https://github.com/pagopa/pagopa-ecommerce-local

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.