### PR TITLE
[CHK-918] (branch 914) transaction sul refactoring della libreria commons

### DIFF
--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -341,8 +341,6 @@ components:
               amount: 100
         status:
           $ref: "#/components/schemas/TransactionStatus"
-        amountTotal:
-          $ref: "#/components/schemas/AmountEuroCents"
         feeTotal:
           $ref: "#/components/schemas/AmountEuroCents"
         origin:

--- a/pom.xml
+++ b/pom.xml
@@ -515,8 +515,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-907-commons-refactoring</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.2.1</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.3.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
     </properties>
     <dependencies>
@@ -515,8 +515,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-907-commons-refactoring</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -51,7 +51,7 @@ public class PaymentGatewayClient {
                 .map(authorizationRequestData -> {
                     BigDecimal grandTotal = BigDecimal.valueOf(
                             ((long) authorizationData.transaction().getPaymentNotices().stream()
-                                    .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum())
+                                    .mapToInt(paymentNotice -> paymentNotice.transactionAmount().value()).sum())
                                     + authorizationData.fee()
                     );
                     // FIXME Handle all description together?
@@ -95,7 +95,7 @@ public class PaymentGatewayClient {
                     if (authorizationData.authDetails()instanceof CardAuthRequestDetailsDto cardData) {
                         BigDecimal grandTotal = BigDecimal.valueOf(
                                 ((long) authorizationData.transaction().getPaymentNotices().stream()
-                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum())
+                                        .mapToInt(paymentNotice -> paymentNotice.transactionAmount().value()).sum())
                                         + authorizationData.fee()
                         );
                         xPayAuthRequest = Mono.just(

--- a/src/main/java/it/pagopa/transactions/commands/TransactionActivateCommand.java
+++ b/src/main/java/it/pagopa/transactions/commands/TransactionActivateCommand.java
@@ -1,13 +1,38 @@
 package it.pagopa.transactions.commands;
 
+import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.domain.RptId;
 import it.pagopa.generated.transactions.server.model.NewTransactionRequestDto;
 
 public final class TransactionActivateCommand extends TransactionsCommand<NewTransactionRequestDto> {
+
+    private Transaction.OriginType originType;
+
     public TransactionActivateCommand(
             RptId rptId,
-            NewTransactionRequestDto data
+            NewTransactionRequestDto data,
+            Transaction.OriginType originType
     ) {
         super(rptId, TransactionsCommandCode.ACTIVATE, data);
+        this.originType = originType;
+    }
+
+    public TransactionActivateCommand(
+            RptId rptId,
+            NewTransactionRequestDto data,
+            String originType
+    ) {
+        this(
+                rptId,
+                data,
+                Transaction.OriginType.fromString(
+                        originType
+
+                )
+        );
+    }
+
+    public Transaction.OriginType getOriginType() {
+        return originType;
     }
 }

--- a/src/main/java/it/pagopa/transactions/commands/TransactionActivateCommand.java
+++ b/src/main/java/it/pagopa/transactions/commands/TransactionActivateCommand.java
@@ -3,7 +3,11 @@ package it.pagopa.transactions.commands;
 import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.domain.RptId;
 import it.pagopa.generated.transactions.server.model.NewTransactionRequestDto;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode(callSuper = true)
 public final class TransactionActivateCommand extends TransactionsCommand<NewTransactionRequestDto> {
 
     private Transaction.OriginType originType;
@@ -17,22 +21,4 @@ public final class TransactionActivateCommand extends TransactionsCommand<NewTra
         this.originType = originType;
     }
 
-    public TransactionActivateCommand(
-            RptId rptId,
-            NewTransactionRequestDto data,
-            String originType
-    ) {
-        this(
-                rptId,
-                data,
-                Transaction.OriginType.fromString(
-                        originType
-
-                )
-        );
-    }
-
-    public Transaction.OriginType getOriginType() {
-        return originType;
-    }
 }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -242,8 +242,8 @@ public class TransactionActivateHandler
         TransactionActivationRequestedData data = new TransactionActivationRequestedData();
         data.setEmail(email);
         PaymentRequestInfo paymentRequestInfo = paymentRequestsInfo.get(0);
-        List<NoticeCode> noticeCodes = List.of(
-                new NoticeCode(
+        List<PaymentNotice> PaymentNotices = List.of(
+                new PaymentNotice(
                         null,
                         paymentRequestInfo.id().value(),
                         paymentRequestInfo.description(),
@@ -251,10 +251,9 @@ public class TransactionActivateHandler
                         paymentContextCode
                 )
         );
-        data.setNoticeCodes(noticeCodes);
+        data.setPaymentNotices(PaymentNotices);
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 transactionId,
-                noticeCodes,
                 data
         );
 
@@ -273,17 +272,16 @@ public class TransactionActivateHandler
                                                                          String transactionId,
                                                                          String email
     ) {
-        List<NoticeCode> noticeCodes = toNoticeCodeList(paymentRequestsInfo);
+        List<PaymentNotice> PaymentNotices = toPaymentNoticeList(paymentRequestsInfo);
         TransactionActivatedData data = new TransactionActivatedData(
                 email,
-                noticeCodes,
+                PaymentNotices,
                 null,
                 null
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId,
-                noticeCodes,
                 data
         );
 
@@ -312,9 +310,9 @@ public class TransactionActivateHandler
                 );
     }
 
-    private List<NoticeCode> toNoticeCodeList(List<PaymentRequestInfo> paymentRequestsInfo) {
+    private List<PaymentNotice> toPaymentNoticeList(List<PaymentRequestInfo> paymentRequestsInfo) {
         return paymentRequestsInfo.stream().map(
-                paymentRequestInfo -> new NoticeCode(
+                paymentRequestInfo -> new PaymentNotice(
                         paymentRequestInfo.paymentToken(),
                         paymentRequestInfo.id().value(),
                         paymentRequestInfo.description(),

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -163,7 +163,8 @@ public class TransactionActivateHandler
                                                             newTransactionActivatedEvent(
                                                                     paymentRequestsInfo,
                                                                     sessionDataDto.getTransactionId(),
-                                                                    sessionDataDto.getEmail()
+                                                                    sessionDataDto.getEmail(),
+                                                                    command.getOriginType()
                                                             ),
                                                             Mono.empty(),
                                                             sessionDataDto
@@ -176,7 +177,8 @@ public class TransactionActivateHandler
                                                                     paymentRequestsInfo,
                                                                     sessionDataDto.getTransactionId(),
                                                                     sessionDataDto.getEmail(),
-                                                                    paymentContextCode
+                                                                    paymentContextCode,
+                                                                    command.getOriginType()
                                                             ),
                                                             sessionDataDto
                                                     )
@@ -237,10 +239,9 @@ public class TransactionActivateHandler
                                                                                              List<PaymentRequestInfo> paymentRequestsInfo,
                                                                                              String transactionId,
                                                                                              String email,
-                                                                                             String paymentContextCode
+                                                                                             String paymentContextCode,
+                                                                                             Transaction.OriginType origin
     ) {
-        TransactionActivationRequestedData data = new TransactionActivationRequestedData();
-        data.setEmail(email);
         PaymentRequestInfo paymentRequestInfo = paymentRequestsInfo.get(0);
         List<PaymentNotice> paymentNotices = List.of(
                 new PaymentNotice(
@@ -251,7 +252,13 @@ public class TransactionActivateHandler
                         paymentContextCode
                 )
         );
-        data.setPaymentNotices(paymentNotices);
+        TransactionActivationRequestedData data = new TransactionActivationRequestedData(
+                paymentNotices,
+                email,
+                null,
+                null,
+                origin
+        );
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 transactionId,
                 data
@@ -270,14 +277,16 @@ public class TransactionActivateHandler
     private Mono<TransactionActivatedEvent> newTransactionActivatedEvent(
                                                                          List<PaymentRequestInfo> paymentRequestsInfo,
                                                                          String transactionId,
-                                                                         String email
+                                                                         String email,
+                                                                         Transaction.OriginType origin
     ) {
         List<PaymentNotice> paymentNotices = toPaymentNoticeList(paymentRequestsInfo);
         TransactionActivatedData data = new TransactionActivatedData(
                 email,
                 paymentNotices,
                 null,
-                null
+                null,
+                origin
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -242,7 +242,7 @@ public class TransactionActivateHandler
         TransactionActivationRequestedData data = new TransactionActivationRequestedData();
         data.setEmail(email);
         PaymentRequestInfo paymentRequestInfo = paymentRequestsInfo.get(0);
-        List<PaymentNotice> PaymentNotices = List.of(
+        List<PaymentNotice> paymentNotices = List.of(
                 new PaymentNotice(
                         null,
                         paymentRequestInfo.id().value(),
@@ -251,7 +251,7 @@ public class TransactionActivateHandler
                         paymentContextCode
                 )
         );
-        data.setPaymentNotices(PaymentNotices);
+        data.setPaymentNotices(paymentNotices);
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 transactionId,
                 data
@@ -272,10 +272,10 @@ public class TransactionActivateHandler
                                                                          String transactionId,
                                                                          String email
     ) {
-        List<PaymentNotice> PaymentNotices = toPaymentNoticeList(paymentRequestsInfo);
+        List<PaymentNotice> paymentNotices = toPaymentNoticeList(paymentRequestsInfo);
         TransactionActivatedData data = new TransactionActivatedData(
                 email,
-                PaymentNotices,
+                paymentNotices,
                 null,
                 null
         );

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandler.java
@@ -2,7 +2,7 @@ package it.pagopa.transactions.commands.handlers;
 
 import com.azure.core.util.BinaryData;
 import com.azure.storage.queue.QueueAsyncClient;
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedData;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedEvent;
 import it.pagopa.ecommerce.commons.domain.TransactionActivationRequested;
@@ -129,14 +129,14 @@ public class TransactionActivateResultHandler
                         saved -> {
                             TransactionActivatedData data = new TransactionActivatedData(
                                     transactionActivationRequested.getEmail().value(),
-                                    transactionActivationRequested.getNoticeCodes().stream()
+                                    transactionActivationRequested.getPaymentNotices().stream()
                                             .map(
-                                                    noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
+                                                    PaymentNotice -> new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                                             saved.paymentToken(),
-                                                            noticeCode.rptId().value(),
-                                                            noticeCode.transactionDescription().value(),
-                                                            noticeCode.transactionAmount().value(),
-                                                            noticeCode.paymentContextCode().value()
+                                                            PaymentNotice.rptId().value(),
+                                                            PaymentNotice.transactionDescription().value(),
+                                                            PaymentNotice.transactionAmount().value(),
+                                                            PaymentNotice.paymentContextCode().value()
                                                     )
                                             )
                                             .toList(),
@@ -146,17 +146,6 @@ public class TransactionActivateResultHandler
 
                             TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                                     transactionId,
-                                    transactionActivationRequested.getNoticeCodes().stream()
-                                            .map(
-                                                    noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                                            saved.paymentToken(),
-                                                            noticeCode.rptId().value(),
-                                                            noticeCode.transactionDescription().value(),
-                                                            noticeCode.transactionAmount().value(),
-                                                            noticeCode.paymentContextCode().value()
-                                                    )
-                                            )
-                                            .toList(),
                                     data
                             );
 
@@ -176,8 +165,9 @@ public class TransactionActivateResultHandler
                                                     "Error to generate event TRANSACTION_ACTIVATED_EVENT for rptIds {} and transactionId {} - error {}",
                                                     String.join(
                                                             ",",
-                                                            transactionActivatedEvent.getNoticeCodes().stream()
-                                                                    .map(NoticeCode::getRptId).toList()
+                                                            transactionActivatedEvent.getData().getPaymentNotices()
+                                                                    .stream()
+                                                                    .map(PaymentNotice::getRptId).toList()
                                                     ),
                                                     transactionActivatedEvent.getTransactionId(),
                                                     exception.getMessage()
@@ -188,7 +178,8 @@ public class TransactionActivateResultHandler
                                                     "Generated event TRANSACTION_ACTIVATED_EVENT for rptIds {} and transactionId {}",
                                                     String.join(
                                                             ",",
-                                                            event.getNoticeCodes().stream().map(NoticeCode::getRptId)
+                                                            event.getData().getPaymentNotices().stream()
+                                                                    .map(PaymentNotice::getRptId)
                                                                     .toList()
                                                     ),
                                                     event.getTransactionId()

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandler.java
@@ -3,6 +3,7 @@ package it.pagopa.transactions.commands.handlers;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.queue.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.PaymentNotice;
+import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedData;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedEvent;
 import it.pagopa.ecommerce.commons.domain.TransactionActivationRequested;
@@ -50,9 +51,9 @@ public class TransactionActivateResultHandler
         final TransactionActivationRequested transactionActivationRequested = command.getData()
                 .transactionActivationRequested();
 
-        final String transactionId = command.getData().transactionActivationRequested().getTransactionId().value()
+        final String transactionId = transactionActivationRequested.getTransactionId().value()
                 .toString();
-
+        final Transaction.OriginType originType = transactionActivationRequested.getOriginType();
         return Mono.just(command)
                 .filter(
                         commandData -> commandData.getData().transactionActivationRequested()
@@ -147,7 +148,8 @@ public class TransactionActivateResultHandler
                                             )
                                             .toList(),
                                     null,
-                                    null
+                                    null,
+                                    originType
                             );
 
                             TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandler.java
@@ -131,12 +131,12 @@ public class TransactionActivateResultHandler
                                     transactionActivationRequested.getEmail().value(),
                                     transactionActivationRequested.getPaymentNotices().stream()
                                             .map(
-                                                    PaymentNotice -> new it.pagopa.ecommerce.commons.documents.PaymentNotice(
+                                                    paymentNotice -> new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                                             saved.paymentToken(),
-                                                            PaymentNotice.rptId().value(),
-                                                            PaymentNotice.transactionDescription().value(),
-                                                            PaymentNotice.transactionAmount().value(),
-                                                            PaymentNotice.paymentContextCode().value()
+                                                            paymentNotice.rptId().value(),
+                                                            paymentNotice.transactionDescription().value(),
+                                                            paymentNotice.transactionAmount().value(),
+                                                            paymentNotice.paymentContextCode().value()
                                                     )
                                             )
                                             .toList(),

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandler.java
@@ -1,7 +1,6 @@
 package it.pagopa.transactions.commands.handlers;
 
 import it.pagopa.ecommerce.commons.documents.*;
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.domain.Transaction;
 import it.pagopa.ecommerce.commons.domain.pojos.BaseTransaction;
@@ -56,7 +55,7 @@ public class TransactionAddUserReceiptHandler
                                 t.getStatus()
                         )
                 )
-                .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getNoticeCodes().get(0).rptId())));
+                .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getPaymentNotices().get(0).rptId())));
 
         return transaction
                 .cast(BaseTransaction.class)
