### PR TITLE
fix: test update netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,12 @@
             <version>1.16.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <version>4.1.82.Final</version>
+            <classifier>osx-aarch_64</classifier>
+        </dependency>
 
     </dependencies>
     <dependencyManagement>


### PR DESCRIPTION
An exception is thrown at the start application. It matters the dns in m1 architecture that doesn't resolve some addresses.

`i.n.r.d.DnsServerAddressStreamProviders  : Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.
`

`Caused by: java.lang.UnsatisfiedLinkError: could not load a native library: netty_resolver_dns_native_macos_aarch_64
`

#### List of Changes

Update the pom file to force the use of the latest version of netty (4.1.82.Final)

#### Motivation and Context

On M1 Arm architecture an issue is present from netty dependency (integrated in spring boot).
Try to update spring boot or force it to use latest version of netty.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Compile issue  in local environment
- [ ] Start issue in local environment

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change doesn't require a change to the documentation.

- [ ] Before approve please try to clean the environment, build and execute on different architecture