### PR TITLE
[CHK-916] (branch CKH-911) x pgs id not mandatory

### DIFF
--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -63,7 +63,7 @@ paths:
           schema:
             type: string
             pattern: 'XPAY|VPOS'
-          required: true
+          required: false
           description: Pgs identifier (populated by APIM policy)
       requestBody:
         $ref: "#/components/requestBodies/RequestAuthorizationRequest"

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandler.java
@@ -54,12 +54,28 @@ public class TransactionRequestAuthorizationHandler
         }
 
         var monoPostePay = Mono.just(command.getData())
-                .flatMap(d -> paymentGatewayClient.requestPostepayAuthorization(d))
-                .map(p -> Tuples.of(p.getRequestId(), p.getUrlRedirect()));
+                .flatMap(
+                        authorizationRequestData -> paymentGatewayClient
+                                .requestPostepayAuthorization(authorizationRequestData)
+                )
+                .map(
+                        postePayAuthResponseEntityDto -> Tuples.of(
+                                postePayAuthResponseEntityDto.getRequestId(),
+                                postePayAuthResponseEntityDto.getUrlRedirect()
+                        )
+                );
 
         var monoXPay = Mono.just(command.getData())
-                .flatMap(d -> paymentGatewayClient.requestXPayAuthorization(d))
-                .map(p -> Tuples.of(p.getRequestId(), p.getUrlRedirect()));
+                .flatMap(
+                        authorizationRequestData -> paymentGatewayClient
+                                .requestXPayAuthorization(authorizationRequestData)
+                )
+                .map(
+                        xPayAuthResponseEntityDto -> Tuples.of(
+                                xPayAuthResponseEntityDto.getRequestId(),
+                                xPayAuthResponseEntityDto.getUrlRedirect()
+                        )
+                );
 
         List<Mono<Tuple2<String, String>>> gatewayRequests = List.of(monoPostePay, monoXPay);
 

--- a/src/main/java/it/pagopa/transactions/controllers/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/TransactionsController.java
@@ -79,8 +79,8 @@ public class TransactionsController implements TransactionsApi {
     @Override
     public Mono<ResponseEntity<RequestAuthorizationResponseDto>> requestTransactionAuthorization(
                                                                                                  String transactionId,
-                                                                                                 String xPgsId,
                                                                                                  Mono<RequestAuthorizationRequestDto> requestAuthorizationRequestDto,
+                                                                                                 String xPgsId,
                                                                                                  ServerWebExchange exchange
     ) {
         return requestAuthorizationRequestDto

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
@@ -170,6 +170,8 @@ class TransactionRequestAuthorizizationHandlerTest {
         ReflectionTestUtils.setField(requestAuthorizationHandler, "queueVisibilityTimeout", "300");
 
         /* preconditions */
+        Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
+                .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestXPayAuthorization(authorizationData))
                 .thenReturn(Mono.just(xPayAuthResponseEntityDto));
         Mockito.when(transactionEventStoreRepository.save(any())).thenReturn(Mono.empty());

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
@@ -7,6 +7,7 @@ import it.pagopa.ecommerce.commons.documents.TransactionAuthorizationRequestData
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.generated.ecommerce.gateway.v1.dto.PostePayAuthResponseEntityDto;
+import it.pagopa.generated.ecommerce.gateway.v1.dto.XPayAuthResponseEntityDto;
 import it.pagopa.generated.transactions.server.model.PostePayAuthRequestDetailsDto;
 import it.pagopa.generated.transactions.server.model.RequestAuthorizationRequestDto;
 import it.pagopa.transactions.client.EcommerceSessionsClient;
@@ -161,16 +162,16 @@ class TransactionRequestAuthorizizationHandlerTest {
                 authorizationData
         );
 
-        PostePayAuthResponseEntityDto postePayAuthResponseEntityDto = new PostePayAuthResponseEntityDto()
-                .channel("channel")
+        XPayAuthResponseEntityDto xPayAuthResponseEntityDto = new XPayAuthResponseEntityDto()
                 .requestId("requestId")
+                .status("status")
                 .urlRedirect("http://example.com");
 
         ReflectionTestUtils.setField(requestAuthorizationHandler, "queueVisibilityTimeout", "300");
 
         /* preconditions */
-        Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
-                .thenReturn(Mono.just(postePayAuthResponseEntityDto));
+        Mockito.when(paymentGatewayClient.requestXPayAuthorization(authorizationData))
+                .thenReturn(Mono.just(xPayAuthResponseEntityDto));
         Mockito.when(transactionEventStoreRepository.save(any())).thenReturn(Mono.empty());
         Mockito.when(queueAsyncClient.sendMessageWithResponse(BinaryData.fromObject(any()), any(), any()))
                 .thenReturn(Mono.empty());

--- a/src/test/java/it/pagopa/transactions/controllers/TransactionsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/TransactionsControllerTest.java
@@ -143,7 +143,7 @@ class TransactionsControllerTest {
 
         /* test */
         ResponseEntity<RequestAuthorizationResponseDto> response = transactionsController
-                .requestTransactionAuthorization(paymentToken, pgsId, Mono.just(authorizationRequest), mockExchange)
+                .requestTransactionAuthorization(paymentToken, Mono.just(authorizationRequest), pgsId, mockExchange)
                 .block();
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -167,7 +167,7 @@ class TransactionsControllerTest {
 
         /* test */
         Mono<ResponseEntity<RequestAuthorizationResponseDto>> mono = transactionsController
-                .requestTransactionAuthorization(paymentToken, pgsId, Mono.just(authorizationRequest), mockExchange);
+                .requestTransactionAuthorization(paymentToken, Mono.just(authorizationRequest), pgsId, mockExchange);
         assertThrows(
                 TransactionNotFoundException.class,
                 () -> mono.block()


### PR DESCRIPTION
Since for some payment methods the pgs is clear and is not valued by apim policy it has been set as not mandatory in the  requestTransactionAuthorization post definition in the yaml file. 

#### List of Changes

- pgsId not mandatory in yaml file
- transaction controller update

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.