### PR TITLE
[CHK-962] clientId unknown removal

### DIFF
--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -323,7 +323,6 @@ components:
             - IO
             - CHECKOUT
             - CHECKOUT_CART
-            - UNKNOWN
         authToken:
           type: string
       required:
@@ -331,6 +330,7 @@ components:
         - amountTotal
         - status
         - payments
+        - clientId
     RequestAuthorizationRequest:
       type: object
       description: Request body for requesting an authorization for a transaction

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.6.3</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.7.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -453,8 +453,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-962-client-id-refactoring</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.6.1</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.6.3</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
     </properties>
     <dependencies>
@@ -453,8 +453,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-962-client-id-refactoring</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/exceptions/InvalidRequestException.java
+++ b/src/main/java/it/pagopa/transactions/exceptions/InvalidRequestException.java
@@ -6,4 +6,11 @@ public class InvalidRequestException extends RuntimeException {
         super(message);
     }
 
+    public InvalidRequestException(
+            String message,
+            Throwable t
+    ) {
+        super(message, t);
+    }
+
 }

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.services;
 
+import com.azure.cosmos.implementation.BadRequestException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuples;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -561,16 +563,16 @@ public class TransactionsService {
     NewTransactionResponseDto.ClientIdEnum convertClientId(
                                                            it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId
     ) {
-        return Optional.ofNullable(clientId)
+        return Optional.ofNullable(clientId).filter(Objects::nonNull)
                 .map(
                         enumVal -> {
                             try {
                                 return NewTransactionResponseDto.ClientIdEnum.fromValue(enumVal.toString());
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
-                                return NewTransactionResponseDto.ClientIdEnum.UNKNOWN;
+                                throw new BadRequestException();
                             }
                         }
-                ).orElse(NewTransactionResponseDto.ClientIdEnum.UNKNOWN);
+                ).orElseThrow(BadRequestException::new);
     }
 }

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -16,10 +16,7 @@ import it.pagopa.transactions.commands.data.AuthorizationRequestData;
 import it.pagopa.transactions.commands.data.ClosureSendData;
 import it.pagopa.transactions.commands.data.UpdateAuthorizationStatusData;
 import it.pagopa.transactions.commands.handlers.*;
-import it.pagopa.transactions.exceptions.NotImplementedException;
-import it.pagopa.transactions.exceptions.TransactionAmountMismatchException;
-import it.pagopa.transactions.exceptions.TransactionNotFoundException;
-import it.pagopa.transactions.exceptions.UnsatisfiablePspRequestException;
+import it.pagopa.transactions.exceptions.*;
 import it.pagopa.transactions.projections.handlers.*;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import it.pagopa.transactions.utils.UUIDUtils;
@@ -570,9 +567,9 @@ public class TransactionsService {
                                 return NewTransactionResponseDto.ClientIdEnum.fromValue(enumVal.toString());
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
-                                throw new BadRequestException();
+                                throw new InvalidRequestException("Unknown input origin", e);
                             }
                         }
-                ).orElseThrow(BadRequestException::new);
+                ).orElseThrow(() -> new InvalidRequestException("Null value as input origin"));
     }
 }

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -146,7 +146,7 @@ class TransactionDocumentTest {
                 email,
                 faultCode,
                 faultCodeString,
-                Transaction.ClientId.UNKNOWN
+                Transaction.ClientId.CHECKOUT
         );
 
         Transaction transactionDocument = Transaction.from(transaction);

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -53,7 +53,7 @@ class AuthorizationUpdateProjectionHandlerTest {
                 new Email("email@example.com"),
                 "faultCode",
                 "faultCodeString",
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.UNKNOWN
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
         );
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.v1.Transaction(
@@ -62,7 +62,7 @@ class AuthorizationUpdateProjectionHandlerTest {
                 null,
                 transaction.getEmail().value(),
                 TransactionStatusDto.AUTHORIZATION_COMPLETED,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.UNKNOWN,
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString()
         );
 
@@ -84,7 +84,7 @@ class AuthorizationUpdateProjectionHandlerTest {
                 null,
                 null,
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.UNKNOWN
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
@@ -84,7 +84,7 @@ class TransactionServiceTest {
                 new Email("foo@example.com"),
                 "faultCode",
                 "faultCodeString",
-                Transaction.ClientId.UNKNOWN
+                Transaction.ClientId.CHECKOUT
         );
 
         /**

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -18,6 +18,7 @@ import it.pagopa.transactions.client.PaymentGatewayClient;
 import it.pagopa.transactions.commands.TransactionRequestAuthorizationCommand;
 import it.pagopa.transactions.commands.data.AuthorizationRequestData;
 import it.pagopa.transactions.commands.handlers.*;
+import it.pagopa.transactions.exceptions.InvalidRequestException;
 import it.pagopa.transactions.exceptions.NotImplementedException;
 import it.pagopa.transactions.exceptions.TransactionAmountMismatchException;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
@@ -720,7 +721,7 @@ public class TransactionServiceTests {
                 .values()) {
             assertEquals(clientId.toString(), transactionsService.convertClientId(clientId).toString());
         }
-        assertThrows(BadRequestException.class, () -> transactionsService.convertClientId(null));
+        assertThrows(InvalidRequestException.class, () -> transactionsService.convertClientId(null));
     }
 
 }

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.services;
 
+import com.azure.cosmos.implementation.BadRequestException;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.v1.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.v1.Transaction;
@@ -719,7 +720,7 @@ public class TransactionServiceTests {
                 .values()) {
             assertEquals(clientId.toString(), transactionsService.convertClientId(clientId).toString());
         }
-        assertEquals("UNKNOWN", transactionsService.convertClientId(null).toString());
+        assertThrows(BadRequestException.class, () -> transactionsService.convertClientId(null));
     }
 
 }

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -118,6 +118,9 @@ public class TransactionServiceTests {
     @MockBean
     private JwtTokenUtils jwtTokenUtils;
 
+    @MockBean
+    private it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId;
+
     final String PAYMENT_TOKEN = "aaa";
     final String TRANSACION_ID = "833d303a-f857-11ec-b939-0242ac120002";
 
@@ -722,6 +725,12 @@ public class TransactionServiceTests {
             assertEquals(clientId.toString(), transactionsService.convertClientId(clientId).toString());
         }
         assertThrows(InvalidRequestException.class, () -> transactionsService.convertClientId(null));
+    }
+
+    @Test
+    void shouldThrowsInvalidRequestExceptionForInvalidClientID() {
+        Mockito.when(clientId.toString()).thenReturn("InvalidClientID");
+        assertThrows(InvalidRequestException.class, () -> transactionsService.convertClientId(clientId));
     }
 
 }


### PR DESCRIPTION
Unknown clientId enum is not acceptable

#### List of Changes

All reference to ClientId.UNKNOWN enum

#### Motivation and Context

Enforce security and expose only to well known client

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

To be merged AFTER https://github.com/pagopa/pagopa-ecommerce-commons/pull/20