@@ -79,15 +78,6 @@ public class TransactionAddUserReceiptHandler
 
                     TransactionUserReceiptAddedEvent event = new TransactionUserReceiptAddedEvent(
                             command.getData().transaction().getTransactionId().value().toString(),
-                            command.getData().transaction().getNoticeCodes().stream().map(
-                                    noticeCode -> new NoticeCode(
-                                            noticeCode.paymentToken().value(),
-                                            noticeCode.rptId().value(),
-                                            noticeCode.transactionDescription().value(),
-                                            noticeCode.transactionAmount().value(),
-                                            noticeCode.paymentContextCode().value()
-                                    )
-                            ).toList(),
                             transactionAddReceiptData
                     );
 
@@ -134,8 +124,11 @@ public class TransactionAddUserReceiptHandler
                                                 Locale.forLanguageTag(language)
                                         ),
                                         amountToHumanReadableString(
-                                                tx.getNoticeCodes().stream()
-                                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value())
+                                                tx.getPaymentNotices().stream()
+                                                        .mapToInt(
+                                                                PaymentNotice -> PaymentNotice.transactionAmount()
+                                                                        .value()
+                                                        )
                                                         .sum()
                                         )
                                 )
@@ -165,8 +158,11 @@ public class TransactionAddUserReceiptHandler
                                                 Locale.forLanguageTag(language)
                                         ),
                                         amountToHumanReadableString(
-                                                tx.getNoticeCodes().stream()
-                                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value())
+                                                tx.getPaymentNotices().stream()
+                                                        .mapToInt(
+                                                                PaymentNotice -> PaymentNotice.transactionAmount()
+                                                                        .value()
+                                                        )
                                                         .sum() + transactionAuthorizationRequestData.getFee()
                                         ),
                                         new PspTemplate(
@@ -191,27 +187,30 @@ public class TransactionAddUserReceiptHandler
                                         tx.getEmail().value()
                                 ),
                                 new CartTemplate(
-                                        tx.getNoticeCodes().stream().map(
-                                                noticeCode -> new ItemTemplate(
+                                        tx.getPaymentNotices().stream().map(
+                                                PaymentNotice -> new ItemTemplate(
                                                         new RefNumberTemplate(
                                                                 RefNumberTemplate.Type.CODICE_AVVISO,
-                                                                noticeCode.rptId().getNoticeId()
+                                                                PaymentNotice.rptId().getNoticeId()
                                                         ),
                                                         null,
                                                         new PayeeTemplate(
                                                                 addUserReceiptRequestDto.getPayments().get(0)
                                                                         .getOfficeName(),
-                                                                noticeCode.rptId().getFiscalCode()
+                                                                PaymentNotice.rptId().getFiscalCode()
                                                         ),
                                                         addUserReceiptRequestDto.getPayments().get(0).getDescription(),
                                                         amountToHumanReadableString(
-                                                                noticeCode.transactionAmount().value()
+                                                                PaymentNotice.transactionAmount().value()
                                                         )
                                                 )
                                         ).toList(),
                                         amountToHumanReadableString(
-                                                tx.getNoticeCodes().stream()
-                                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value())
+                                                tx.getPaymentNotices().stream()
+                                                        .mapToInt(
+                                                                PaymentNotice -> PaymentNotice.transactionAmount()
+                                                                        .value()
+                                                        )
                                                         .sum()
                                         )
                                 )

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandler.java
@@ -1,8 +1,12 @@
 package it.pagopa.transactions.commands.handlers;
 
-import it.pagopa.ecommerce.commons.documents.*;
-import it.pagopa.ecommerce.commons.domain.*;
+import it.pagopa.ecommerce.commons.documents.TransactionAddReceiptData;
+import it.pagopa.ecommerce.commons.documents.TransactionAuthorizationRequestData;
+import it.pagopa.ecommerce.commons.documents.TransactionEvent;
+import it.pagopa.ecommerce.commons.documents.TransactionUserReceiptAddedEvent;
+import it.pagopa.ecommerce.commons.domain.EmptyTransaction;
 import it.pagopa.ecommerce.commons.domain.Transaction;
+import it.pagopa.ecommerce.commons.domain.TransactionClosed;
 import it.pagopa.ecommerce.commons.domain.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.generated.notifications.templates.ko.KoTemplate;
@@ -126,7 +130,7 @@ public class TransactionAddUserReceiptHandler
                                         amountToHumanReadableString(
                                                 tx.getPaymentNotices().stream()
                                                         .mapToInt(
-                                                                PaymentNotice -> PaymentNotice.transactionAmount()
+                                                                paymentNotice -> paymentNotice.transactionAmount()
                                                                         .value()
                                                         )
                                                         .sum()
@@ -160,7 +164,7 @@ public class TransactionAddUserReceiptHandler
                                         amountToHumanReadableString(
                                                 tx.getPaymentNotices().stream()
                                                         .mapToInt(
-                                                                PaymentNotice -> PaymentNotice.transactionAmount()
+                                                                paymentNotice -> paymentNotice.transactionAmount()
                                                                         .value()
                                                         )
                                                         .sum() + transactionAuthorizationRequestData.getFee()
@@ -188,27 +192,27 @@ public class TransactionAddUserReceiptHandler
                                 ),
                                 new CartTemplate(
                                         tx.getPaymentNotices().stream().map(
-                                                PaymentNotice -> new ItemTemplate(
+                                                paymentNotice -> new ItemTemplate(
                                                         new RefNumberTemplate(
                                                                 RefNumberTemplate.Type.CODICE_AVVISO,
-                                                                PaymentNotice.rptId().getNoticeId()
+                                                                paymentNotice.rptId().getNoticeId()
                                                         ),
                                                         null,
                                                         new PayeeTemplate(
                                                                 addUserReceiptRequestDto.getPayments().get(0)
                                                                         .getOfficeName(),
-                                                                PaymentNotice.rptId().getFiscalCode()
+                                                                paymentNotice.rptId().getFiscalCode()
                                                         ),
                                                         addUserReceiptRequestDto.getPayments().get(0).getDescription(),
                                                         amountToHumanReadableString(
-                                                                PaymentNotice.transactionAmount().value()
+                                                                paymentNotice.transactionAmount().value()
                                                         )
                                                 )
                                         ).toList(),
                                         amountToHumanReadableString(
                                                 tx.getPaymentNotices().stream()
                                                         .mapToInt(
-                                                                PaymentNotice -> PaymentNotice.transactionAmount()
+                                                                paymentNotice -> paymentNotice.transactionAmount()
                                                                         .value()
                                                         )
                                                         .sum()

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandler.java
@@ -78,7 +78,7 @@ public class TransactionRequestAuthorizationHandler
                             String.join(
                                     ",",
                                     transaction.getPaymentNotices().stream()
-                                            .map(PaymentNotice -> PaymentNotice.rptId().value())
+                                            .map(paymentNotice -> paymentNotice.rptId().value())
                                             .toList()
                             )
                     );
@@ -86,7 +86,7 @@ public class TransactionRequestAuthorizationHandler
                             transaction.getTransactionId().value().toString(),
                             new TransactionAuthorizationRequestData(
                                     command.getData().transaction().getPaymentNotices().stream()
-                                            .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum(),
+                                            .mapToInt(paymentNotice -> paymentNotice.transactionAmount().value()).sum(),
                                     command.getData().fee(),
                                     command.getData().paymentInstrumentId(),
                                     command.getData().pspId(),

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -123,7 +123,7 @@ public class TransactionSendClosureHandler
                                     EuroUtils.euroCentsToEuro(
                                             tx.getPaymentNotices().stream()
                                                     .mapToInt(
-                                                            PaymentNotice -> PaymentNotice.transactionAmount().value()
+                                                            paymentNotice -> paymentNotice.transactionAmount().value()
                                                     )
                                                     .sum() + transactionAuthorizationRequestData.getFee()
                                     )

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
@@ -1,6 +1,5 @@
 package it.pagopa.transactions.commands.handlers;
 
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
 import it.pagopa.ecommerce.commons.documents.TransactionAuthorizationStatusUpdateData;
 import it.pagopa.ecommerce.commons.documents.TransactionAuthorizationStatusUpdatedEvent;
 import it.pagopa.ecommerce.commons.domain.TransactionActivated;
@@ -15,8 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-
-import java.util.Arrays;
 
 @Component
 @Slf4j
@@ -58,7 +55,6 @@ public class TransactionUpdateAuthorizationHandler implements
 
             TransactionAuthorizationStatusUpdatedEvent event = new TransactionAuthorizationStatusUpdatedEvent(
                     transaction.getTransactionId().value().toString(),
-                    transaction.getTransactionActivatedData().getNoticeCodes(),
                     statusUpdateData
             );
 

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -23,7 +23,7 @@ public class AuthorizationUpdateProjectionHandler
     public Mono<TransactionActivated> handle(TransactionAuthorizationStatusUpdatedEvent data) {
         return transactionsViewRepository.findById(data.getTransactionId())
                 .switchIfEmpty(
-                        Mono.error(new TransactionNotFoundException(data.getNoticeCodes().get(0).getPaymentToken()))
+                        Mono.error(new TransactionNotFoundException(data.getTransactionId()))
                 )
                 .flatMap(transactionDocument -> {
                     transactionDocument.setStatus(data.getData().getNewTransactionStatus());
@@ -32,14 +32,14 @@ public class AuthorizationUpdateProjectionHandler
                 .map(
                         transactionDocument -> new TransactionActivated(
                                 new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
-                                transactionDocument.getNoticeCodes().stream()
+                                transactionDocument.getPaymentNotices().stream()
                                         .map(
-                                                noticeCode -> new NoticeCode(
-                                                        new PaymentToken(noticeCode.getPaymentToken()),
-                                                        new RptId(noticeCode.getRptId()),
-                                                        new TransactionAmount(noticeCode.getAmount()),
-                                                        new TransactionDescription(noticeCode.getDescription()),
-                                                        new PaymentContextCode(noticeCode.getPaymentContextCode())
+                                                PaymentNotice -> new PaymentNotice(
+                                                        new PaymentToken(PaymentNotice.getPaymentToken()),
+                                                        new RptId(PaymentNotice.getRptId()),
+                                                        new TransactionAmount(PaymentNotice.getAmount()),
+                                                        new TransactionDescription(PaymentNotice.getDescription()),
+                                                        new PaymentContextCode(PaymentNotice.getPaymentContextCode())
                                                 )
                                         ).toList(),
                                 new Email(transactionDocument.getEmail()),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -34,12 +34,12 @@ public class AuthorizationUpdateProjectionHandler
                                 new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                                 transactionDocument.getPaymentNotices().stream()
                                         .map(
-                                                PaymentNotice -> new PaymentNotice(
-                                                        new PaymentToken(PaymentNotice.getPaymentToken()),
-                                                        new RptId(PaymentNotice.getRptId()),
-                                                        new TransactionAmount(PaymentNotice.getAmount()),
-                                                        new TransactionDescription(PaymentNotice.getDescription()),
-                                                        new PaymentContextCode(PaymentNotice.getPaymentContextCode())
+                                                paymentNotice -> new PaymentNotice(
+                                                        new PaymentToken(paymentNotice.getPaymentToken()),
+                                                        new RptId(paymentNotice.getRptId()),
+                                                        new TransactionAmount(paymentNotice.getAmount()),
+                                                        new TransactionDescription(paymentNotice.getDescription()),
+                                                        new PaymentContextCode(paymentNotice.getPaymentContextCode())
                                                 )
                                         ).toList(),
                                 new Email(transactionDocument.getEmail()),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -46,7 +46,8 @@ public class AuthorizationUpdateProjectionHandler
                                 null,
                                 null,
                                 ZonedDateTime.parse(transactionDocument.getCreationDate()),
-                                transactionDocument.getStatus()
+                                transactionDocument.getStatus(),
+                                transactionDocument.getOrigin()
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandler.java
@@ -21,7 +21,7 @@ public class ClosureErrorProjectionHandler
     public Mono<Transaction> handle(TransactionClosureErrorEvent event) {
         return transactionsViewRepository.findById(event.getTransactionId())
                 .switchIfEmpty(
-                        Mono.error(new TransactionNotFoundException(event.getNoticeCodes().get(0).getPaymentToken()))
+                        Mono.error(new TransactionNotFoundException(event.getTransactionId()))
                 )
                 .flatMap(transactionDocument -> {
                     transactionDocument.setStatus(TransactionStatusDto.CLOSURE_ERROR);

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandler.java
@@ -30,13 +30,13 @@ public class TransactionUserReceiptProjectionHandler
                 .map(
                         transactionDocument -> new TransactionActivated(
                                 new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
-                                transactionDocument.getNoticeCodes().stream().map(
-                                        noticeCode -> new NoticeCode(
-                                                new PaymentToken(noticeCode.getPaymentToken()),
-                                                new RptId(noticeCode.getRptId()),
-                                                new TransactionAmount(noticeCode.getAmount()),
-                                                new TransactionDescription(noticeCode.getDescription()),
-                                                new PaymentContextCode(noticeCode.getPaymentContextCode())
+                                transactionDocument.getPaymentNotices().stream().map(
+                                        PaymentNotice -> new PaymentNotice(
+                                                new PaymentToken(PaymentNotice.getPaymentToken()),
+                                                new RptId(PaymentNotice.getRptId()),
+                                                new TransactionAmount(PaymentNotice.getAmount()),
+                                                new TransactionDescription(PaymentNotice.getDescription()),
+                                                new PaymentContextCode(PaymentNotice.getPaymentContextCode())
                                         )
                                 ).toList(),
                                 new Email(transactionDocument.getEmail()),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandler.java
@@ -31,12 +31,12 @@ public class TransactionUserReceiptProjectionHandler
                         transactionDocument -> new TransactionActivated(
                                 new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                                 transactionDocument.getPaymentNotices().stream().map(
-                                        PaymentNotice -> new PaymentNotice(
-                                                new PaymentToken(PaymentNotice.getPaymentToken()),
-                                                new RptId(PaymentNotice.getRptId()),
-                                                new TransactionAmount(PaymentNotice.getAmount()),
-                                                new TransactionDescription(PaymentNotice.getDescription()),
-                                                new PaymentContextCode(PaymentNotice.getPaymentContextCode())
+                                        paymentNotice -> new PaymentNotice(
+                                                new PaymentToken(paymentNotice.getPaymentToken()),
+                                                new RptId(paymentNotice.getRptId()),
+                                                new TransactionAmount(paymentNotice.getAmount()),
+                                                new TransactionDescription(paymentNotice.getDescription()),
+                                                new PaymentContextCode(paymentNotice.getPaymentContextCode())
                                         )
                                 ).toList(),
                                 new Email(transactionDocument.getEmail()),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandler.java
@@ -43,7 +43,8 @@ public class TransactionUserReceiptProjectionHandler
                                 null,
                                 null,
                                 ZonedDateTime.parse(transactionDocument.getCreationDate()),
-                                transactionDocument.getStatus()
+                                transactionDocument.getStatus(),
+                                transactionDocument.getOrigin()
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.projections.handlers;
 
+import it.pagopa.ecommerce.commons.documents.Transaction.OriginType;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedData;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedEvent;
 import it.pagopa.ecommerce.commons.domain.*;
@@ -37,6 +38,7 @@ public class TransactionsActivationProjectionHandler
         Email email = new Email(event.getData().getEmail());
         String faultCode = event.getData().getFaultCode();
         String faultCodeString = event.getData().getFaultCodeString();
+        OriginType originType = event.getData().getOriginType();
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
@@ -44,7 +46,8 @@ public class TransactionsActivationProjectionHandler
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                originType
         );
 
         it.pagopa.ecommerce.commons.documents.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.Transaction

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
@@ -26,13 +26,13 @@ public class TransactionsActivationProjectionHandler
     public Mono<TransactionActivated> handle(TransactionActivatedEvent event) {
         TransactionActivatedData data = event.getData();
         TransactionId transactionId = new TransactionId(UUID.fromString(event.getTransactionId()));
-        List<NoticeCode> noticeCodeList = data.getNoticeCodes().stream().map(
-                noticeCodeData -> new NoticeCode(
-                        new PaymentToken(noticeCodeData.getPaymentToken()),
-                        new RptId(noticeCodeData.getRptId()),
-                        new TransactionAmount(noticeCodeData.getAmount()),
-                        new TransactionDescription(noticeCodeData.getDescription()),
-                        new PaymentContextCode(noticeCodeData.getPaymentContextCode())
+        List<PaymentNotice> PaymentNoticeList = data.getPaymentNotices().stream().map(
+                PaymentNoticeData -> new PaymentNotice(
+                        new PaymentToken(PaymentNoticeData.getPaymentToken()),
+                        new RptId(PaymentNoticeData.getRptId()),
+                        new TransactionAmount(PaymentNoticeData.getAmount()),
+                        new TransactionDescription(PaymentNoticeData.getDescription()),
+                        new PaymentContextCode(PaymentNoticeData.getPaymentContextCode())
                 )
         ).toList();
         Email email = new Email(event.getData().getEmail());
@@ -41,7 +41,7 @@ public class TransactionsActivationProjectionHandler
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
-                noticeCodeList,
+                PaymentNoticeList,
                 email,
                 faultCode,
                 faultCodeString,

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
@@ -12,7 +12,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -26,13 +25,13 @@ public class TransactionsActivationProjectionHandler
     public Mono<TransactionActivated> handle(TransactionActivatedEvent event) {
         TransactionActivatedData data = event.getData();
         TransactionId transactionId = new TransactionId(UUID.fromString(event.getTransactionId()));
-        List<PaymentNotice> PaymentNoticeList = data.getPaymentNotices().stream().map(
-                PaymentNoticeData -> new PaymentNotice(
-                        new PaymentToken(PaymentNoticeData.getPaymentToken()),
-                        new RptId(PaymentNoticeData.getRptId()),
-                        new TransactionAmount(PaymentNoticeData.getAmount()),
-                        new TransactionDescription(PaymentNoticeData.getDescription()),
-                        new PaymentContextCode(PaymentNoticeData.getPaymentContextCode())
+        List<PaymentNotice> paymentNoticeList = data.getPaymentNotices().stream().map(
+                paymentNoticeData -> new PaymentNotice(
+                        new PaymentToken(paymentNoticeData.getPaymentToken()),
+                        new RptId(paymentNoticeData.getRptId()),
+                        new TransactionAmount(paymentNoticeData.getAmount()),
+                        new TransactionDescription(paymentNoticeData.getDescription()),
+                        new PaymentContextCode(paymentNoticeData.getPaymentContextCode())
                 )
         ).toList();
         Email email = new Email(event.getData().getEmail());
@@ -41,7 +40,7 @@ public class TransactionsActivationProjectionHandler
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
-                PaymentNoticeList,
+                paymentNoticeList,
                 email,
                 faultCode,
                 faultCodeString,

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationRequestedProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationRequestedProjectionHandler.java
@@ -28,14 +28,14 @@ public class TransactionsActivationRequestedProjectionHandler
         TransactionId transactionId = new TransactionId(
                 UUID.fromString(transactionActivationRequestedEvent.getTransactionId())
         );
-        List<PaymentNotice> PaymentNoticeList = transactionActivationRequestedEvent.getData().getPaymentNotices()
+        List<PaymentNotice> paymentNoticeList = transactionActivationRequestedEvent.getData().getPaymentNotices()
                 .stream()
                 .map(
-                        PaymentNotice -> new it.pagopa.ecommerce.commons.domain.PaymentNotice(
+                        paymentNotice -> new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 new PaymentToken(null),
-                                new RptId(PaymentNotice.getRptId()),
-                                new TransactionAmount(PaymentNotice.getAmount()),
-                                new TransactionDescription(PaymentNotice.getDescription()),
+                                new RptId(paymentNotice.getRptId()),
+                                new TransactionAmount(paymentNotice.getAmount()),
+                                new TransactionDescription(paymentNotice.getDescription()),
                                 new PaymentContextCode(null)
                         )
                 ).toList();
@@ -43,7 +43,7 @@ public class TransactionsActivationRequestedProjectionHandler
 
         TransactionActivationRequested transaction = new TransactionActivationRequested(
                 transactionId,
-                PaymentNoticeList,
+                paymentNoticeList,
                 email,
                 TransactionStatusDto.ACTIVATION_REQUESTED
         );

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationRequestedProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationRequestedProjectionHandler.java
@@ -28,13 +28,14 @@ public class TransactionsActivationRequestedProjectionHandler
         TransactionId transactionId = new TransactionId(
                 UUID.fromString(transactionActivationRequestedEvent.getTransactionId())
         );
-        List<NoticeCode> noticeCodeList = transactionActivationRequestedEvent.getNoticeCodes().stream()
+        List<PaymentNotice> PaymentNoticeList = transactionActivationRequestedEvent.getData().getPaymentNotices()
+                .stream()
                 .map(
-                        noticeCode -> new NoticeCode(
+                        PaymentNotice -> new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 new PaymentToken(null),
-                                new RptId(noticeCode.getRptId()),
-                                new TransactionAmount(noticeCode.getAmount()),
-                                new TransactionDescription(noticeCode.getDescription()),
+                                new RptId(PaymentNotice.getRptId()),
+                                new TransactionAmount(PaymentNotice.getAmount()),
+                                new TransactionDescription(PaymentNotice.getDescription()),
                                 new PaymentContextCode(null)
                         )
                 ).toList();
@@ -42,7 +43,7 @@ public class TransactionsActivationRequestedProjectionHandler
 
         TransactionActivationRequested transaction = new TransactionActivationRequested(
                 transactionId,
-                noticeCodeList,
+                PaymentNoticeList,
                 email,
                 TransactionStatusDto.ACTIVATION_REQUESTED
         );
@@ -57,8 +58,8 @@ public class TransactionsActivationRequestedProjectionHandler
                                 "Transactions update view for rptId: {}",
                                 String.join(
                                         ",",
-                                        event.getNoticeCodes().stream()
-                                                .map(it.pagopa.ecommerce.commons.documents.NoticeCode::getRptId)
+                                        event.getPaymentNotices().stream()
+                                                .map(it.pagopa.ecommerce.commons.documents.PaymentNotice::getRptId)
                                                 .toList()
                                 )
                         )

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationRequestedProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationRequestedProjectionHandler.java
@@ -45,7 +45,8 @@ public class TransactionsActivationRequestedProjectionHandler
                 transactionId,
                 paymentNoticeList,
                 email,
-                TransactionStatusDto.ACTIVATION_REQUESTED
+                TransactionStatusDto.ACTIVATION_REQUESTED,
+                transactionActivationRequestedEvent.getData().getOriginType()
         );
 
         it.pagopa.ecommerce.commons.documents.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.Transaction

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -133,11 +133,11 @@ public class TransactionsService {
                                 .transactionId(transaction.getTransactionId())
                                 .payments(
                                         transaction.getPaymentNotices().stream().map(
-                                                PaymentNotice -> new PaymentInfoDto()
-                                                        .amount(PaymentNotice.getAmount())
-                                                        .reason(PaymentNotice.getDescription())
-                                                        .paymentToken(PaymentNotice.getPaymentToken())
-                                                        .rptId(PaymentNotice.getRptId())
+                                                paymentNotice -> new PaymentInfoDto()
+                                                        .amount(paymentNotice.getAmount())
+                                                        .reason(paymentNotice.getDescription())
+                                                        .paymentToken(paymentNotice.getPaymentToken())
+                                                        .rptId(paymentNotice.getRptId())
                                         ).toList()
                                 )
                                 .feeTotal(transaction.getFeeTotal())
@@ -240,13 +240,13 @@ public class TransactionsService {
                                     new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                                     transactionDocument.getPaymentNotices().stream()
                                             .map(
-                                                    PaymentNotice -> new PaymentNotice(
-                                                            new PaymentToken(PaymentNotice.getPaymentToken()),
-                                                            new RptId(PaymentNotice.getRptId()),
-                                                            new TransactionAmount(PaymentNotice.getAmount()),
-                                                            new TransactionDescription(PaymentNotice.getDescription()),
+                                                    paymentNotice -> new PaymentNotice(
+                                                            new PaymentToken(paymentNotice.getPaymentToken()),
+                                                            new RptId(paymentNotice.getRptId()),
+                                                            new TransactionAmount(paymentNotice.getAmount()),
+                                                            new TransactionDescription(paymentNotice.getDescription()),
                                                             new PaymentContextCode(
-                                                                    PaymentNotice.getPaymentContextCode()
+                                                                    paymentNotice.getPaymentContextCode()
                                                             )
                                                     )
                                             ).toList(),
@@ -307,13 +307,13 @@ public class TransactionsService {
                                     new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                                     transactionDocument.getPaymentNotices().stream()
                                             .map(
-                                                    PaymentNotice -> new PaymentNotice(
-                                                            new PaymentToken(PaymentNotice.getPaymentToken()),
-                                                            new RptId(PaymentNotice.getRptId()),
-                                                            new TransactionAmount(PaymentNotice.getAmount()),
-                                                            new TransactionDescription(PaymentNotice.getDescription()),
+                                                    paymentNotice -> new PaymentNotice(
+                                                            new PaymentToken(paymentNotice.getPaymentToken()),
+                                                            new RptId(paymentNotice.getRptId()),
+                                                            new TransactionAmount(paymentNotice.getAmount()),
+                                                            new TransactionDescription(paymentNotice.getDescription()),
                                                             new PaymentContextCode(
-                                                                    PaymentNotice.getPaymentContextCode()
+                                                                    paymentNotice.getPaymentContextCode()
                                                             )
                                                     )
                                             ).toList(),
@@ -386,13 +386,13 @@ public class TransactionsService {
                                                     .transactionId(transactionDocument.getTransactionId())
                                                     .payments(
                                                             transactionDocument.getPaymentNotices().stream().map(
-                                                                    PaymentNotice -> new PaymentInfoDto()
-                                                                            .amount(PaymentNotice.getAmount())
-                                                                            .reason(PaymentNotice.getDescription())
+                                                                    paymentNotice -> new PaymentInfoDto()
+                                                                            .amount(paymentNotice.getAmount())
+                                                                            .reason(paymentNotice.getDescription())
                                                                             .paymentToken(
-                                                                                    PaymentNotice.getPaymentToken()
+                                                                                    paymentNotice.getPaymentToken()
                                                                             )
-                                                                            .rptId(PaymentNotice.getRptId())
+                                                                            .rptId(paymentNotice.getRptId())
                                                             ).toList()
                                                     )
                                                     .status(
@@ -420,13 +420,13 @@ public class TransactionsService {
                                     new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                                     transactionDocument.getPaymentNotices().stream()
                                             .map(
-                                                    PaymentNotice -> new PaymentNotice(
-                                                            new PaymentToken(PaymentNotice.getPaymentToken()),
-                                                            new RptId(PaymentNotice.getRptId()),
-                                                            new TransactionAmount(PaymentNotice.getAmount()),
-                                                            new TransactionDescription(PaymentNotice.getDescription()),
+                                                    paymentNotice -> new PaymentNotice(
+                                                            new PaymentToken(paymentNotice.getPaymentToken()),
+                                                            new RptId(paymentNotice.getRptId()),
+                                                            new TransactionAmount(paymentNotice.getAmount()),
+                                                            new TransactionDescription(paymentNotice.getDescription()),
                                                             new PaymentContextCode(
-                                                                    PaymentNotice.getPaymentContextCode()
+                                                                    paymentNotice.getPaymentContextCode()
                                                             )
                                                     )
                                             )
@@ -468,23 +468,23 @@ public class TransactionsService {
                                 .transactionId(transaction.getTransactionId().value().toString())
                                 .payments(
                                         transaction.getPaymentNotices().stream().map(
-                                                PaymentNotice -> new PaymentInfoDto()
+                                                paymentNotice -> new PaymentInfoDto()
                                                         .amount(
                                                                 transaction.getTransactionActivatedData()
                                                                         .getPaymentNotices().stream()
                                                                         .filter(
-                                                                                PaymentNoticeData -> PaymentNoticeData
+                                                                                paymentNoticeData -> paymentNoticeData
                                                                                         .getRptId().equals(
-                                                                                                PaymentNotice.rptId()
+                                                                                                paymentNotice.rptId()
                                                                                                         .value()
                                                                                         )
                                                                         )
                                                                         .findFirst().get()
                                                                         .getAmount()
                                                         )
-                                                        .reason(PaymentNotice.transactionDescription().value())
-                                                        .paymentToken(PaymentNotice.paymentToken().value())
-                                                        .rptId(PaymentNotice.rptId().value())
+                                                        .reason(paymentNotice.transactionDescription().value())
+                                                        .paymentToken(paymentNotice.paymentToken().value())
+                                                        .rptId(paymentNotice.rptId().value())
                                         ).toList()
                                 )
                                 .status(TransactionStatusDto.fromValue(transaction.getStatus().toString()))
@@ -518,11 +518,11 @@ public class TransactionsService {
                                 .transactionId(transaction.getTransactionId().value().toString())
                                 .payments(
                                         transaction.getPaymentNotices().stream().map(
-                                                PaymentNotice -> new PaymentInfoDto()
-                                                        .amount(PaymentNotice.transactionAmount().value())
-                                                        .reason(PaymentNotice.transactionDescription().value())
-                                                        .rptId(PaymentNotice.rptId().value())
-                                                        .paymentToken(PaymentNotice.paymentToken().value())
+                                                paymentNotice -> new PaymentInfoDto()
+                                                        .amount(paymentNotice.transactionAmount().value())
+                                                        .reason(paymentNotice.transactionDescription().value())
+                                                        .rptId(paymentNotice.rptId().value())
+                                                        .paymentToken(paymentNotice.paymentToken().value())
                                         ).toList()
                                 )
                                 .authToken(sessionDataDto.getSessionToken())
@@ -543,11 +543,11 @@ public class TransactionsService {
                                 .transactionId(transaction.getTransactionId().value().toString())
                                 .payments(
                                         transaction.getPaymentNotices().stream().map(
-                                                PaymentNotice -> new PaymentInfoDto()
-                                                        .amount(PaymentNotice.transactionAmount().value())
-                                                        .reason(PaymentNotice.transactionDescription().value())
-                                                        .rptId(PaymentNotice.rptId().value())
-                                                        .paymentToken(PaymentNotice.paymentToken().value())
+                                                paymentNotice -> new PaymentInfoDto()
+                                                        .amount(paymentNotice.transactionAmount().value())
+                                                        .reason(paymentNotice.transactionDescription().value())
+                                                        .rptId(paymentNotice.rptId().value())
+                                                        .paymentToken(paymentNotice.paymentToken().value())
                                         ).toList()
                                 )
                                 .authToken(sessionDataDto.getSessionToken())

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -89,7 +89,7 @@ public class TransactionsService {
         TransactionActivateCommand command = new TransactionActivateCommand(
                 new RptId(newTransactionRequestDto.getPaymentNotices().get(0).getRptId()),
                 newTransactionRequestDto,
-                //TODO cambiare con l'origin letta dall'header della richiesta
+                // TODO cambiare con l'origin letta dall'header della richiesta
                 it.pagopa.ecommerce.commons.documents.Transaction.OriginType.fromString("UNKNOWN")
         );
 
@@ -531,9 +531,14 @@ public class TransactionsService {
                                 .authToken(sessionDataDto.getSessionToken())
                                 .status(TransactionStatusDto.fromValue(transaction.getStatus().toString()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .origin(Optional.ofNullable(transaction.getOriginType())
-                                        .map(origin -> NewTransactionResponseDto.OriginEnum.fromValue(origin.toString()))
-                                        .orElse(NewTransactionResponseDto.OriginEnum.UNKNOWN))
+                                .origin(
+                                        Optional.ofNullable(transaction.getOriginType())
+                                                .map(
+                                                        origin -> NewTransactionResponseDto.OriginEnum
+                                                                .fromValue(origin.toString())
+                                                )
+                                                .orElse(NewTransactionResponseDto.OriginEnum.UNKNOWN)
+                                )
                 );
     }
 
@@ -558,9 +563,14 @@ public class TransactionsService {
                                 .authToken(sessionDataDto.getSessionToken())
                                 .status(TransactionStatusDto.fromValue(transaction.getStatus().toString()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .origin(Optional.ofNullable(transaction.getOriginType())
-                                        .map(origin -> NewTransactionResponseDto.OriginEnum.fromValue(origin.toString()))
-                                        .orElse(NewTransactionResponseDto.OriginEnum.UNKNOWN))
+                                .origin(
+                                        Optional.ofNullable(transaction.getOriginType())
+                                                .map(
+                                                        origin -> NewTransactionResponseDto.OriginEnum
+                                                                .fromValue(origin.toString())
+                                                )
+                                                .orElse(NewTransactionResponseDto.OriginEnum.UNKNOWN)
+                                )
                 );
     }
 }

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -168,7 +168,7 @@ public class TransactionsService {
                                     "Authorization request amount validation for transactionId: {}",
                                     transactionId
                             );
-                            return amountTotal.equals(requestAuthorizationRequestDto.getAmount())
+                            return !amountTotal.equals(requestAuthorizationRequestDto.getAmount())
                                     ? Mono.empty()
                                     : Mono.just(transaction);
                         }

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -168,7 +168,7 @@ public class TransactionsService {
                                     "Authorization request amount validation for transactionId: {}",
                                     transactionId
                             );
-                            return amountTotal != requestAuthorizationRequestDto.getAmount()
+                            return amountTotal.equals(requestAuthorizationRequestDto.getAmount())
                                     ? Mono.empty()
                                     : Mono.just(transaction);
                         }

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -31,9 +31,6 @@ import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +71,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -119,7 +117,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -194,7 +193,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -263,7 +263,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .detailType("card")
@@ -287,7 +288,7 @@ class PaymentGatewayClientTest {
         XPayAuthRequestDto xPayAuthRequestDto = new XPayAuthRequestDto()
                 .cvv(cardDetails.getCvv())
                 .pan(cardDetails.getPan())
-                .exipiryDate(cardDetails.getExpiryDate().format(DateTimeFormatter.ofPattern("yyyyMM")))
+                .exipiryDate(cardDetails.getExpiryDate())
                 .idTransaction(transactionIdUUID.toString())
                 .grandTotal(
                         BigDecimal.valueOf(
@@ -349,7 +350,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -400,8 +402,8 @@ class PaymentGatewayClientTest {
         StepVerifier.create(client.requestPostepayAuthorization(authorizationData))
                 .expectErrorMatches(
                         error -> error instanceof AlreadyProcessedException &&
-                                ((AlreadyProcessedException) error).getRptId()
-                                        .equals(transaction.getPaymentNotices().get(0).rptId())
+                                ((AlreadyProcessedException) error).getTransactionId()
+                                        .equals(transaction.getTransactionId())
                 )
                 .verify();
 
@@ -429,7 +431,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 "faultCode",
                 "faultCodeString",
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -507,7 +510,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -583,7 +587,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto().cvv("345").pan("16589654852")
                 .expiryDate("203012");
@@ -661,7 +666,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -732,7 +738,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto().cvv("345").pan("16589654852")
                 .expiryDate("203012");
@@ -805,7 +812,8 @@ class PaymentGatewayClientTest {
                 new Email("foo@example.com"),
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -63,7 +63,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -108,7 +108,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -148,8 +148,8 @@ class PaymentGatewayClientTest {
                 .idTransaction(transactionIdUUID.toString())
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 );
@@ -183,7 +183,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -214,12 +214,12 @@ class PaymentGatewayClientTest {
         PostePayAuthRequestDto postePayAuthRequest = new PostePayAuthRequestDto()
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 )
-                .description(transaction.getNoticeCodes().get(0).transactionDescription().value())
+                .description(transaction.getPaymentNotices().get(0).transactionDescription().value())
                 .paymentChannel(authorizationData.pspChannelCode())
                 .idTransaction(transactionIdUUID.toString());
 
@@ -252,7 +252,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -291,8 +291,8 @@ class PaymentGatewayClientTest {
                 .idTransaction(transactionIdUUID.toString())
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 );
@@ -325,7 +325,7 @@ class PaymentGatewayClientTest {
                 .expectErrorMatches(
                         error -> error instanceof AlreadyProcessedException &&
                                 ((AlreadyProcessedException) error).getRptId()
-                                        .equals(transaction.getNoticeCodes().get(0).rptId())
+                                        .equals(transaction.getPaymentNotices().get(0).rptId())
                 )
                 .verify();
 
@@ -338,7 +338,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -369,12 +369,12 @@ class PaymentGatewayClientTest {
         PostePayAuthRequestDto postePayAuthRequest = new PostePayAuthRequestDto()
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 )
-                .description(transaction.getNoticeCodes().get(0).transactionDescription().value())
+                .description(transaction.getPaymentNotices().get(0).transactionDescription().value())
                 .paymentChannel(authorizationData.pspChannelCode())
                 .idTransaction(transactionIdUUID.toString());
 
@@ -401,7 +401,7 @@ class PaymentGatewayClientTest {
                 .expectErrorMatches(
                         error -> error instanceof AlreadyProcessedException &&
                                 ((AlreadyProcessedException) error).getRptId()
-                                        .equals(transaction.getNoticeCodes().get(0).rptId())
+                                        .equals(transaction.getPaymentNotices().get(0).rptId())
                 )
                 .verify();
 
@@ -418,7 +418,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -449,12 +449,12 @@ class PaymentGatewayClientTest {
         PostePayAuthRequestDto postePayAuthRequest = new PostePayAuthRequestDto()
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 )
-                .description(transaction.getNoticeCodes().get(0).transactionDescription().value())
+                .description(transaction.getPaymentNotices().get(0).transactionDescription().value())
                 .paymentChannel(authorizationData.pspChannelCode())
                 .idTransaction(transactionIdUUID.toString());
 
@@ -496,7 +496,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -527,12 +527,12 @@ class PaymentGatewayClientTest {
         PostePayAuthRequestDto postePayAuthRequest = new PostePayAuthRequestDto()
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 )
-                .description(transaction.getNoticeCodes().get(0).transactionDescription().value())
+                .description(transaction.getPaymentNotices().get(0).transactionDescription().value())
                 .paymentChannel(authorizationData.pspChannelCode())
                 .idTransaction(transactionIdUUID.toString());
 
@@ -572,7 +572,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -608,8 +608,8 @@ class PaymentGatewayClientTest {
                 .idTransaction(transactionIdUUID.toString())
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 );
@@ -650,7 +650,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -681,12 +681,12 @@ class PaymentGatewayClientTest {
         PostePayAuthRequestDto postePayAuthRequest = new PostePayAuthRequestDto()
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 )
-                .description(transaction.getNoticeCodes().get(0).transactionDescription().value())
+                .description(transaction.getPaymentNotices().get(0).transactionDescription().value())
                 .paymentChannel(authorizationData.pspChannelCode())
                 .idTransaction(transactionIdUUID.toString());
 
@@ -721,7 +721,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -757,8 +757,8 @@ class PaymentGatewayClientTest {
                 .idTransaction(transactionIdUUID.toString())
                 .grandTotal(
                         BigDecimal.valueOf(
-                                transaction.getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                transaction.getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationData.fee()
                         )
                 );
@@ -794,7 +794,7 @@ class PaymentGatewayClientTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(transactionIdUUID),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandlerTest.java
@@ -76,7 +76,7 @@ class TransactionActivateResultHandlerTest {
         TransactionActivationRequested transaction = new TransactionActivationRequested(
                 new TransactionId(UUID.fromString(transactionId)),
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 null,
                                 rptId,
                                 new TransactionAmount(amount),
@@ -134,7 +134,7 @@ class TransactionActivateResultHandlerTest {
         TransactionActivationRequested transaction = new TransactionActivationRequested(
                 new TransactionId(UUID.fromString(transactionId)),
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 null,
                                 rptId,
                                 new TransactionAmount(amount),
@@ -152,25 +152,16 @@ class TransactionActivateResultHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 command.getData().transactionActivationRequested().getTransactionId().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken,
-                                rptId.value(),
-                                null,
-                                null,
-                                null
-                        )
-                ),
                 new TransactionActivatedData(
                         null,
-                        transaction.getNoticeCodes().stream()
+                        transaction.getPaymentNotices().stream()
                                 .map(
-                                        noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
+                                        PaymentNotice -> new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                                 paymentToken,
-                                                noticeCode.rptId().value(),
-                                                noticeCode.transactionDescription().value(),
-                                                noticeCode.transactionAmount().value(),
-                                                noticeCode.paymentContextCode().value()
+                                                PaymentNotice.rptId().value(),
+                                                PaymentNotice.transactionDescription().value(),
+                                                PaymentNotice.transactionAmount().value(),
+                                                PaymentNotice.paymentContextCode().value()
                                         )
                                 ).toList(),
                         null,
@@ -252,7 +243,7 @@ class TransactionActivateResultHandlerTest {
         TransactionActivationRequested transactionActivationRequested = new TransactionActivationRequested(
                 new TransactionId(UUID.fromString(transactionId)),
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 null,
                                 rptId,
                                 new TransactionAmount(amount),
@@ -310,7 +301,7 @@ class TransactionActivateResultHandlerTest {
         TransactionActivationRequested transactionActivationRequested = new TransactionActivationRequested(
                 new TransactionId(UUID.fromString(transactionId)),
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 null,
                                 rptId,
                                 new TransactionAmount(amount),

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionActivateResultHandlerTest.java
@@ -18,7 +18,6 @@ import it.pagopa.transactions.commands.data.ActivationResultData;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
-import org.aspectj.weaver.ast.Not;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -85,7 +84,8 @@ class TransactionActivateResultHandlerTest {
                         )
                 ),
                 new Email(requestDto.getEmail()),
-                TransactionStatusDto.ACTIVATION_REQUESTED
+                TransactionStatusDto.ACTIVATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         ActivationResultData activationResultData = new ActivationResultData(transaction, activationResultRequestDto);
@@ -143,7 +143,8 @@ class TransactionActivateResultHandlerTest {
                         )
                 ),
                 new Email(requestDto.getEmail()),
-                TransactionStatusDto.ACTIVATION_REQUESTED
+                TransactionStatusDto.ACTIVATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         ActivationResultData activationResultData = new ActivationResultData(transaction, activationResultRequestDto);
@@ -165,7 +166,8 @@ class TransactionActivateResultHandlerTest {
                                         )
                                 ).toList(),
                         null,
-                        null
+                        null,
+                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -252,7 +254,8 @@ class TransactionActivateResultHandlerTest {
                         )
                 ),
                 new Email(requestDto.getEmail()),
-                TransactionStatusDto.AUTHORIZED
+                TransactionStatusDto.AUTHORIZED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         ActivationResultData activationResultData = new ActivationResultData(
@@ -310,7 +313,8 @@ class TransactionActivateResultHandlerTest {
                         )
                 ),
                 new Email(requestDto.getEmail()),
-                TransactionStatusDto.ACTIVATION_REQUESTED
+                TransactionStatusDto.ACTIVATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         ActivationResultData activationResultData = new ActivationResultData(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandlerTest.java
@@ -1,7 +1,7 @@
 package it.pagopa.transactions.commands.handlers;
 
 import it.pagopa.ecommerce.commons.documents.*;
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -62,7 +62,7 @@ class TransactionAddUserReceiptHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -78,19 +78,10 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                null,
-                                null,
-                                null
-                        )
-                ),
                 new TransactionActivatedData(
                         email.value(),
                         Arrays.asList(
-                                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+                                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                         paymentToken.value(),
                                         rptId.value(),
                                         description.value(),
@@ -105,15 +96,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                description.value(),
-                                amount.value(),
-                                nullPaymentContextCode.value()
-                        )
-                ),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -130,15 +112,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                description.value(),
-                                amount.value(),
-                                nullPaymentContextCode.value()
-                        )
-                ),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -148,7 +121,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionClosureSentEvent closureSentEvent = new TransactionClosureSentEvent(
                 transactionId.toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionClosureSendData(
                         ClosePaymentResponseDto.OutcomeEnum.OK,
                         TransactionStatusDto.CLOSED
@@ -175,7 +147,7 @@ class TransactionAddUserReceiptHandlerTest {
         );
 
         TransactionAddUserReceiptCommand addUserReceiptCommand = new TransactionAddUserReceiptCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 addUserReceiptData
         );
 
@@ -185,7 +157,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionUserReceiptAddedEvent event = new TransactionUserReceiptAddedEvent(
                 transactionId.toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes(),
                 transactionAddReceiptData
         );
 
@@ -230,7 +201,7 @@ class TransactionAddUserReceiptHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -246,19 +217,10 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                description.value(),
-                                amount.value(),
-                                nullPaymentContextCode.value()
-                        )
-                ),
                 new TransactionActivatedData(
                         email.value(),
                         Arrays.asList(
-                                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+                                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                         paymentToken.value(),
                                         rptId.value(),
                                         description.value(),
@@ -273,7 +235,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -290,7 +251,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                authorizationRequestedEvent.getNoticeCodes(),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -300,7 +260,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionClosureSentEvent closureSentEvent = new TransactionClosureSentEvent(
                 transactionId.toString(),
-                authorizationStatusUpdatedEvent.getNoticeCodes(),
                 new TransactionClosureSendData(
                         ClosePaymentResponseDto.OutcomeEnum.OK,
                         TransactionStatusDto.CLOSED
@@ -327,7 +286,7 @@ class TransactionAddUserReceiptHandlerTest {
         );
 
         TransactionAddUserReceiptCommand transactionAddUserReceiptCommand = new TransactionAddUserReceiptCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 addUserReceiptData
         );
 
@@ -337,7 +296,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionUserReceiptAddedEvent event = new TransactionUserReceiptAddedEvent(
                 transactionId.toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes(),
                 transactionAddReceiptData
         );
 
@@ -382,7 +340,7 @@ class TransactionAddUserReceiptHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -398,19 +356,10 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                null,
-                                null,
-                                null
-                        )
-                ),
                 new TransactionActivatedData(
                         email.value(),
                         Arrays.asList(
-                                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+                                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                         paymentToken.value(),
                                         rptId.value(),
                                         description.value(),
@@ -425,15 +374,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                null,
-                                null,
-                                null
-                        )
-                ),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -450,15 +390,6 @@ class TransactionAddUserReceiptHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                paymentToken.value(),
-                                rptId.value(),
-                                null,
-                                null,
-                                null
-                        )
-                ),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -486,7 +417,7 @@ class TransactionAddUserReceiptHandlerTest {
         );
 
         TransactionAddUserReceiptCommand requestStatusCommand = new TransactionAddUserReceiptCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 addUserReceiptData
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionAddUserReceiptHandlerTest.java
@@ -1,7 +1,7 @@
 package it.pagopa.transactions.commands.handlers;
 
+import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.documents.*;
-import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -73,7 +73,8 @@ class TransactionAddUserReceiptHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.CLOSED
+                TransactionStatusDto.CLOSED,
+                Transaction.OriginType.UNKNOWN
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
@@ -90,7 +91,8 @@ class TransactionAddUserReceiptHandlerTest {
                                 )
                         ),
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -212,7 +214,8 @@ class TransactionAddUserReceiptHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.CLOSED
+                TransactionStatusDto.CLOSED,
+                Transaction.OriginType.UNKNOWN
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
@@ -229,7 +232,8 @@ class TransactionAddUserReceiptHandlerTest {
                                 )
                         ),
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -351,7 +355,8 @@ class TransactionAddUserReceiptHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                Transaction.OriginType.UNKNOWN
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
@@ -368,7 +373,8 @@ class TransactionAddUserReceiptHandlerTest {
                                 )
                         ),
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        Transaction.OriginType.UNKNOWN
                 )
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -6,10 +6,7 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.queue.QueueAsyncClient;
 import com.azure.storage.queue.models.SendMessageResult;
-import it.pagopa.ecommerce.commons.documents.TransactionActivatedData;
-import it.pagopa.ecommerce.commons.documents.TransactionActivatedEvent;
-import it.pagopa.ecommerce.commons.documents.TransactionActivationRequestedData;
-import it.pagopa.ecommerce.commons.documents.TransactionActivationRequestedEvent;
+import it.pagopa.ecommerce.commons.documents.*;
 import it.pagopa.ecommerce.commons.domain.IdempotencyKey;
 import it.pagopa.ecommerce.commons.domain.RptId;
 import it.pagopa.ecommerce.commons.domain.TransactionEventCode;
@@ -87,7 +84,11 @@ class TransactionInitializerHandlerTest {
         requestDto.setEmail("jhon.doe@email.com");
         paymentNoticeInfoDto.setAmount(1200);
         paymentNoticeInfoDto.setPaymentContextCode(UUID.randomUUID().toString().replace("-", ""));
-        TransactionActivateCommand command = new TransactionActivateCommand(rptId, requestDto);
+        TransactionActivateCommand command = new TransactionActivateCommand(
+                rptId,
+                requestDto,
+                Transaction.OriginType.UNKNOWN
+        );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
                 rptId,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -111,9 +111,10 @@ class TransactionInitializerHandlerTest {
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent();
         transactionActivatedEvent.setTransactionId(transactionId);
         transactionActivatedEvent.setEventCode(TransactionEventCode.TRANSACTION_ACTIVATED_EVENT);
-        transactionActivatedEvent.setNoticeCodes(
+        TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
+        transactionActivatedData.setPaymentNotices(
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
+                        new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                                 paymentToken,
                                 rptId.value(),
                                 null,
@@ -122,6 +123,7 @@ class TransactionInitializerHandlerTest {
                         )
                 )
         );
+        transactionActivatedEvent.setData(transactionActivatedData);
 
         /** preconditions */
         Mockito.when(paymentRequestInfoRepository.findById(rptId))

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
@@ -9,7 +9,6 @@ import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.generated.ecommerce.gateway.v1.dto.PostePayAuthResponseEntityDto;
 import it.pagopa.generated.transactions.server.model.PostePayAuthRequestDetailsDto;
 import it.pagopa.generated.transactions.server.model.RequestAuthorizationRequestDto;
-import it.pagopa.transactions.client.EcommerceSessionsClient;
 import it.pagopa.transactions.client.PaymentGatewayClient;
 import it.pagopa.transactions.commands.TransactionRequestAuthorizationCommand;
 import it.pagopa.transactions.commands.data.AuthorizationRequestData;
@@ -25,9 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -67,7 +64,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 null,
                 null,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -133,7 +131,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.AUTHORIZATION_REQUESTED
+                TransactionStatusDto.AUTHORIZATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -187,7 +186,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
@@ -63,7 +63,7 @@ class TransactionRequestAuthorizizationHandlerTest {
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
-                List.of(new NoticeCode(paymentToken, rptId, amount, description, nullPaymentContextCode)),
+                List.of(new PaymentNotice(paymentToken, rptId, amount, description, nullPaymentContextCode)),
                 email,
                 null,
                 null,
@@ -92,7 +92,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 authorizationData
         );
 
@@ -129,7 +129,7 @@ class TransactionRequestAuthorizizationHandlerTest {
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
-                List.of(new NoticeCode(paymentToken, rptId, amount, description, nullPaymentContextCode)),
+                List.of(new PaymentNotice(paymentToken, rptId, amount, description, nullPaymentContextCode)),
                 email,
                 faultCode,
                 faultCodeString,
@@ -158,7 +158,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 authorizationData
         );
 
@@ -183,7 +183,7 @@ class TransactionRequestAuthorizizationHandlerTest {
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
-                List.of(new NoticeCode(paymentToken, rptId, amount, description, nullPaymentContextCode)),
+                List.of(new PaymentNotice(paymentToken, rptId, amount, description, nullPaymentContextCode)),
                 email,
                 faultCode,
                 faultCodeString,
@@ -212,7 +212,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 authorizationData
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -8,7 +8,7 @@ import com.azure.storage.queue.QueueAsyncClient;
 import com.azure.storage.queue.models.SendMessageResult;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.*;
-import it.pagopa.ecommerce.commons.domain.NoticeCode;
+import it.pagopa.ecommerce.commons.domain.PaymentNotice;
 import it.pagopa.ecommerce.commons.domain.Transaction;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.domain.pojos.BaseTransactionWithPaymentToken;
@@ -81,8 +81,8 @@ class TransactionSendClosureHandlerTest {
         TransactionDescription description = new TransactionDescription("description");
         TransactionAmount amount = new TransactionAmount(100);
         Email email = new Email("foo@example.com");
-        List<it.pagopa.ecommerce.commons.documents.NoticeCode> noticeCodes = List.of(
-                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+        List<it.pagopa.ecommerce.commons.documents.PaymentNotice> PaymentNotices = List.of(
+                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                         paymentToken.value(),
                         rptId.value(),
                         description.value(),
@@ -95,13 +95,13 @@ class TransactionSendClosureHandlerTest {
         String faultCodeString = "faultCodeString";
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
-                noticeCodes.stream().map(
-                        noticeCode -> new NoticeCode(
-                                new PaymentToken(noticeCode.getPaymentToken()),
-                                new RptId(noticeCode.getRptId()),
-                                new TransactionAmount(noticeCode.getAmount()),
-                                new TransactionDescription(noticeCode.getDescription()),
-                                new PaymentContextCode(noticeCode.getPaymentContextCode())
+                PaymentNotices.stream().map(
+                        PaymentNotice -> new PaymentNotice(
+                                new PaymentToken(PaymentNotice.getPaymentToken()),
+                                new RptId(PaymentNotice.getRptId()),
+                                new TransactionAmount(PaymentNotice.getAmount()),
+                                new TransactionDescription(PaymentNotice.getDescription()),
+                                new PaymentContextCode(PaymentNotice.getPaymentContextCode())
                         )
                 )
                         .toList(),
@@ -122,16 +122,15 @@ class TransactionSendClosureHandlerTest {
         );
 
         TransactionClosureSendCommand closureSendCommand = new TransactionClosureSendCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 closureSendData
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes(),
                 new TransactionActivatedData(
                         email.value(),
-                        transaction.getTransactionActivatedData().getNoticeCodes(),
+                        transaction.getTransactionActivatedData().getPaymentNotices(),
                         faultCode,
                         faultCodeString
                 )
@@ -139,7 +138,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes(),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -156,7 +154,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes(),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -166,7 +163,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionClosureSentEvent closureSentEvent = new TransactionClosureSentEvent(
                 transactionId.value().toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes(),
                 new TransactionClosureSendData(
                         ClosePaymentResponseDto.OutcomeEnum.OK,
                         TransactionStatusDto.CLOSED
@@ -200,8 +196,8 @@ class TransactionSendClosureHandlerTest {
         Email email = new Email("foo@example.com");
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
-        List<it.pagopa.ecommerce.commons.documents.NoticeCode> noticeCodes = List.of(
-                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+        List<it.pagopa.ecommerce.commons.documents.PaymentNotice> PaymentNotices = List.of(
+                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                         paymentToken.value(),
                         rptId.value(),
                         description.value(),
@@ -212,10 +208,9 @@ class TransactionSendClosureHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                noticeCodes,
                 new TransactionActivatedData(
                         email.value(),
-                        noticeCodes,
+                        PaymentNotices,
                         faultCode,
                         faultCodeString
                 )
@@ -223,7 +218,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -240,7 +234,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -269,13 +262,12 @@ class TransactionSendClosureHandlerTest {
         );
 
         TransactionClosureSendCommand closureSendCommand = new TransactionClosureSendCommand(
-                new RptId(transactionActivatedEvent.getNoticeCodes().get(0).getRptId()),
+                new RptId(transactionActivatedEvent.getData().getPaymentNotices().get(0).getRptId()),
                 closureSendData
         );
 
         TransactionClosureSentEvent event = new TransactionClosureSentEvent(
                 transactionId.toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 transactionClosureSendData
         );
 
@@ -285,7 +277,7 @@ class TransactionSendClosureHandlerTest {
                 .paymentTokens(
                         List.of(
                                 ((BaseTransactionWithPaymentToken) transaction).getTransactionActivatedData()
-                                        .getNoticeCodes().get(0).getPaymentToken()
+                                        .getPaymentNotices().get(0).getPaymentToken()
                         )
                 )
                 .outcome(ClosePaymentRequestV2Dto.OutcomeEnum.OK)
@@ -295,8 +287,8 @@ class TransactionSendClosureHandlerTest {
                 .transactionId(((BaseTransactionWithPaymentToken) transaction).getTransactionId().value().toString())
                 .totalAmount(
                         EuroUtils.euroCentsToEuro(
-                                ((BaseTransactionWithPaymentToken) transaction).getNoticeCodes().stream()
-                                        .mapToInt(noticeCode -> noticeCode.transactionAmount().value()).sum()
+                                ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
+                                        .mapToInt(PaymentNotice -> PaymentNotice.transactionAmount().value()).sum()
                                         + authorizationRequestData.getFee()
                         )
                 )
@@ -342,8 +334,8 @@ class TransactionSendClosureHandlerTest {
         Email email = new Email("foo@example.com");
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
-        List<it.pagopa.ecommerce.commons.documents.NoticeCode> noticeCodes = List.of(
-                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+        List<it.pagopa.ecommerce.commons.documents.PaymentNotice> PaymentNotices = List.of(
+                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                         paymentToken.value(),
                         rptId.value(),
                         description.value(),
@@ -354,10 +346,9 @@ class TransactionSendClosureHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                noticeCodes,
                 new TransactionActivatedData(
                         email.value(),
-                        noticeCodes,
+                        PaymentNotices,
                         faultCode,
                         faultCodeString
                 )
@@ -365,7 +356,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -382,7 +372,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -410,13 +399,12 @@ class TransactionSendClosureHandlerTest {
         );
 
         TransactionClosureSendCommand closureSendCommand = new TransactionClosureSendCommand(
-                new RptId(transactionActivatedEvent.getNoticeCodes().get(0).getRptId()),
+                new RptId(transactionActivatedEvent.getData().getPaymentNotices().get(0).getRptId()),
                 closureSendData
         );
 
         TransactionClosureSentEvent event = new TransactionClosureSentEvent(
                 transactionId.toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 transactionClosureSendData
         );
 
@@ -424,8 +412,8 @@ class TransactionSendClosureHandlerTest {
 
         ClosePaymentRequestV2Dto closePaymentRequest = new ClosePaymentRequestV2Dto()
                 .paymentTokens(
-                        transactionActivatedEvent.getNoticeCodes().stream()
-                                .map(it.pagopa.ecommerce.commons.documents.NoticeCode::getPaymentToken).toList()
+                        transactionActivatedEvent.getData().getPaymentNotices().stream()
+                                .map(it.pagopa.ecommerce.commons.documents.PaymentNotice::getPaymentToken).toList()
                 )
                 .outcome(ClosePaymentRequestV2Dto.OutcomeEnum.OK)
                 .idPSP(authorizationRequestData.getPspId())
@@ -434,8 +422,8 @@ class TransactionSendClosureHandlerTest {
                 .transactionId(((BaseTransactionWithPaymentToken) transaction).getTransactionId().value().toString())
                 .totalAmount(
                         EuroUtils.euroCentsToEuro(
-                                (transactionActivatedEvent.getNoticeCodes().stream()
-                                        .mapToInt(it.pagopa.ecommerce.commons.documents.NoticeCode::getAmount).sum()
+                                (transactionActivatedEvent.getData().getPaymentNotices().stream()
+                                        .mapToInt(it.pagopa.ecommerce.commons.documents.PaymentNotice::getAmount).sum()
                                         + authorizationRequestData.getFee())
                         )
                 )
@@ -452,8 +440,7 @@ class TransactionSendClosureHandlerTest {
                 );
 
         TransactionClosureErrorEvent errorEvent = new TransactionClosureErrorEvent(
-                transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes()
+                transactionId.value().toString()
         );
 
         RuntimeException closePaymentError = new RuntimeException("Network error");
@@ -496,8 +483,8 @@ class TransactionSendClosureHandlerTest {
         Email email = new Email("foo@example.com");
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
-        List<it.pagopa.ecommerce.commons.documents.NoticeCode> noticeCodes = List.of(
-                new it.pagopa.ecommerce.commons.documents.NoticeCode(
+        List<it.pagopa.ecommerce.commons.documents.PaymentNotice> PaymentNotices = List.of(
+                new it.pagopa.ecommerce.commons.documents.PaymentNotice(
                         paymentToken.value(),
                         rptId.value(),
                         description.value(),
@@ -508,10 +495,9 @@ class TransactionSendClosureHandlerTest {
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 transactionId.value().toString(),
-                noticeCodes,
                 new TransactionActivatedData(
                         email.value(),
-                        noticeCodes,
+                        PaymentNotices,
                         faultCode,
                         faultCodeString
                 )
@@ -519,7 +505,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationRequestedEvent authorizationRequestedEvent = new TransactionAuthorizationRequestedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationRequestData(
                         amount.value(),
                         10,
@@ -536,7 +521,6 @@ class TransactionSendClosureHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent authorizationStatusUpdatedEvent = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes(),
                 new TransactionAuthorizationStatusUpdateData(
                         AuthorizationResultDto.OK,
                         TransactionStatusDto.AUTHORIZED,
@@ -564,7 +548,7 @@ class TransactionSendClosureHandlerTest {
         );
 
         TransactionClosureSendCommand closureSendCommand = new TransactionClosureSendCommand(
-                new RptId(transactionActivatedEvent.getNoticeCodes().get(0).getRptId()),
+                new RptId(transactionActivatedEvent.getData().getPaymentNotices().get(0).getRptId()),
                 closureSendData
         );
 
@@ -574,7 +558,7 @@ class TransactionSendClosureHandlerTest {
                 .paymentTokens(
                         List.of(
                                 ((BaseTransactionWithPaymentToken) transaction).getTransactionActivatedData()
-                                        .getNoticeCodes().get(0).getPaymentToken()
+                                        .getPaymentNotices().get(0).getPaymentToken()
                         )
                 )
                 .outcome(ClosePaymentRequestV2Dto.OutcomeEnum.OK)
@@ -585,7 +569,7 @@ class TransactionSendClosureHandlerTest {
                 .totalAmount(
                         EuroUtils.euroCentsToEuro(
                                 ((BaseTransactionWithPaymentToken) transaction).getTransactionActivatedData()
-                                        .getNoticeCodes().get(0).getAmount() + authorizationRequestData.getFee()
+                                        .getPaymentNotices().get(0).getAmount() + authorizationRequestData.getFee()
                         )
                 )
                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
@@ -604,8 +588,7 @@ class TransactionSendClosureHandlerTest {
                 .outcome(ClosePaymentResponseDto.OutcomeEnum.KO);
 
         TransactionClosureErrorEvent errorEvent = new TransactionClosureErrorEvent(
-                transactionId.value().toString(),
-                transactionActivatedEvent.getNoticeCodes()
+                transactionId.value().toString()
         );
 
         RuntimeException redisError = new RuntimeException("Network error");

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -34,7 +34,6 @@ import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -108,7 +107,8 @@ class TransactionSendClosureHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -132,7 +132,8 @@ class TransactionSendClosureHandlerTest {
                         email.value(),
                         transaction.getTransactionActivatedData().getPaymentNotices(),
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -212,7 +213,8 @@ class TransactionSendClosureHandlerTest {
                         email.value(),
                         PaymentNotices,
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -350,7 +352,8 @@ class TransactionSendClosureHandlerTest {
                         email.value(),
                         PaymentNotices,
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -499,7 +502,8 @@ class TransactionSendClosureHandlerTest {
                         email.value(),
                         PaymentNotices,
                         faultCode,
-                        faultCodeString
+                        faultCodeString,
+                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
                 )
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -50,7 +50,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -75,7 +75,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         );
 
         TransactionUpdateAuthorizationCommand requestAuthorizationCommand = new TransactionUpdateAuthorizationCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 updateAuthorizationStatusData
         );
 
@@ -87,16 +87,6 @@ class TransactionUpdateAuthorizationHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent event = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.toString(),
-                transaction.getNoticeCodes().stream()
-                        .map(
-                                noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                        noticeCode.paymentToken().value(),
-                                        noticeCode.rptId().value(),
-                                        noticeCode.transactionDescription().value(),
-                                        noticeCode.transactionAmount().value(),
-                                        noticeCode.paymentContextCode().value()
-                                )
-                        ).toList(),
                 transactionAuthorizationStatusUpdateData
         );
 
@@ -131,7 +121,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -156,7 +146,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         );
 
         TransactionUpdateAuthorizationCommand requestAuthorizationCommand = new TransactionUpdateAuthorizationCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 updateAuthorizationStatusData
         );
 
@@ -182,7 +172,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -207,7 +197,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         );
 
         TransactionUpdateAuthorizationCommand requestAuthorizationCommand = new TransactionUpdateAuthorizationCommand(
-                transaction.getNoticeCodes().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId(),
                 updateAuthorizationStatusData
         );
 
@@ -219,18 +209,6 @@ class TransactionUpdateAuthorizationHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent event = new TransactionAuthorizationStatusUpdatedEvent(
                 transactionId.toString(),
-                transaction.getNoticeCodes().stream().map(
-                        noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                transaction.getTransactionActivatedData().getNoticeCodes().stream()
-                                        .filter(
-                                                noticeCode1 -> noticeCode1.getRptId().equals(noticeCode.rptId().value())
-                                        ).findFirst().get().getPaymentToken(),
-                                noticeCode.rptId().value(),
-                                noticeCode.transactionDescription().value(),
-                                noticeCode.transactionAmount().value(),
-                                noticeCode.paymentContextCode().value()
-                        )
-                ).toList(),
                 transactionAuthorizationStatusUpdateData
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -61,7 +61,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.AUTHORIZATION_REQUESTED
+                TransactionStatusDto.AUTHORIZATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -132,7 +133,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -183,7 +185,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.AUTHORIZATION_REQUESTED
+                TransactionStatusDto.AUTHORIZATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.transactions.commands.handlers;
 
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedData;
 import it.pagopa.ecommerce.commons.documents.TransactionActivatedEvent;
 import it.pagopa.ecommerce.commons.domain.*;
@@ -39,9 +39,9 @@ class TransactionsActivationProjectionHandlerTest {
         int amountInt = 100;
         TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
         transactionActivatedData.setEmail("jon.doe@email.it");
-        transactionActivatedData.setNoticeCodes(
+        transactionActivatedData.setPaymentNotices(
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 paymentTokenString,
                                 rptIdString,
                                 transactionDescription,
@@ -53,16 +53,17 @@ class TransactionsActivationProjectionHandlerTest {
 
         TransactionActivatedEvent event = new TransactionActivatedEvent(
                 transactionIdString,
-                Arrays.asList(new NoticeCode(paymentTokenString, rptIdString, transactionDescription, amountInt, null)),
                 transactionActivatedData
         );
 
         TransactionActivatedData data = event.getData();
         TransactionId transactionId = new TransactionId(UUID.fromString(event.getTransactionId()));
-        PaymentToken paymentToken = new PaymentToken(event.getNoticeCodes().get(0).getPaymentToken());
-        RptId rptId = new RptId(event.getNoticeCodes().get(0).getRptId());
-        TransactionDescription description = new TransactionDescription(data.getNoticeCodes().get(0).getDescription());
-        TransactionAmount amount = new TransactionAmount(data.getNoticeCodes().get(0).getAmount());
+        PaymentToken paymentToken = new PaymentToken(event.getData().getPaymentNotices().get(0).getPaymentToken());
+        RptId rptId = new RptId(event.getData().getPaymentNotices().get(0).getRptId());
+        TransactionDescription description = new TransactionDescription(
+                data.getPaymentNotices().get(0).getDescription()
+        );
+        TransactionAmount amount = new TransactionAmount(data.getPaymentNotices().get(0).getAmount());
         Email email = new Email("foo@example.com");
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
@@ -71,7 +72,7 @@ class TransactionsActivationProjectionHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -100,20 +101,20 @@ class TransactionsActivationProjectionHandlerTest {
         Assert.assertEquals(transactionResult.getTransactionId(), transaction.getTransactionId());
         Assert.assertEquals(transactionResult.getStatus(), transaction.getStatus());
         Assert.assertEquals(
-                transactionResult.getNoticeCodes().get(0).transactionAmount(),
-                transaction.getNoticeCodes().get(0).transactionAmount()
+                transactionResult.getPaymentNotices().get(0).transactionAmount(),
+                transaction.getPaymentNotices().get(0).transactionAmount()
         );
         Assert.assertEquals(
-                transactionResult.getNoticeCodes().get(0).transactionDescription(),
-                transaction.getNoticeCodes().get(0).transactionDescription()
+                transactionResult.getPaymentNotices().get(0).transactionDescription(),
+                transaction.getPaymentNotices().get(0).transactionDescription()
         );
         Assert.assertEquals(
-                transactionResult.getNoticeCodes().get(0).rptId(),
-                transaction.getNoticeCodes().get(0).rptId()
+                transactionResult.getPaymentNotices().get(0).rptId(),
+                transaction.getPaymentNotices().get(0).rptId()
         );
         Assert.assertEquals(
-                transactionResult.getTransactionActivatedData().getNoticeCodes().get(0).getPaymentToken(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getPaymentToken()
+                transactionResult.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken()
         );
 
     }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
@@ -83,7 +83,8 @@ class TransactionsActivationProjectionHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         it.pagopa.ecommerce.commons.documents.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.Transaction

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -117,7 +117,8 @@ class TransactionDocumentTest {
                 email,
                 faultCode,
                 faultCodeString,
-                status
+                status,
+                Transaction.OriginType.UNKNOWN
         );
 
         Transaction transactionDocument = Transaction.from(transaction);

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.transactions.documents;
 
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -66,23 +66,23 @@ class TransactionDocumentTest {
                 null,
                 ZonedDateTime.now()
         );
-        it.pagopa.ecommerce.commons.documents.NoticeCode noticeCode = new NoticeCode(
+        it.pagopa.ecommerce.commons.documents.PaymentNotice paymentNotice = new PaymentNotice(
                 TEST_TOKEN,
                 TEST_RPTID,
                 TEST_DESC,
                 TEST_AMOUNT,
                 null
         );
-        differentTransaction.setNoticeCodes(Arrays.asList(noticeCode));
+        differentTransaction.setPaymentNotices(Arrays.asList(paymentNotice));
         differentTransaction.setStatus(TEST_STATUS);
 
         /**
          * Assertions
          */
-        assertEquals(TEST_TOKEN, transaction.getNoticeCodes().get(0).getPaymentToken());
-        assertEquals(TEST_RPTID, transaction.getNoticeCodes().get(0).getRptId());
-        assertEquals(TEST_DESC, transaction.getNoticeCodes().get(0).getDescription());
-        assertEquals(TEST_AMOUNT, transaction.getNoticeCodes().get(0).getAmount());
+        assertEquals(TEST_TOKEN, transaction.getPaymentNotices().get(0).getPaymentToken());
+        assertEquals(TEST_RPTID, transaction.getPaymentNotices().get(0).getRptId());
+        assertEquals(TEST_DESC, transaction.getPaymentNotices().get(0).getDescription());
+        assertEquals(TEST_AMOUNT, transaction.getPaymentNotices().get(0).getAmount());
         assertEquals(TEST_STATUS, transaction.getStatus());
 
         assertNotEquals(transaction, differentTransaction);
@@ -106,7 +106,7 @@ class TransactionDocumentTest {
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 paymentToken,
                                 rptId,
                                 amount,
@@ -123,20 +123,20 @@ class TransactionDocumentTest {
         Transaction transactionDocument = Transaction.from(transaction);
 
         assertEquals(
-                transactionDocument.getNoticeCodes().get(0).getPaymentToken(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getPaymentToken()
+                transactionDocument.getPaymentNotices().get(0).getPaymentToken(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken()
         );
         assertEquals(
-                transactionDocument.getNoticeCodes().get(0).getRptId(),
-                transaction.getNoticeCodes().get(0).rptId().value()
+                transactionDocument.getPaymentNotices().get(0).getRptId(),
+                transaction.getPaymentNotices().get(0).rptId().value()
         );
         assertEquals(
-                transactionDocument.getNoticeCodes().get(0).getDescription(),
-                transaction.getNoticeCodes().get(0).transactionDescription().value()
+                transactionDocument.getPaymentNotices().get(0).getDescription(),
+                transaction.getPaymentNotices().get(0).transactionDescription().value()
         );
         assertEquals(
-                transactionDocument.getNoticeCodes().get(0).getAmount(),
-                transaction.getNoticeCodes().get(0).transactionAmount().value()
+                transactionDocument.getPaymentNotices().get(0).getAmount(),
+                transaction.getPaymentNotices().get(0).transactionAmount().value()
         );
         assertEquals(ZonedDateTime.parse(transactionDocument.getCreationDate()), transaction.getCreationDate());
         assertEquals(transactionDocument.getStatus(), transaction.getStatus());

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -53,7 +53,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 new Email("email@example.com"),
                 "faultCode",
                 "faultCodeString",
-                it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.AUTHORIZATION_REQUESTED
+                it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.AUTHORIZATION_REQUESTED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         it.pagopa.ecommerce.commons.documents.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.Transaction(
@@ -95,7 +96,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 null,
                 null,
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
-                expectedDocument.getStatus()
+                expectedDocument.getStatus(),
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -42,7 +42,7 @@ class AuthorizationUpdateProjectionHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(UUID.randomUUID()),
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -58,10 +58,10 @@ class AuthorizationUpdateProjectionHandlerTest {
 
         it.pagopa.ecommerce.commons.documents.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.Transaction(
                 transaction.getTransactionId().value().toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getPaymentToken(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getRptId(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getDescription(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getAmount(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getRptId(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getDescription(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getAmount(),
                 transaction.getEmail().value(),
                 it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.AUTHORIZED,
                 transaction.getCreationDate()
@@ -76,29 +76,19 @@ class AuthorizationUpdateProjectionHandlerTest {
 
         TransactionAuthorizationStatusUpdatedEvent event = new TransactionAuthorizationStatusUpdatedEvent(
                 transaction.getTransactionId().value().toString(),
-                transaction.getNoticeCodes().stream()
-                        .map(
-                                noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                        noticeCode.paymentToken().value(),
-                                        noticeCode.rptId().value(),
-                                        null,
-                                        null,
-                                        null
-                                )
-                        ).toList(),
                 statusUpdateData
         );
 
         TransactionActivated expected = new TransactionActivated(
                 transaction.getTransactionId(),
-                transaction.getNoticeCodes().stream()
+                transaction.getPaymentNotices().stream()
                         .map(
-                                noticeCode -> new it.pagopa.ecommerce.commons.domain.NoticeCode(
-                                        noticeCode.paymentToken(),
-                                        noticeCode.rptId(),
-                                        noticeCode.transactionAmount(),
-                                        noticeCode.transactionDescription(),
-                                        noticeCode.paymentContextCode()
+                                PaymentNotice -> new it.pagopa.ecommerce.commons.domain.PaymentNotice(
+                                        PaymentNotice.paymentToken(),
+                                        PaymentNotice.rptId(),
+                                        PaymentNotice.transactionAmount(),
+                                        PaymentNotice.transactionDescription(),
+                                        PaymentNotice.paymentContextCode()
                                 )
                         ).toList(),
                 transaction.getEmail(),

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.transactions.projections.handlers;
 
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.documents.TransactionClosureErrorEvent;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -35,14 +35,12 @@ class ClosureErrorProjectionHandlerTest {
         Transaction transaction = transactionDocument();
 
         TransactionClosureErrorEvent closureErrorEvent = new TransactionClosureErrorEvent(
-                transaction.getTransactionId(),
-                transaction.getNoticeCodes()
+                transaction.getTransactionId()
         );
 
         Transaction expected = new Transaction(
                 transaction.getTransactionId(),
-                transaction.getNoticeCodes(),
-                transaction.getNoticeCodes().stream().mapToInt(NoticeCode::getAmount).sum(),
+                transaction.getPaymentNotices(),
                 transaction.getFeeTotal(),
                 transaction.getEmail(),
                 TransactionStatusDto.CLOSURE_ERROR,
@@ -65,8 +63,7 @@ class ClosureErrorProjectionHandlerTest {
         Transaction transaction = transactionDocument();
 
         TransactionClosureErrorEvent closureErrorEvent = new TransactionClosureErrorEvent(
-                transaction.getTransactionId(),
-                transaction.getNoticeCodes()
+                transaction.getTransactionId()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId())).thenReturn(Mono.empty());
@@ -81,7 +78,7 @@ class ClosureErrorProjectionHandlerTest {
         return new Transaction(
                 UUID.randomUUID().toString(),
                 List.of(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 "paymentToken",
                                 "77777777777302016723749670035",
                                 "description",
@@ -89,7 +86,6 @@ class ClosureErrorProjectionHandlerTest {
                                 null
                         )
                 ),
-                100,
                 0,
                 "foo@example.com",
                 TransactionStatusDto.AUTHORIZED,

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionProjectionHandlerTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.transactions.projections.handlers;
 
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.TransactionActivationRequestedData;
 import it.pagopa.ecommerce.commons.documents.TransactionActivationRequestedEvent;
 import it.pagopa.ecommerce.commons.domain.*;
@@ -36,30 +36,20 @@ class TransactionProjectionHandlerTest {
 
         TransactionActivationRequestedData transactionActivationRequestedData = new TransactionActivationRequestedData();
         transactionActivationRequestedData.setEmail("email@test.it");
-        NoticeCode noticeCode = new NoticeCode(null, null, "reason", 1, null);
-        transactionActivationRequestedData.setNoticeCodes(Arrays.asList(noticeCode));
+        PaymentNotice paymentNotice = new PaymentNotice(null, "77777777777302016723749670035", "reason", 1, null);
+        transactionActivationRequestedData.setPaymentNotices(Arrays.asList(paymentNotice));
         transactionActivationRequestedData.setFaultCode("faultCode");
         transactionActivationRequestedData.setFaultCodeString("faultCodeString");
 
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 transactionUUID.toString(),
-                Arrays.asList(
-                        new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                null,
-                                "77777777777302016723749670035",
-                                "reason",
-                                1,
-                                "ccpcode"
-                        )
-                ),
                 transactionActivationRequestedData
         );
 
         TransactionActivationRequestedEvent event = new TransactionActivationRequestedEvent(
                 transactionActivationRequestedEvent.getTransactionId(),
-                transactionActivationRequestedEvent.getNoticeCodes(),
                 new TransactionActivationRequestedData(
-                        transactionActivationRequestedData.getNoticeCodes(),
+                        transactionActivationRequestedData.getPaymentNotices(),
                         "foo@example.com",
                         "faultCode",
                         "faultCodeString"
@@ -68,26 +58,26 @@ class TransactionProjectionHandlerTest {
 
         TransactionId transactionId = new TransactionId(transactionUUID);
         PaymentToken paymentToken = new PaymentToken(
-                transactionActivationRequestedEvent.getNoticeCodes().get(0).getPaymentToken()
+                transactionActivationRequestedEvent.getData().getPaymentNotices().get(0).getPaymentToken()
         );
-        RptId rptId = new RptId(transactionActivationRequestedEvent.getNoticeCodes().get(0).getRptId());
+        RptId rptId = new RptId(transactionActivationRequestedEvent.getData().getPaymentNotices().get(0).getRptId());
         TransactionDescription description = new TransactionDescription(
-                transactionActivationRequestedData.getNoticeCodes().get(0).getDescription()
+                transactionActivationRequestedData.getPaymentNotices().get(0).getDescription()
         );
         TransactionAmount amount = new TransactionAmount(
-                transactionActivationRequestedData.getNoticeCodes().get(0).getAmount()
+                transactionActivationRequestedData.getPaymentNotices().get(0).getAmount()
         );
         Email email = new Email(transactionActivationRequestedData.getEmail());
         ZonedDateTime creationDate = ZonedDateTime.now();
         PaymentContextCode paymentContextCode = new PaymentContextCode(
-                transactionActivationRequestedData.getNoticeCodes().get(0).getPaymentContextCode()
+                transactionActivationRequestedData.getPaymentNotices().get(0).getPaymentContextCode()
         );
         try (
                 MockedStatic<ZonedDateTime> zonedDateTime = Mockito.mockStatic(ZonedDateTime.class)) {
             TransactionActivationRequested expected = new TransactionActivationRequested(
                     transactionId,
                     Arrays.asList(
-                            new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                            new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                     paymentToken,
                                     rptId,
                                     amount,

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionProjectionHandlerTest.java
@@ -52,7 +52,8 @@ class TransactionProjectionHandlerTest {
                         transactionActivationRequestedData.getPaymentNotices(),
                         "foo@example.com",
                         "faultCode",
-                        "faultCodeString"
+                        "faultCodeString",
+                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
                 )
         );
 
@@ -87,7 +88,8 @@ class TransactionProjectionHandlerTest {
                     ),
                     email,
                     creationDate,
-                    TransactionStatusDto.ACTIVATION_REQUESTED
+                    TransactionStatusDto.ACTIVATION_REQUESTED,
+                    it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
             );
 
             /*

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionProjectionHandlerTest.java
@@ -40,21 +40,12 @@ class TransactionProjectionHandlerTest {
         transactionActivationRequestedData.setPaymentNotices(Arrays.asList(paymentNotice));
         transactionActivationRequestedData.setFaultCode("faultCode");
         transactionActivationRequestedData.setFaultCodeString("faultCodeString");
+        transactionActivationRequestedData
+                .setOriginType(it.pagopa.ecommerce.commons.documents.Transaction.OriginType.CHECKOUT);
 
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 transactionUUID.toString(),
                 transactionActivationRequestedData
-        );
-
-        TransactionActivationRequestedEvent event = new TransactionActivationRequestedEvent(
-                transactionActivationRequestedEvent.getTransactionId(),
-                new TransactionActivationRequestedData(
-                        transactionActivationRequestedData.getPaymentNotices(),
-                        "foo@example.com",
-                        "faultCode",
-                        "faultCodeString",
-                        it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
-                )
         );
 
         TransactionId transactionId = new TransactionId(transactionUUID);
@@ -89,7 +80,7 @@ class TransactionProjectionHandlerTest {
                     email,
                     creationDate,
                     TransactionStatusDto.ACTIVATION_REQUESTED,
-                    it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
+                    it.pagopa.ecommerce.commons.documents.Transaction.OriginType.CHECKOUT
             );
 
             /*

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
@@ -45,7 +45,7 @@ class TransactionUserReceiptProjectionHandlerTest {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(UUID.randomUUID()),
                 Arrays.asList(
-                        new NoticeCode(
+                        new PaymentNotice(
                                 new PaymentToken("paymentToken"),
                                 new RptId("77777777777111111111111111111"),
                                 new TransactionAmount(100),
@@ -61,10 +61,10 @@ class TransactionUserReceiptProjectionHandlerTest {
 
         it.pagopa.ecommerce.commons.documents.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.Transaction(
                 transaction.getTransactionId().value().toString(),
-                transaction.getTransactionActivatedData().getNoticeCodes().get(0).getPaymentToken(),
-                transaction.getNoticeCodes().get(0).rptId().value(),
-                transaction.getNoticeCodes().get(0).transactionDescription().value(),
-                transaction.getNoticeCodes().get(0).transactionAmount().value(),
+                transaction.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken(),
+                transaction.getPaymentNotices().get(0).rptId().value(),
+                transaction.getPaymentNotices().get(0).transactionDescription().value(),
+                transaction.getPaymentNotices().get(0).transactionAmount().value(),
                 transaction.getEmail().value(),
                 TransactionStatusDto.NOTIFIED,
                 transaction.getCreationDate()
@@ -76,28 +76,18 @@ class TransactionUserReceiptProjectionHandlerTest {
 
         TransactionUserReceiptAddedEvent event = new TransactionUserReceiptAddedEvent(
                 transaction.getTransactionId().value().toString(),
-                transaction.getNoticeCodes().stream()
-                        .map(
-                                noticeCode -> new it.pagopa.ecommerce.commons.documents.NoticeCode(
-                                        noticeCode.paymentToken().value(),
-                                        noticeCode.rptId().value(),
-                                        noticeCode.transactionDescription().value(),
-                                        noticeCode.transactionAmount().value(),
-                                        noticeCode.paymentContextCode().value()
-                                )
-                        ).toList(),
                 transactionAddReceiptData
         );
 
         TransactionActivated expected = new TransactionActivated(
                 transaction.getTransactionId(),
-                transaction.getTransactionActivatedData().getNoticeCodes().stream().map(
-                        noticeCode -> new NoticeCode(
-                                new PaymentToken(noticeCode.getPaymentToken()),
-                                new RptId(noticeCode.getRptId()),
-                                new TransactionAmount(noticeCode.getAmount()),
-                                new TransactionDescription(noticeCode.getDescription()),
-                                new PaymentContextCode(noticeCode.getPaymentContextCode())
+                transaction.getTransactionActivatedData().getPaymentNotices().stream().map(
+                        PaymentNotice -> new PaymentNotice(
+                                new PaymentToken(PaymentNotice.getPaymentToken()),
+                                new RptId(PaymentNotice.getRptId()),
+                                new TransactionAmount(PaymentNotice.getAmount()),
+                                new TransactionDescription(PaymentNotice.getDescription()),
+                                new PaymentContextCode(PaymentNotice.getPaymentContextCode())
                         )
                 ).toList(),
                 transaction.getEmail(),

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
@@ -56,7 +56,8 @@ class TransactionUserReceiptProjectionHandlerTest {
                 new Email("foo@example.com"),
                 faultCode,
                 faultCodeString,
-                TransactionStatusDto.CLOSED
+                TransactionStatusDto.CLOSED,
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         it.pagopa.ecommerce.commons.documents.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.Transaction(
@@ -94,7 +95,8 @@ class TransactionUserReceiptProjectionHandlerTest {
                 transaction.getTransactionActivatedData().getFaultCode(),
                 transaction.getTransactionActivatedData().getFaultCodeString(),
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
-                expectedDocument.getStatus()
+                expectedDocument.getStatus(),
+                it.pagopa.ecommerce.commons.documents.Transaction.OriginType.UNKNOWN
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.transactions.services;
 
-import it.pagopa.ecommerce.commons.documents.NoticeCode;
+import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.*;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -59,22 +59,20 @@ class TransactionServiceTest {
         TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
         transactionActivatedData.setEmail(TEST_EMAIL);
         transactionActivatedData
-                .setNoticeCodes(Arrays.asList(new NoticeCode(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
+                .setPaymentNotices(Arrays.asList(new PaymentNotice(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 TRANSACTION_ID.toString(),
-                Arrays.asList(new NoticeCode(TEST_TOKEN, TEST_RPTID, null, null, TEST_CPP.toString())),
                 transactionActivatedData
         );
 
         TransactionActivationRequestedData transactionActivationRequestedData = new TransactionActivationRequestedData();
         transactionActivatedData
-                .setNoticeCodes(Arrays.asList(new NoticeCode(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
+                .setPaymentNotices(Arrays.asList(new PaymentNotice(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
         transactionActivationRequestedData.setEmail(TEST_EMAIL);
 
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 TRANSACTION_ID.toString(),
-                Arrays.asList(new NoticeCode(null, TEST_RPTID, null, null, null)),
                 transactionActivationRequestedData
         );
 
@@ -95,7 +93,7 @@ class TransactionServiceTest {
         TransactionActivated transactionActivated = new TransactionActivated(
                 new TransactionId(TRANSACTION_ID),
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 new PaymentToken(TEST_TOKEN),
                                 new RptId(TEST_RPTID),
                                 new TransactionAmount(0),
@@ -112,7 +110,7 @@ class TransactionServiceTest {
         TransactionActivationRequested transactionActivationRequested = new TransactionActivationRequested(
                 new TransactionId(TRANSACTION_ID),
                 Arrays.asList(
-                        new it.pagopa.ecommerce.commons.domain.NoticeCode(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 null,
                                 new RptId(TEST_RPTID),
                                 new TransactionAmount(0),
@@ -164,22 +162,20 @@ class TransactionServiceTest {
         TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
         transactionActivatedData.setEmail(TEST_EMAIL);
         transactionActivatedData
-                .setNoticeCodes(Arrays.asList(new NoticeCode(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
+                .setPaymentNotices(Arrays.asList(new PaymentNotice(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
                 TRANSACTION_ID.toString(),
-                Arrays.asList(new NoticeCode(TEST_TOKEN, TEST_RPTID, null, null, TEST_CPP.toString())),
                 transactionActivatedData
         );
 
         TransactionActivationRequestedData transactionActivationRequestedData = new TransactionActivationRequestedData();
         transactionActivatedData
-                .setNoticeCodes(Arrays.asList(new NoticeCode(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
+                .setPaymentNotices(Arrays.asList(new PaymentNotice(TEST_TOKEN, null, "dest", 0, TEST_CPP.toString())));
         transactionActivationRequestedData.setEmail(TEST_EMAIL);
 
         TransactionActivationRequestedEvent transactionActivationRequestedEvent = new TransactionActivationRequestedEvent(
                 TRANSACTION_ID.toString(),
-                Arrays.asList(new NoticeCode(null, TEST_RPTID, null, null, null)),
                 transactionActivationRequestedData
         );
 
@@ -196,8 +192,8 @@ class TransactionServiceTest {
                         Mono.just(transactionActivationRequestedEvent),
                         sessionDataDto
                 );
-        List<it.pagopa.ecommerce.commons.domain.NoticeCode> noticeCodeList = List.of(
-                new it.pagopa.ecommerce.commons.domain.NoticeCode(
+        List<it.pagopa.ecommerce.commons.domain.PaymentNotice> PaymentNoticeList = List.of(
+                new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                         new PaymentToken(TEST_TOKEN),
                         new RptId(TEST_RPTID),
                         new TransactionAmount(0),
@@ -207,7 +203,7 @@ class TransactionServiceTest {
         );
         TransactionActivated transactionActivated = new TransactionActivated(
                 new TransactionId(TRANSACTION_ID),
-                noticeCodeList,
+                PaymentNoticeList,
                 new Email("foo@example.com"),
                 "faultCode",
                 "faultCodeString",
@@ -216,7 +212,7 @@ class TransactionServiceTest {
 
         TransactionActivationRequested transactionActivationRequested = new TransactionActivationRequested(
                 new TransactionId(TRANSACTION_ID),
-                noticeCodeList,
+                PaymentNoticeList,
                 new Email("foo@example.com"),
                 TransactionStatusDto.ACTIVATION_REQUESTED
         );

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.transactions.services;
 
 import it.pagopa.ecommerce.commons.documents.PaymentNotice;
+import it.pagopa.ecommerce.commons.documents.Transaction;
 import it.pagopa.ecommerce.commons.documents.*;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -104,7 +105,8 @@ class TransactionServiceTest {
                 new Email("foo@example.com"),
                 "faultCode",
                 "faultCodeString",
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                Transaction.OriginType.UNKNOWN
         );
 
         TransactionActivationRequested transactionActivationRequested = new TransactionActivationRequested(
@@ -119,7 +121,8 @@ class TransactionServiceTest {
                         )
                 ),
                 new Email("foo@example.com"),
-                TransactionStatusDto.ACTIVATION_REQUESTED
+                TransactionStatusDto.ACTIVATION_REQUESTED,
+                Transaction.OriginType.UNKNOWN
         );
 
         /**
@@ -207,14 +210,16 @@ class TransactionServiceTest {
                 new Email("foo@example.com"),
                 "faultCode",
                 "faultCodeString",
-                TransactionStatusDto.ACTIVATED
+                TransactionStatusDto.ACTIVATED,
+                Transaction.OriginType.UNKNOWN
         );
 
         TransactionActivationRequested transactionActivationRequested = new TransactionActivationRequested(
                 new TransactionId(TRANSACTION_ID),
                 PaymentNoticeList,
                 new Email("foo@example.com"),
-                TransactionStatusDto.ACTIVATION_REQUESTED
+                TransactionStatusDto.ACTIVATION_REQUESTED,
+                Transaction.OriginType.UNKNOWN
         );
 
         /**

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -1,10 +1,10 @@
 package it.pagopa.transactions.services;
 
 import io.vavr.control.Either;
-import it.pagopa.ecommerce.commons.documents.*;
 import it.pagopa.ecommerce.commons.documents.Transaction;
-import it.pagopa.ecommerce.commons.domain.*;
+import it.pagopa.ecommerce.commons.documents.*;
 import it.pagopa.ecommerce.commons.domain.PaymentNotice;
+import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.generated.ecommerce.gateway.v1.dto.PostePayAuthResponseEntityDto;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 import it.pagopa.generated.ecommerce.paymentinstruments.v1.dto.PSPsResponseDto;
@@ -294,12 +294,12 @@ public class TransactionServiceTests {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                 transactionDocument.getPaymentNotices().stream().map(
-                        PaymentNotice -> new PaymentNotice(
-                                new PaymentToken(PaymentNotice.getPaymentToken()),
-                                new RptId(PaymentNotice.getRptId()),
-                                new TransactionAmount(PaymentNotice.getAmount()),
-                                new TransactionDescription(PaymentNotice.getDescription()),
-                                new PaymentContextCode(PaymentNotice.getPaymentContextCode())
+                        paymentNotice -> new PaymentNotice(
+                                new PaymentToken(paymentNotice.getPaymentToken()),
+                                new RptId(paymentNotice.getRptId()),
+                                new TransactionAmount(paymentNotice.getAmount()),
+                                new TransactionDescription(paymentNotice.getDescription()),
+                                new PaymentContextCode(paymentNotice.getPaymentContextCode())
                         )
                 ).toList(),
                 new Email(transactionDocument.getEmail()),
@@ -339,11 +339,11 @@ public class TransactionServiceTests {
                 .transactionId(transactionDocument.getTransactionId())
                 .payments(
                         transactionDocument.getPaymentNotices().stream().map(
-                                PaymentNotice -> new PaymentInfoDto()
-                                        .amount(PaymentNotice.getAmount())
-                                        .reason(PaymentNotice.getDescription())
-                                        .paymentToken(PaymentNotice.getPaymentToken())
-                                        .rptId(PaymentNotice.getRptId())
+                                paymentNotice -> new PaymentInfoDto()
+                                        .amount(paymentNotice.getAmount())
+                                        .reason(paymentNotice.getDescription())
+                                        .paymentToken(paymentNotice.getPaymentToken())
+                                        .rptId(paymentNotice.getRptId())
                         ).toList()
                 )
                 .status(TransactionStatusDto.CLOSED);
@@ -416,12 +416,12 @@ public class TransactionServiceTests {
         TransactionActivated transaction = new TransactionActivated(
                 new TransactionId(UUID.fromString(transactionDocument.getTransactionId())),
                 transactionDocument.getPaymentNotices().stream().map(
-                        PaymentNotice -> new PaymentNotice(
-                                new PaymentToken(PaymentNotice.getPaymentToken()),
-                                new RptId(PaymentNotice.getRptId()),
-                                new TransactionAmount(PaymentNotice.getAmount()),
-                                new TransactionDescription(PaymentNotice.getDescription()),
-                                new PaymentContextCode(PaymentNotice.getPaymentContextCode())
+                        paymentNotice -> new PaymentNotice(
+                                new PaymentToken(paymentNotice.getPaymentToken()),
+                                new RptId(paymentNotice.getRptId()),
+                                new TransactionAmount(paymentNotice.getAmount()),
+                                new TransactionDescription(paymentNotice.getDescription()),
+                                new PaymentContextCode(paymentNotice.getPaymentContextCode())
                         )
                 ).toList(),
                 new Email(transactionDocument.getEmail()),
@@ -457,11 +457,11 @@ public class TransactionServiceTests {
                 .transactionId(transactionDocument.getTransactionId())
                 .payments(
                         transactionDocument.getPaymentNotices().stream().map(
-                                PaymentNotice -> new PaymentInfoDto()
-                                        .amount(PaymentNotice.getAmount())
-                                        .reason(PaymentNotice.getDescription())
-                                        .paymentToken(PaymentNotice.getPaymentToken())
-                                        .rptId(PaymentNotice.getRptId())
+                                paymentNotice -> new PaymentInfoDto()
+                                        .amount(paymentNotice.getAmount())
+                                        .reason(paymentNotice.getDescription())
+                                        .paymentToken(paymentNotice.getPaymentToken())
+                                        .rptId(paymentNotice.getRptId())
                         ).toList()
                 )
                 .status(TransactionStatusDto.NOTIFIED);

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -35,8 +35,6 @@ import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.time.LocalDate;
-import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -305,7 +303,8 @@ public class TransactionServiceTests {
                 new Email(transactionDocument.getEmail()),
                 "faultCode",
                 "faultCodeString",
-                transactionDocument.getStatus()
+                transactionDocument.getStatus(),
+                Transaction.OriginType.UNKNOWN
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -427,7 +426,8 @@ public class TransactionServiceTests {
                 new Email(transactionDocument.getEmail()),
                 null,
                 null,
-                it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.NOTIFIED
+                it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.NOTIFIED,
+                Transaction.OriginType.UNKNOWN
         );
 
         TransactionAddReceiptData transactionAddReceiptData = new TransactionAddReceiptData(


### PR DESCRIPTION
Depends on pagopa/pagopa-ecommerce-commons#15

After commons library update, also transaction need to be aligned with this new version.

#### List of Changes

- Transaction now fit new ecommerce commons, in details now the `NoticeCode` name is `PaymentNotice` (and all get methods that return this kind of data changed their name)
- fee total in transactioninfo is not filled if it is null in transaction document 
- Amount total removed from transactionInfo

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.