### PR TITLE
CHK-1127-invalidate-cache-after-closePyament

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -269,9 +269,9 @@ public class TransactionSendClosureHandler extends
                             })
                             .doFinally(response -> {
                                 tx.getPaymentNotices().forEach(el -> {
-                                            log.info("Invalidate cache for RptId : {}", el.rptId().value());
-                                            paymentRequestsInfoRepository.deleteById(el.rptId());
-                                        }
+                                    log.info("Invalidate cache for RptId : {}", el.rptId().value());
+                                    paymentRequestsInfoRepository.deleteById(el.rptId());
+                                }
                                 );
                             });
                 });

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -157,13 +157,6 @@ public class TransactionSendClosureHandler extends
                                             response.getOutcome()
                                     )
                             )
-                            .doOnSuccess(success -> {
-                                tx.getPaymentNotices().forEach(el -> {
-                                    log.info("Invalidate cache for RptId : {}", el.rptId().value());
-                                    paymentRequestsInfoRepository.deleteById(el.rptId());
-                                }
-                                );
-                            })
                             .flatMap(
                                     event -> sendClosureEvent(
                                             event,
@@ -273,6 +266,13 @@ public class TransactionSendClosureHandler extends
                                                 )
                                         )
                                         .map(Either::right);
+                            })
+                            .doFinally(response -> {
+                                tx.getPaymentNotices().forEach(el -> {
+                                            log.info("Invalidate cache for RptId : {}", el.rptId().value());
+                                            paymentRequestsInfoRepository.deleteById(el.rptId());
+                                        }
+                                );
                             });
                 });
     }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -4,7 +4,6 @@ import com.azure.core.util.BinaryData;
 import com.azure.storage.queue.QueueAsyncClient;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.v1.*;
-import it.pagopa.ecommerce.commons.domain.v1.RptId;
 import it.pagopa.ecommerce.commons.domain.v1.Transaction;
 import it.pagopa.ecommerce.commons.domain.v1.TransactionAuthorizationCompleted;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
@@ -158,13 +157,13 @@ public class TransactionSendClosureHandler extends
                                             response.getOutcome()
                                     )
                             )
-                            .doOnNext(
-                                    response -> {
-                                        log.info("Invalidate cache for RptId: {}", paymentNotice.rptId().value());
-                                        paymentRequestsInfoRepository
-                                                .deleteById(new RptId(paymentNotice.rptId().value()));
-                                    }
-                            )
+                            .doOnSuccess(success -> {
+                                tx.getPaymentNotices().forEach(el -> {
+                                    log.info("Invalidate cache for RptId : {}", el.rptId().value());
+                                    paymentRequestsInfoRepository.deleteById(el.rptId());
+                                }
+                                );
+                            })
                             .flatMap(
                                     event -> sendClosureEvent(
                                             event,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -13,6 +13,8 @@ import it.pagopa.ecommerce.commons.domain.v1.PaymentNotice;
 import it.pagopa.ecommerce.commons.domain.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionWithPaymentToken;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
+import it.pagopa.ecommerce.commons.repositories.PaymentRequestInfo;
+import it.pagopa.ecommerce.commons.repositories.PaymentRequestsInfoRepository;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
@@ -51,6 +53,9 @@ class TransactionSendClosureHandlerTest {
     private final TransactionsEventStoreRepository<Void> transactionClosureErrorEventStoreRepository = Mockito
             .mock(TransactionsEventStoreRepository.class);
 
+    private final PaymentRequestsInfoRepository paymentRequestsInfoRepositoryRepository = Mockito
+            .mock(PaymentRequestsInfoRepository.class);
+
     private final TransactionsEventStoreRepository<Object> eventStoreRepository = Mockito
             .mock(TransactionsEventStoreRepository.class);
 
@@ -65,6 +70,7 @@ class TransactionSendClosureHandlerTest {
     private final TransactionSendClosureHandler transactionSendClosureHandler = new TransactionSendClosureHandler(
             transactionEventStoreRepository,
             transactionClosureErrorEventStoreRepository,
+            paymentRequestsInfoRepositoryRepository,
             eventStoreRepository,
             nodeForPspClient,
             transactionClosureSentEventQueueClient,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Invalidate cache after closePaymentV2 with outcome OK or KO or generic error

<!--- Describe your changes in detail -->

#### Motivation and Context
After invoking the node to execute closePaymentV2, in case of OK, KO outcome or generic error we need to invalidate the cache for the rptId handled by the transaction. This is to delegate to the node the management of a possible further attempt of the user.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
The tests were performed with pagopa-ecommerce-local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.