### PR TITLE
[CHK-894] fix: nodo request building side-effect

### DIFF
--- a/src/main/java/it/pagopa/transactions/client/NodoPerPspClient.java
+++ b/src/main/java/it/pagopa/transactions/client/NodoPerPspClient.java
@@ -1,11 +1,11 @@
 package it.pagopa.transactions.client;
 
-import javax.xml.bind.JAXBElement;
-
 import it.pagopa.generated.nodoperpsp.model.NodoAttivaRPT;
 import it.pagopa.generated.nodoperpsp.model.NodoAttivaRPTRisposta;
 import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
 import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPTRisposta;
+import it.pagopa.transactions.utils.soap.SoapEnvelope;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -13,10 +13,9 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ResponseStatusException;
-
-import it.pagopa.transactions.utils.soap.SoapEnvelope;
-import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
+
+import javax.xml.bind.JAXBElement;
 
 @Component
 @Slf4j

--- a/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
+++ b/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
@@ -1,42 +1,47 @@
 package it.pagopa.transactions.configurations;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.generated.nodoperpsp.model.NodoAttivaRPT;
 import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
 import it.pagopa.generated.transactions.model.ActivatePaymentNoticeReq;
 import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
 import it.pagopa.transactions.utils.NodoConnectionString;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
+@Slf4j
 public class NodoConfig {
 
-    @Bean
-    public NodoConnectionString nodoConnectionString(
-                                                     @Value(
-                                                         "${nodo.connection.string}"
-                                                     ) String nodoConnectionParamsAsString
-    )
-            throws JsonProcessingException {
+    @Value("${nodo.connection.string}")
+    private String nodoConnectionParamsAsString;
 
-        return new ObjectMapper().readValue(nodoConnectionParamsAsString, NodoConnectionString.class);
+    @Autowired
+    private it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp;
+
+    @Autowired
+    private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
+
+    @Bean
+    public NodoConnectionString nodoConnectionString() {
+        NodoConnectionString nodoConnectionString = null;
+        try {
+            nodoConnectionString = new ObjectMapper()
+                    .readValue(nodoConnectionParamsAsString, NodoConnectionString.class);
+        } catch (JsonProcessingException e) {
+            // exception not logged here since it can expose sensitive information contained
+            // into nodo connection string
+            log.error("Exception parsing nodo connection string");
+        }
+        return nodoConnectionString;
     }
 
-    @Bean
-    public NodoVerificaRPT baseNodoVerificaRPTRequest(
-                                                      @Value(
-                                                          "${nodo.connection.string}"
-                                                      ) String nodoConnectionParamsAsString,
-                                                      it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp
-    )
-            throws JsonProcessingException {
-
-        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
-
+    public NodoVerificaRPT baseNodoVerificaRPTRequest() {
+        NodoConnectionString nodoConnectionParams = nodoConnectionString();
         NodoVerificaRPT request = objectFactoryNodoPerPsp.createNodoVerificaRPT();
         request.setIdentificativoPSP(nodoConnectionParams.getIdPSP());
         request.setIdentificativoCanale(nodoConnectionParams.getIdChannel());
@@ -47,17 +52,8 @@ public class NodoConfig {
         return request;
     }
 
-    @Bean
-    public NodoAttivaRPT baseNodoAttivaRPTRequest(
-                                                  @Value(
-                                                      "${nodo.connection.string}"
-                                                  ) String nodoConnectionParamsAsString,
-                                                  it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp
-    )
-            throws JsonProcessingException {
-
-        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
-
+    public NodoAttivaRPT baseNodoAttivaRPTRequest() {
+        NodoConnectionString nodoConnectionParams = nodoConnectionString();
         NodoAttivaRPT request = objectFactoryNodoPerPsp.createNodoAttivaRPT();
         request.setIdentificativoPSP(nodoConnectionParams.getIdPSP());
         request.setIdentificativoCanale(nodoConnectionParams.getIdChannel());
@@ -69,17 +65,8 @@ public class NodoConfig {
         return request;
     }
 
-    @Bean
-    public VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq(
-                                                             @Value(
-                                                                 "${nodo.connection.string}"
-                                                             ) String nodoConnectionParamsAsString,
-                                                             it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp
-    )
-            throws JsonProcessingException {
-
-        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
-
+    public VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq() {
+        NodoConnectionString nodoConnectionParams = nodoConnectionString();
         VerifyPaymentNoticeReq request = objectFactoryNodeForPsp.createVerifyPaymentNoticeReq();
         request.setIdPSP(nodoConnectionParams.getIdPSP());
         request.setIdChannel(nodoConnectionParams.getIdChannel());
@@ -88,23 +75,13 @@ public class NodoConfig {
         return request;
     }
 
-    @Bean
-    public ActivatePaymentNoticeReq baseActivatePaymentNoticeReq(
-                                                                 @Value(
-                                                                     "${nodo.connection.string}"
-                                                                 ) String nodoConnectionParamsAsString,
-                                                                 it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp
-    )
-            throws JsonProcessingException {
-
-        NodoConnectionString nodoConnectionParams = nodoConnectionString(nodoConnectionParamsAsString);
-
+    public ActivatePaymentNoticeReq baseActivatePaymentNoticeReq() {
+        NodoConnectionString nodoConnectionParams = nodoConnectionString();
         ActivatePaymentNoticeReq request = objectFactoryNodeForPsp.createActivatePaymentNoticeReq();
         request.setIdPSP(nodoConnectionParams.getIdPSP());
         request.setIdChannel(nodoConnectionParams.getIdChannel());
         request.setIdBrokerPSP(nodoConnectionParams.getIdBrokerPSP());
         request.setPassword(nodoConnectionParams.getPassword());
-
         return request;
     }
 }

--- a/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
+++ b/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
@@ -26,16 +26,14 @@ public class NodoConfig {
 
     @Bean
     public NodoConnectionString nodoConnectionString() {
-        NodoConnectionString nodoConnectionString = null;
         try {
-            nodoConnectionString = new ObjectMapper()
+            return new ObjectMapper()
                     .readValue(nodoConnectionParamsAsString, NodoConnectionString.class);
         } catch (JsonProcessingException e) {
             // exception not logged here since it can expose sensitive information contained
             // into nodo connection string
             throw new IllegalStateException("Exception parsing JSON nodo connection string");
         }
-        return nodoConnectionString;
     }
 
     public NodoVerificaRPT baseNodoVerificaRPTRequest() {

--- a/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
+++ b/src/main/java/it/pagopa/transactions/configurations/NodoConfig.java
@@ -7,14 +7,12 @@ import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
 import it.pagopa.generated.transactions.model.ActivatePaymentNoticeReq;
 import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
 import it.pagopa.transactions.utils.NodoConnectionString;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@Slf4j
 public class NodoConfig {
 
     @Value("${nodo.connection.string}")
@@ -35,7 +33,7 @@ public class NodoConfig {
         } catch (JsonProcessingException e) {
             // exception not logged here since it can expose sensitive information contained
             // into nodo connection string
-            log.error("Exception parsing nodo connection string");
+            throw new IllegalStateException("Exception parsing JSON nodo connection string");
         }
         return nodoConnectionString;
     }

--- a/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
+++ b/src/main/java/it/pagopa/transactions/services/PaymentRequestsService.java
@@ -10,6 +10,7 @@ import it.pagopa.generated.transactions.model.StOutcome;
 import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.client.NodoPerPspClient;
+import it.pagopa.transactions.configurations.NodoConfig;
 import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.utils.NodoOperations;
 import it.pagopa.transactions.utils.NodoUtilities;
@@ -43,16 +44,13 @@ public class PaymentRequestsService {
     private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
 
     @Autowired
-    private NodoVerificaRPT baseNodoVerificaRPTRequest;
-
-    @Autowired
-    private VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq;
-
-    @Autowired
     private NodoOperations nodoOperations;
 
     @Autowired
     private NodoUtilities nodoUtilities;
+
+    @Autowired
+    private NodoConfig nodoConfig;
 
     public Mono<PaymentRequestsGetResponseDto> getPaymentRequestInfo(String rptId) {
 
@@ -112,7 +110,7 @@ public class PaymentRequestsService {
         return Mono.just(rptId)
                 .flatMap(
                         request -> {
-                            NodoVerificaRPT nodoVerificaRPTRequest = baseNodoVerificaRPTRequest;
+                            NodoVerificaRPT nodoVerificaRPTRequest = nodoConfig.baseNodoVerificaRPTRequest();
                             NodoTipoCodiceIdRPT nodoTipoCodiceIdRPT = nodoUtilities.getCodiceIdRpt(rptId);
                             nodoVerificaRPTRequest.setCodiceIdRPT(nodoTipoCodiceIdRPT);
                             nodoVerificaRPTRequest.setCodiceContestoPagamento(paymentContextCode);
@@ -143,7 +141,7 @@ public class PaymentRequestsService {
 
                             if (Boolean.TRUE.equals(isNM3)) {
 
-                                VerifyPaymentNoticeReq verifyPaymentNoticeReq = baseVerifyPaymentNoticeReq;
+                                VerifyPaymentNoticeReq verifyPaymentNoticeReq = nodoConfig.baseVerifyPaymentNoticeReq();
                                 CtQrCode qrCode = new CtQrCode();
                                 qrCode.setFiscalCode(rptId.getFiscalCode());
                                 qrCode.setNoticeNumber(rptId.getNoticeId());

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -13,6 +13,7 @@ import it.pagopa.generated.transactions.model.StOutcome;
 import it.pagopa.generated.transactions.server.model.NewTransactionRequestDto;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.client.NodoPerPspClient;
+import it.pagopa.transactions.configurations.NodoConfig;
 import it.pagopa.transactions.exceptions.NodoErrorException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,23 +41,19 @@ public class NodoOperations {
     NodeForPspClient nodeForPspClient;
 
     @Autowired
-    ActivatePaymentNoticeReq baseActivatePaymentNoticeReq;
-
-    @Autowired
-    NodoAttivaRPT baseNodoAttivaRPT;
-
-    @Autowired
     it.pagopa.generated.nodoperpsp.model.ObjectFactory objectFactoryNodoPerPsp;
 
     @Autowired
     it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
+    @Autowired
+    NodoConfig nodoConfig;
 
     @Autowired
     NodoUtilities nodoUtilities;
 
     public Mono<PaymentRequestInfo> activatePaymentRequest(
-                                                           PaymentRequestInfo paymentRequestInfo,
-                                                           NewTransactionRequestDto newTransactionRequestDto
+            PaymentRequestInfo paymentRequestInfo,
+            NewTransactionRequestDto newTransactionRequestDto
     ) {
 
         RptId rptId = paymentRequestInfo.id();
@@ -117,7 +114,7 @@ public class NodoOperations {
         CtQrCode qrCode = new CtQrCode();
         qrCode.setFiscalCode(rptId.getFiscalCode());
         qrCode.setNoticeNumber(rptId.getNoticeId());
-        ActivatePaymentNoticeReq request = baseActivatePaymentNoticeReq;
+        ActivatePaymentNoticeReq request = nodoConfig.baseActivatePaymentNoticeReq();
         request.setAmount(amount);
         request.setQrCode(qrCode);
         request.setIdempotencyKey(idempotencyKey);
@@ -139,8 +136,7 @@ public class NodoOperations {
                                                                 String idempotencyKey,
                                                                 String paymentContextCode
     ) {
-        NodoAttivaRPT nodoAttivaRPTReq = baseNodoAttivaRPT;
-
+        NodoAttivaRPT nodoAttivaRPTReq = nodoConfig.baseNodoAttivaRPTRequest();
         NodoTipoCodiceIdRPT nodoTipoCodiceIdRPT = nodoUtilities.getCodiceIdRpt(rptId);
         NodoTipoDatiPagamentoPSP datiPagamentoPsp = objectFactoryNodoPerPsp.createNodoTipoDatiPagamentoPSP();
         datiPagamentoPsp.setImportoSingoloVersamento(amount);

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -52,8 +52,8 @@ public class NodoOperations {
     NodoUtilities nodoUtilities;
 
     public Mono<PaymentRequestInfo> activatePaymentRequest(
-            PaymentRequestInfo paymentRequestInfo,
-            NewTransactionRequestDto newTransactionRequestDto
+                                                           PaymentRequestInfo paymentRequestInfo,
+                                                           NewTransactionRequestDto newTransactionRequestDto
     ) {
 
         RptId rptId = paymentRequestInfo.id();

--- a/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
+++ b/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
@@ -1,11 +1,14 @@
 package it.pagopa.transactions.configurations;
 
+import it.pagopa.generated.nodoperpsp.model.NodoAttivaRPT;
 import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
+import it.pagopa.generated.transactions.model.ActivatePaymentNoticeReq;
 import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,14 +20,51 @@ class NodoConfigTest {
 
     @Test
     void shouldReturnValidVerificaRPTBaseRequest() {
+        ReflectionTestUtils.setField(nodoConfig, "nodoConnectionParamsAsString", "{}");
+        ReflectionTestUtils.setField(
+                nodoConfig,
+                "objectFactoryNodoPerPsp",
+                new it.pagopa.generated.nodoperpsp.model.ObjectFactory()
+        );
         NodoVerificaRPT nodoVerificaRPT = nodoConfig.baseNodoVerificaRPTRequest();
         assertEquals(Boolean.TRUE, nodoVerificaRPT != null);
     }
 
     @Test
     void shouldReturnValidVerifyPaymentNoticeBaseRequest() {
+        ReflectionTestUtils.setField(nodoConfig, "nodoConnectionParamsAsString", "{}");
+        ReflectionTestUtils.setField(
+                nodoConfig,
+                "objectFactoryNodeForPsp",
+                new it.pagopa.generated.transactions.model.ObjectFactory()
+        );
         VerifyPaymentNoticeReq verifyPaymentNoticeReq = nodoConfig
                 .baseVerifyPaymentNoticeReq();
         assertEquals(Boolean.TRUE, verifyPaymentNoticeReq != null);
+    }
+
+    @Test
+    void shouldReturnValidNodoAttivaRPTBaseRequest() {
+        ReflectionTestUtils.setField(nodoConfig, "nodoConnectionParamsAsString", "{}");
+        ReflectionTestUtils.setField(
+                nodoConfig,
+                "objectFactoryNodoPerPsp",
+                new it.pagopa.generated.nodoperpsp.model.ObjectFactory()
+        );
+        NodoAttivaRPT request = nodoConfig.baseNodoAttivaRPTRequest();
+        assertEquals(Boolean.TRUE, request != null);
+    }
+
+    @Test
+    void shouldReturnValidActivatePaymentNoticeReqRPTRequest() {
+        ReflectionTestUtils.setField(nodoConfig, "nodoConnectionParamsAsString", "{}");
+        ReflectionTestUtils.setField(
+                nodoConfig,
+                "objectFactoryNodeForPsp",
+                new it.pagopa.generated.transactions.model.ObjectFactory()
+        );
+        ActivatePaymentNoticeReq request = nodoConfig
+                .baseActivatePaymentNoticeReq();
+        assertEquals(Boolean.TRUE, request != null);
     }
 }

--- a/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
+++ b/src/test/java/it/pagopa/transactions/configurations/NodoConfigTest.java
@@ -1,14 +1,11 @@
 package it.pagopa.transactions.configurations;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import it.pagopa.generated.nodoperpsp.model.NodoVerificaRPT;
-import it.pagopa.generated.transactions.model.ObjectFactory;
 import it.pagopa.generated.transactions.model.VerifyPaymentNoticeReq;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.lang.reflect.InvocationTargetException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,27 +15,16 @@ class NodoConfigTest {
     @InjectMocks
     private NodoConfig nodoConfig;
 
-    private final String nodoConnectionString = "{\"idPSP\":\"idPsp\",\"idChannel\":\"idChannel\",\"idBrokerPSP\":\"idBrokerPsp\",\"password\":\"password\"}";
-
     @Test
-    void shouldReturnValidVerificaRPTBaseRequest()
-            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
-            JsonProcessingException {
-
-        NodoVerificaRPT nodoVerificaRPT = nodoConfig.baseNodoVerificaRPTRequest(
-                nodoConnectionString,
-                new it.pagopa.generated.nodoperpsp.model.ObjectFactory()
-        );
+    void shouldReturnValidVerificaRPTBaseRequest() {
+        NodoVerificaRPT nodoVerificaRPT = nodoConfig.baseNodoVerificaRPTRequest();
         assertEquals(Boolean.TRUE, nodoVerificaRPT != null);
     }
 
     @Test
-    void shouldReturnValidVerifyPaymentNoticeBaseRequest()
-            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
-            JsonProcessingException {
-
+    void shouldReturnValidVerifyPaymentNoticeBaseRequest() {
         VerifyPaymentNoticeReq verifyPaymentNoticeReq = nodoConfig
-                .baseVerifyPaymentNoticeReq(nodoConnectionString, new ObjectFactory());
+                .baseVerifyPaymentNoticeReq();
         assertEquals(Boolean.TRUE, verifyPaymentNoticeReq != null);
     }
 }

--- a/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/PaymentRequestsServiceTest.java
@@ -10,6 +10,7 @@ import it.pagopa.generated.payment.requests.model.ValidationFaultDto;
 import it.pagopa.generated.transactions.model.*;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.client.NodoPerPspClient;
+import it.pagopa.transactions.configurations.NodoConfig;
 import it.pagopa.transactions.exceptions.NodoErrorException;
 import it.pagopa.transactions.utils.NodoOperations;
 import it.pagopa.transactions.utils.NodoUtilities;
@@ -41,10 +42,10 @@ class PaymentRequestsServiceTest {
 
     @InjectMocks
     private PaymentRequestsService paymentRequestsService;
-
     @Mock
     private PaymentRequestsInfoRepository paymentRequestsInfoRepository;
-
+    @Mock
+    private NodoConfig nodoConfig;
     @Mock
     private NodoPerPspClient nodoPerPspClient;
 
@@ -56,12 +57,6 @@ class PaymentRequestsServiceTest {
 
     @Mock
     private it.pagopa.generated.transactions.model.ObjectFactory objectFactoryNodeForPsp;
-
-    @Mock
-    private NodoVerificaRPT baseNodoVerificaRPTRequest;
-
-    @Mock
-    private VerifyPaymentNoticeReq baseVerifyPaymentNoticeReq;
 
     @Mock
     private NodoOperations nodoOperations;
@@ -141,6 +136,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
         Mockito.when(nodoOperations.getEuroCentsFromNodoAmount(amountForNodo))
                 .thenReturn(amount);
 
@@ -184,6 +180,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
         Mockito.when(nodoOperations.getEuroCentsFromNodoAmount(amountForNodo))
                 .thenReturn(amount);
 
@@ -243,6 +240,8 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
+        Mockito.when(nodoConfig.baseVerifyPaymentNoticeReq()).thenReturn(new VerifyPaymentNoticeReq());
         Mockito.when(nodeForPspClient.verifyPaymentNotice(Mockito.any()))
                 .thenReturn(Mono.just(verifyPaymentNotice));
         Mockito.when(nodoOperations.getEuroCentsFromNodoAmount(amountForNodo))
@@ -278,6 +277,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(new NodoTipoCodiceIdRPT());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
 
         /** Test */
         Mono<PaymentRequestsGetResponseDto> paymentRequestInfoMono = paymentRequestsService
@@ -308,6 +308,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
 
         /** Test */
         Mono<PaymentRequestsGetResponseDto> paymentRequestInfoMono = paymentRequestsService
@@ -360,6 +361,8 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Mono.just(verificaRPTRIsposta));
         Mockito.when(nodeForPspClient.verifyPaymentNotice(Mockito.any()))
                 .thenReturn(Mono.just(verifyPaymentNotice));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
+        Mockito.when(nodoConfig.baseVerifyPaymentNoticeReq()).thenReturn(new VerifyPaymentNoticeReq());
         Mockito.when(nodoOperations.getEuroCentsFromNodoAmount(amountForNodo))
                 .thenReturn(amount);
 
@@ -392,7 +395,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
-
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
         /** Assertions */
         StepVerifier
                 .create(paymentRequestsService.getPaymentRequestInfo(rptIdAsString))
@@ -423,7 +426,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
-
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
         /** Assertions */
         StepVerifier
                 .create(paymentRequestsService.getPaymentRequestInfo(rptIdAsString))
@@ -458,6 +461,7 @@ class PaymentRequestsServiceTest {
                 .thenReturn(Optional.empty());
         Mockito.when(nodoPerPspClient.verificaRPT(Mockito.any()))
                 .thenReturn(Mono.just(verificaRPTRIsposta));
+        Mockito.when(nodoConfig.baseNodoVerificaRPTRequest()).thenReturn(new NodoVerificaRPT());
 
         /** Assertions */
         StepVerifier

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -9,6 +9,7 @@ import it.pagopa.generated.transactions.server.model.NewTransactionRequestDto;
 import it.pagopa.generated.transactions.server.model.PaymentNoticeInfoDto;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.client.NodoPerPspClient;
+import it.pagopa.transactions.configurations.NodoConfig;
 import it.pagopa.transactions.exceptions.NodoErrorException;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,9 @@ class NodoOperationsTest {
 
     @Mock
     NodeForPspClient nodeForPspClient;
+
+    @Mock
+    NodoConfig nodoConfig;
 
     @Mock
     ActivatePaymentNoticeReq baseActivatePaymentNoticeReq;
@@ -105,6 +109,8 @@ class NodoOperationsTest {
                 .thenReturn(Mono.just(activatePaymentRes));
         Mockito.when(objectFactoryNodeForPsp.createActivatePaymentNoticeReq(Mockito.any()))
                 .thenReturn(objectFactoryUtil.createActivatePaymentNoticeReq(activatePaymentReq));
+        Mockito.when(nodoConfig.baseActivatePaymentNoticeReq()).thenReturn(new ActivatePaymentNoticeReq());
+
         /** test */
         PaymentRequestInfo response = nodoOperations
                 .activatePaymentRequest(
@@ -159,6 +165,7 @@ class NodoOperationsTest {
                 .thenReturn(Mono.just(activatePaymentRes));
         Mockito.when(objectFactoryNodeForPsp.createActivatePaymentNoticeReq(Mockito.any()))
                 .thenReturn(objectFactoryUtil.createActivatePaymentNoticeReq(activatePaymentReq));
+        Mockito.when(nodoConfig.baseActivatePaymentNoticeReq()).thenReturn(new ActivatePaymentNoticeReq());
 
         PaymentRequestInfo paymentRequestInfo = new PaymentRequestInfo(
                 rptId,
@@ -262,6 +269,8 @@ class NodoOperationsTest {
         Mockito.when(objectFactoryNodoPerPsp.createNodoAttivaRPT(Mockito.any()))
                 .thenReturn(objectFactoryUtilNodoPerPsp.createNodoAttivaRPT(nodoAttivaRPT));
         Mockito.when(nodoUtilities.getCodiceIdRpt(Mockito.any(RptId.class))).thenReturn(nodoTipoCodiceIdRPT);
+        Mockito.when(nodoConfig.baseNodoAttivaRPTRequest()).thenReturn(new NodoAttivaRPT());
+        Mockito.when(nodoConfig.baseActivatePaymentNoticeReq()).thenReturn(new ActivatePaymentNoticeReq());
 
         PaymentRequestInfo paymentRequestInfo = new PaymentRequestInfo(
                 rptId,
@@ -351,7 +360,7 @@ class NodoOperationsTest {
                 .thenReturn(Mono.just(attivaRPTRisposta));
         Mockito.when(objectFactoryNodoPerPsp.createNodoAttivaRPT(Mockito.any()))
                 .thenReturn(objectFactoryUtilNodoPerPsp.createNodoAttivaRPT(nodoAttivaRPT));
-
+        Mockito.when(nodoConfig.baseNodoAttivaRPTRequest()).thenReturn(new NodoAttivaRPT());
         PaymentRequestInfo paymentRequestInfo = new PaymentRequestInfo(
                 rptId,
                 paTaxCode,
@@ -442,6 +451,7 @@ class NodoOperationsTest {
         Mockito.when(objectFactoryNodoPerPsp.createNodoAttivaRPT(Mockito.any()))
                 .thenReturn(objectFactoryUtilNodoPerPsp.createNodoAttivaRPT(nodoAttivaRPT));
         Mockito.when(nodoUtilities.getCodiceIdRpt(Mockito.any(RptId.class))).thenReturn(nodoTipoCodiceIdRPT);
+        Mockito.when(nodoConfig.baseNodoAttivaRPTRequest()).thenReturn(new NodoAttivaRPT());
 
         PaymentRequestInfo paymentRequestInfo = new PaymentRequestInfo(
                 rptId,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Removed Nodo base requests build as DI beans and class attribute
<!--- Describe your changes in detail -->

#### Motivation and Context
This fix is needed since having base request as clients classes attribute cause side-effect when multiple concurrent requests override requests values with the latest processed ones
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local test elaborating 5 payment notice concurrent processing requests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.