### PR TITLE
[CHK-1399] pass idcart in activateV2

### DIFF
--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -351,6 +351,10 @@ components:
           type: string
           pattern: (?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])
           example : mario.rossi@gmail.it
+        idCart:
+          description: Cart identifier provided by creditor institution
+          type: string
+          example: idCartFromCreditorInstitution
       required:
         - paymentNotices
         - email
@@ -405,6 +409,10 @@ components:
         authToken:
           description: authorization token
           type: string
+        idCart:
+          description: Cart identifier provided by creditor institution
+          type: string
+          example: idCartFromCreditorInstitution
       required:
         - transactionId
         - amountTotal

--- a/api-tests/pagoPA-eCommerce.postman_collection.json
+++ b/api-tests/pagoPA-eCommerce.postman_collection.json
@@ -34,7 +34,35 @@
 			"response": []
 		},
 		{
-			"name": "get tramsaction info",
+			"name": "new transaction",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"rptId\": \"77777777777302016723749670001\",\n    \"email\": \"test@example.com\",\n    \"idCart\": \"idCartTest\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/transactions",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"transactions"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get transaction info",
 			"request": {
 				"method": "GET",
 				"header": [],

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pagopa-ecommerce-transactions-service
 description: Microservice that handles transactions lifecycle and workflow in ecommerce pagoPA
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: 0.12.1
 dependencies:
   - name: microservice-chart

--- a/pom.xml
+++ b/pom.xml
@@ -401,8 +401,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-1397-save-idCart-common</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.9.3</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.10.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
     </properties>
     <dependencies>
@@ -401,8 +401,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-1397-save-idCart-common</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -84,9 +84,10 @@ public class TransactionActivateHandler
         final boolean multiplePaymentNotices = paymentNotices.size() > 1;
 
         log.info(
-                "Nodo parallel processed requests : [{}]. Multiple payment notices: [{}]",
+                "Nodo parallel processed requests : [{}]. Multiple payment notices: [{}]. Id cart: [{}]",
                 nodoParallelRequests,
-                multiplePaymentNotices
+                multiplePaymentNotices,
+                Optional.ofNullable(newTransactionRequestDto.getIdCart()).orElse("id cart not found")
         );
         return Mono.defer(
                 () -> Flux.fromIterable(paymentNotices)
@@ -178,7 +179,8 @@ public class TransactionActivateHandler
                                                                     idempotencyKey,
                                                                     paymentNotice.getAmount(),
                                                                     transactionId,
-                                                                    paymentTokenTimeout
+                                                                    paymentTokenTimeout,
+                                                                    newTransactionRequestDto.getIdCart()
                                                             )
                                                             .doOnSuccess(
                                                                     p -> log.info(
@@ -216,7 +218,8 @@ public class TransactionActivateHandler
                                                             paymentRequestsInfo,
                                                             transactionId,
                                                             newTransactionRequestDto.getEmail(),
-                                                            command.getClientId()
+                                                            command.getClientId(),
+                                                            newTransactionRequestDto.getIdCart()
                                                     ),
                                                     authToken
                                             )
@@ -244,7 +247,8 @@ public class TransactionActivateHandler
                                                                          List<PaymentRequestInfo> paymentRequestsInfo,
                                                                          String transactionId,
                                                                          String email,
-                                                                         Transaction.ClientId clientId
+                                                                         Transaction.ClientId clientId,
+                                                                         String idCart
     ) {
         List<PaymentNotice> paymentNotices = toPaymentNoticeList(paymentRequestsInfo);
         Mono<TransactionActivatedData> data = confidentialMailUtils.toConfidential(email).map(
@@ -253,7 +257,8 @@ public class TransactionActivateHandler
                         paymentNotices,
                         null,
                         null,
-                        clientId
+                        clientId,
+                        idCart
                 )
         );
 

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -56,7 +56,8 @@ public class AuthorizationUpdateProjectionHandler
                                 null,
                                 null,
                                 ZonedDateTime.parse(transactionDocument.getCreationDate()),
-                                transactionDocument.getClientId()
+                                transactionDocument.getClientId(),
+                                transactionDocument.getIdCart()
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
@@ -50,6 +50,7 @@ public class TransactionsActivationProjectionHandler
         String faultCode = event.getData().getFaultCode();
         String faultCodeString = event.getData().getFaultCodeString();
         ClientId clientId = event.getData().getClientId();
+        String idCart = event.getData().getIdCart();
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
@@ -57,7 +58,8 @@ public class TransactionsActivationProjectionHandler
                 email,
                 faultCode,
                 faultCodeString,
-                clientId
+                clientId,
+                idCart
         );
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v1.Transaction

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -359,7 +359,8 @@ public class TransactionsService {
                                     transactionDocument.getEmail(),
                                     null,
                                     null,
-                                    transactionDocument.getClientId()
+                                    transactionDocument.getClientId(),
+                                    transactionDocument.getIdCart()
                             );
 
                             AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -622,7 +623,8 @@ public class TransactionsService {
                                     transactionDocument.getEmail(),
                                     null,
                                     null,
-                                    transactionDocument.getClientId()
+                                    transactionDocument.getClientId(),
+                                    transactionDocument.getIdCart()
                             );
                             AddUserReceiptData addUserReceiptData = new AddUserReceiptData(
                                     transaction,

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.security.SecureRandom;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -37,7 +38,8 @@ public class NodoOperations {
                                                            IdempotencyKey idempotencyKey,
                                                            Integer amount,
                                                            String transactionId,
-                                                           Integer paymentTokenTimeout
+                                                           Integer paymentTokenTimeout,
+                                                           String idCart
     ) {
 
         final BigDecimal amountAsBigDecimal = BigDecimal.valueOf(amount.doubleValue() / 100)
@@ -48,7 +50,8 @@ public class NodoOperations {
                 amountAsBigDecimal,
                 idempotencyKey.rawValue(),
                 transactionId,
-                paymentTokenTimeout
+                paymentTokenTimeout,
+                idCart
         );
     }
 
@@ -57,7 +60,8 @@ public class NodoOperations {
                                                                         BigDecimal amount,
                                                                         String idempotencyKey,
                                                                         String transactionId,
-                                                                        Integer paymentTokenTimeout
+                                                                        Integer paymentTokenTimeout,
+                                                                        String idCart
     ) {
         CtQrCode qrCode = new CtQrCode();
         qrCode.setFiscalCode(rptId.getFiscalCode());
@@ -69,6 +73,7 @@ public class NodoOperations {
         // multiply paymentTokenTimeout by 1000 because on ecommerce it is represented
         // in seconds
         request.setExpirationTime(BigInteger.valueOf(paymentTokenTimeout).multiply(BigInteger.valueOf(1000)));
+        request.setPaymentNote(idCart);
         // TODO Maybe here more values (all optional) can be passed such as Touchpoint
         // and PaymentMethod
         return nodeForPspClient
@@ -76,9 +81,10 @@ public class NodoOperations {
                 .flatMap(
                         activatePaymentNoticeV2Response -> {
                             log.info(
-                                    "Nodo activation for NM3 payment. Transaction id: [{}] RPT id: [{}] response outcome: [{}]",
+                                    "Nodo activation for NM3 payment. Transaction id: [{}] RPT id: [{}] idCart: [{}] response outcome: [{}]",
                                     transactionId,
                                     rptId,
+                                    Optional.ofNullable(idCart).orElse("idCart not present"),
                                     activatePaymentNoticeV2Response.getOutcome()
                             );
                             if (StOutcome.OK.value().equals(activatePaymentNoticeV2Response.getOutcome().value())) {

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -96,7 +96,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -147,7 +148,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -234,7 +236,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -312,7 +315,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -406,7 +410,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .detailType("card")
@@ -503,7 +508,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -590,7 +596,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 "faultCode",
                 "faultCodeString",
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -659,7 +666,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -743,7 +751,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -833,7 +842,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -931,7 +941,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -1009,7 +1020,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -1093,7 +1105,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -1185,7 +1198,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -1237,7 +1251,8 @@ class PaymentGatewayClientTest {
                 TransactionTestUtils.EMAIL,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -310,7 +310,7 @@ class TransactionInitializerHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRepository.findById(rptId))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
-        Mockito.when(nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any()))
+        Mockito.when(nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.error(new InvalidNodoResponseException("Invalid payment token received")));
         ReflectionTestUtils.setField(handler, "nodoParallelRequests", 5);
         /* run test */
@@ -378,7 +378,7 @@ class TransactionInitializerHandlerTest {
         Mockito.when(paymentRequestInfoRepository.save(any(PaymentRequestInfo.class)))
                 .thenReturn(paymentRequestInfoBeforeActivation);
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any())
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoAfterActivation));
         Mockito.when(jwtTokenUtils.generateToken(any()))
@@ -451,7 +451,7 @@ class TransactionInitializerHandlerTest {
         Mockito.when(paymentRequestInfoRepository.save(any(PaymentRequestInfo.class)))
                 .thenReturn(paymentRequestInfoActivation);
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any())
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoActivation));
         Mockito.when(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
@@ -69,7 +69,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         TransactionAmount amount = new TransactionAmount(100);
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
-
+        String idCart = "idCart";
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -87,7 +87,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -143,7 +144,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         TransactionAmount amount = new TransactionAmount(100);
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
-
+        String idCart = "idCart";
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -161,7 +162,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 null,
                 null,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -219,6 +221,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
 
         TransactionActivated transaction = new TransactionActivated(
@@ -238,7 +241,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -290,6 +294,7 @@ class TransactionRequestAuthorizizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
 
         TransactionActivated transaction = new TransactionActivated(
@@ -309,7 +314,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -160,6 +160,7 @@ class TransactionSendClosureHandlerTest {
 
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 PaymentNotices.stream().map(
@@ -183,7 +184,8 @@ class TransactionSendClosureHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                Transaction.ClientId.CHECKOUT
+                Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -208,7 +210,8 @@ class TransactionSendClosureHandlerTest {
                         transaction.getTransactionActivatedData().getPaymentNotices(),
                         faultCode,
                         faultCodeString,
-                        it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                        it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -266,6 +269,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -284,7 +288,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -421,6 +426,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -439,7 +445,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -576,6 +583,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -594,7 +602,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -731,6 +740,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -749,7 +759,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -898,6 +909,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -916,7 +928,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -1069,6 +1082,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -1087,7 +1101,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -1250,6 +1265,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -1268,7 +1284,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -1428,6 +1445,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -1446,7 +1464,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -1606,6 +1625,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> PaymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -1624,7 +1644,8 @@ class TransactionSendClosureHandlerTest {
                         PaymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 
@@ -1775,6 +1796,7 @@ class TransactionSendClosureHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         List<it.pagopa.ecommerce.commons.documents.v1.PaymentNotice> paymentNotices = List.of(
                 new it.pagopa.ecommerce.commons.documents.v1.PaymentNotice(
                         paymentToken.value(),
@@ -1793,7 +1815,8 @@ class TransactionSendClosureHandlerTest {
                         paymentNotices,
                         faultCode,
                         faultCodeString,
-                        Transaction.ClientId.CHECKOUT
+                        Transaction.ClientId.CHECKOUT,
+                        idCart
                 )
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -93,6 +93,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
+        String idCart = "idCart";
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
@@ -109,7 +110,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
@@ -74,6 +74,7 @@ class TransactionsActivationProjectionHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
+        String idCart = "idCart";
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
 
         TransactionActivated transaction = new TransactionActivated(
@@ -98,7 +99,8 @@ class TransactionsActivationProjectionHandlerTest {
                 email,
                 faultCode,
                 faultCodeString,
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v1.Transaction

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -29,6 +29,7 @@ class TransactionDocumentTest {
         String TEST_PAFISCALCODE = "77777777777";
         String TEST_RPTID = TEST_PAFISCALCODE + "302016723749670035";
         String TEST_DESC = "";
+        String TEST_CART = "TEST_CART";
         ZonedDateTime TEST_TIME = ZonedDateTime.now();
         Confidential<Email> CONFIDENTIAL_TEST_EMAIL = TransactionTestUtils.EMAIL;
         int TEST_AMOUNT = 1;
@@ -62,7 +63,8 @@ class TransactionDocumentTest {
                 CONFIDENTIAL_TEST_EMAIL,
                 TEST_STATUS,
                 Transaction.ClientId.CHECKOUT,
-                TEST_TIME.toString()
+                TEST_TIME.toString(),
+                TEST_CART
         );
 
         Transaction sameTransaction = new Transaction(
@@ -81,7 +83,8 @@ class TransactionDocumentTest {
                 CONFIDENTIAL_TEST_EMAIL,
                 TEST_STATUS,
                 Transaction.ClientId.CHECKOUT,
-                TEST_TIME.toString()
+                TEST_TIME.toString(),
+                TEST_CART
         );
 
         // Different transaction (creation date)
@@ -101,7 +104,8 @@ class TransactionDocumentTest {
                 CONFIDENTIAL_TEST_EMAIL,
                 TEST_STATUS,
                 Transaction.ClientId.CHECKOUT,
-                ZonedDateTime.now().toString()
+                ZonedDateTime.now().toString(),
+                TEST_CART
         );
         it.pagopa.ecommerce.commons.documents.v1.PaymentNotice paymentNotice = new PaymentNotice(
                 TEST_TOKEN,
@@ -140,6 +144,7 @@ class TransactionDocumentTest {
         String faultCode = "faultCode";
         String faultCodeString = "faultCodeString";
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
+        String idCart = "idCart";
 
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
@@ -156,7 +161,8 @@ class TransactionDocumentTest {
                 email,
                 faultCode,
                 faultCodeString,
-                Transaction.ClientId.CHECKOUT
+                Transaction.ClientId.CHECKOUT,
+                idCart
         );
 
         Transaction transactionDocument = Transaction.from(transaction);

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -51,7 +51,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 transaction.getEmail(),
                 TransactionStatusDto.AUTHORIZATION_COMPLETED,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate().toString()
+                transaction.getCreationDate().toString(),
+                transaction.getTransactionActivatedData().getIdCart()
         );
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
@@ -72,7 +73,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 null,
                 null,
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
-                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                transaction.getTransactionActivatedData().getIdCart()
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/projections/handlers/CancellationRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/CancellationRequestProjectionHandlerTests.java
@@ -44,7 +44,8 @@ public class CancellationRequestProjectionHandlerTests {
                 transaction.getEmail(),
                 TransactionStatusDto.CANCELLATION_REQUESTED,
                 Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate()
+                transaction.getCreationDate(),
+                transaction.getIdCart()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
@@ -43,7 +43,8 @@ class ClosureErrorProjectionHandlerTest {
                 transaction.getEmail(),
                 TransactionStatusDto.REFUND_REQUESTED,
                 Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate()
+                transaction.getCreationDate(),
+                transaction.getIdCart()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandlerTests.java
@@ -44,7 +44,8 @@ class ClosureSendProjectionHandlerTests {
                 transaction.getEmail(),
                 TransactionStatusDto.CLOSED,
                 Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate()
+                transaction.getCreationDate(),
+                transaction.getIdCart()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))
@@ -72,7 +73,8 @@ class ClosureSendProjectionHandlerTests {
                 transaction.getEmail(),
                 TransactionStatusDto.UNAUTHORIZED,
                 Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate()
+                transaction.getCreationDate(),
+                transaction.getIdCart()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
@@ -39,7 +39,8 @@ class TransactionUserReceiptProjectionHandlerTest {
                 transaction.getEmail(),
                 TransactionStatusDto.NOTIFICATION_REQUESTED,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate().toString()
+                transaction.getCreationDate().toString(),
+                transaction.getTransactionActivatedData().getIdCart()
         );
 
         TransactionUserReceiptRequestedEvent event = TransactionTestUtils
@@ -85,7 +86,8 @@ class TransactionUserReceiptProjectionHandlerTest {
                 transaction.getEmail(),
                 TransactionStatusDto.NOTIFICATION_REQUESTED,
                 transaction.getClientId(),
-                transaction.getCreationDate().toString()
+                transaction.getCreationDate().toString(),
+                transaction.getTransactionActivatedData().getIdCart()
         );
 
         TransactionUserReceiptRequestedEvent event = TransactionTestUtils

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
@@ -104,7 +104,8 @@ class TransactionServiceTest {
                 TransactionTestUtils.EMAIL,
                 "faultCode",
                 "faultCodeString",
-                Transaction.ClientId.CHECKOUT
+                Transaction.ClientId.CHECKOUT,
+                "idCart"
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -320,7 +320,8 @@ public class TransactionServiceTests {
                 transactionDocument.getEmail(),
                 "faultCode",
                 "faultCodeString",
-                Transaction.ClientId.CHECKOUT
+                Transaction.ClientId.CHECKOUT,
+                transactionDocument.getIdCart()
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -362,7 +363,8 @@ public class TransactionServiceTests {
                 transactionDocument.getEmail(),
                 it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.CLOSED,
                 Transaction.ClientId.CHECKOUT,
-                ZonedDateTime.now().toString()
+                ZonedDateTime.now().toString(),
+                transactionDocument.getIdCart()
         );
 
         /* preconditions */
@@ -1007,7 +1009,8 @@ public class TransactionServiceTests {
                 transactionDocument.getEmail(),
                 "faultCode",
                 "faultCodeString",
-                Transaction.ClientId.CHECKOUT
+                Transaction.ClientId.CHECKOUT,
+                transactionDocument.getIdCart()
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -1049,7 +1052,8 @@ public class TransactionServiceTests {
                 transactionDocument.getEmail(),
                 it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.CLOSURE_ERROR,
                 Transaction.ClientId.CHECKOUT,
-                ZonedDateTime.now().toString()
+                ZonedDateTime.now().toString(),
+                transactionDocument.getIdCart()
         );
 
         /* preconditions */

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -96,9 +96,9 @@ class NodoOperationsTest {
         Mockito.when(nodeForPspClient.activatePaymentNoticeV2(Mockito.any()))
                 .thenReturn(Mono.just(activatePaymentRes));
         Mockito.when(
-                        objectFactoryNodeForPsp
-                                .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote().equals(idCart)))
-                )
+                objectFactoryNodeForPsp
+                        .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote().equals(idCart)))
+        )
                 .thenAnswer(args -> objectFactoryUtil.createActivatePaymentNoticeV2Request(args.getArgument(0)));
         Mockito.when(nodoConfig.baseActivatePaymentNoticeV2Request()).thenReturn(new ActivatePaymentNoticeV2Request());
 
@@ -180,9 +180,9 @@ class NodoOperationsTest {
         Mockito.when(nodeForPspClient.activatePaymentNoticeV2(Mockito.any()))
                 .thenReturn(Mono.just(activatePaymentRes));
         Mockito.when(
-                        objectFactoryNodeForPsp
-                                .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote() == null))
-                )
+                objectFactoryNodeForPsp
+                        .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote() == null))
+        )
                 .thenAnswer(args -> objectFactoryUtil.createActivatePaymentNoticeV2Request(args.getArgument(0)));
         Mockito.when(nodoConfig.baseActivatePaymentNoticeV2Request()).thenReturn(new ActivatePaymentNoticeV2Request());
 

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -129,7 +129,6 @@ class NodoOperationsTest {
         String paTaxCode = "77777777777";
         String description = "Description";
         int amount = 1000;
-        String idCart = null;
         it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
         BigDecimal amountBigDec = BigDecimal.valueOf(amount);
         String fiscalCode = "77777777777";
@@ -188,7 +187,7 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        null
                 )
                 .block();
 

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -47,7 +47,7 @@ class NodoOperationsTest {
         String paTaxCode = "77777777777";
         String description = "Description";
         int amount = 1000;
-
+        String idCart = "idCart";
         it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
         BigDecimal amountBigDec = BigDecimal.valueOf(amount);
         String fiscalCode = "77777777777";
@@ -105,7 +105,90 @@ class NodoOperationsTest {
                         idempotencyKey,
                         amount,
                         transactionId,
-                        900
+                        900,
+                        idCart
+                )
+                .block();
+
+        /* asserts */
+        Mockito.verify(nodeForPspClient, Mockito.times(1)).activatePaymentNoticeV2(Mockito.any());
+
+        assertEquals(rptId, response.id());
+        assertEquals(paymentToken, response.paymentToken());
+        assertEquals(description, response.description());
+        assertEquals(idempotencyKey, response.idempotencyKey());
+        assertEquals(paTaxCode, response.paFiscalCode());
+    }
+
+    @Test
+    void shouldActiveNM3PaymentRequestWithIdCartNull() {
+        RptId rptId = new RptId("77777777777302016723749670035");
+        IdempotencyKey idempotencyKey = new IdempotencyKey("32009090901", "aabbccddee");
+        String paymentToken = UUID.randomUUID().toString();
+        String transactionId = UUID.randomUUID().toString();
+        String paTaxCode = "77777777777";
+        String description = "Description";
+        int amount = 1000;
+        String idCart = null;
+        it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
+        BigDecimal amountBigDec = BigDecimal.valueOf(amount);
+        String fiscalCode = "77777777777";
+        String paymentNotice = "302000100000009424";
+        CtTransferListPSPV2 ctTransferListPSPV2 = objectFactoryUtil.createCtTransferListPSPV2();
+        CtTransferPSPV2 ctTransferPSPV2 = objectFactoryUtil.createCtTransferPSPV2();
+        ctTransferPSPV2.setIdTransfer(1);
+        ctTransferPSPV2.setFiscalCodePA(fiscalCode);
+        ctTransferPSPV2.setTransferAmount(BigDecimal.valueOf(amount));
+        ctTransferPSPV2.setIBAN("It41B0000000000000000899876543234567");
+        ctTransferPSPV2.setRemittanceInformation("test1");
+        byte[] testByte = new byte[] {
+                0,
+                1,
+                2,
+                3
+        };
+        CtRichiestaMarcaDaBollo ctRichiestaMarcaDaBollo = objectFactoryUtil.createCtRichiestaMarcaDaBollo();
+        ctRichiestaMarcaDaBollo.setTipoBollo("Tipo Bollo");
+        ctRichiestaMarcaDaBollo.setProvinciaResidenza("RM");
+        ctRichiestaMarcaDaBollo.setHashDocumento(testByte);
+        CtTransferPSPV2 ctTransferPSPV2_1 = objectFactoryUtil.createCtTransferPSPV2();
+        ctTransferPSPV2_1.setIdTransfer(1);
+        ctTransferPSPV2_1.setFiscalCodePA(fiscalCode);
+        ctTransferPSPV2_1.setTransferAmount(BigDecimal.valueOf(amount));
+        ctTransferPSPV2_1.setRichiestaMarcaDaBollo(ctRichiestaMarcaDaBollo);
+        ctTransferPSPV2_1.setRemittanceInformation("test1");
+        ctTransferListPSPV2.getTransfer().add(ctTransferPSPV2);
+        ctTransferListPSPV2.getTransfer().add(ctTransferPSPV2_1);
+        ActivatePaymentNoticeV2Request activatePaymentReq = objectFactoryUtil.createActivatePaymentNoticeV2Request();
+        CtQrCode qrCode = new CtQrCode();
+        qrCode.setFiscalCode(fiscalCode);
+        qrCode.setNoticeNumber(paymentNotice);
+        activatePaymentReq.setAmount(amountBigDec);
+        activatePaymentReq.setQrCode(qrCode);
+
+        ActivatePaymentNoticeV2Response activatePaymentRes = objectFactoryUtil.createActivatePaymentNoticeV2Response();
+        activatePaymentRes.setPaymentToken(paymentToken);
+        activatePaymentRes.setFiscalCodePA(fiscalCode);
+        activatePaymentRes.setTotalAmount(amountBigDec);
+        activatePaymentRes.setPaymentDescription(description);
+        activatePaymentRes.setOutcome(StOutcome.OK);
+        activatePaymentRes.setTransferList(ctTransferListPSPV2);
+        /* preconditions */
+        Mockito.when(nodeForPspClient.activatePaymentNoticeV2(Mockito.any()))
+                .thenReturn(Mono.just(activatePaymentRes));
+        Mockito.when(objectFactoryNodeForPsp.createActivatePaymentNoticeV2Request(Mockito.any()))
+                .thenReturn(objectFactoryUtil.createActivatePaymentNoticeV2Request(activatePaymentReq));
+        Mockito.when(nodoConfig.baseActivatePaymentNoticeV2Request()).thenReturn(new ActivatePaymentNoticeV2Request());
+
+        /* test */
+        PaymentRequestInfo response = nodoOperations
+                .activatePaymentRequest(
+                        rptId,
+                        idempotencyKey,
+                        amount,
+                        transactionId,
+                        900,
+                        idCart
                 )
                 .block();
 
@@ -125,7 +208,7 @@ class NodoOperationsTest {
         IdempotencyKey idempotencyKey = new IdempotencyKey("32009090901", "aabbccddee");
         String transactionId = UUID.randomUUID().toString();
         int amount = 1000;
-
+        String idCart = "idCart";
         it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
         BigDecimal amountBigDec = BigDecimal.valueOf(amount);
         String fiscalCode = "77777777777";
@@ -158,7 +241,8 @@ class NodoOperationsTest {
                         idempotencyKey,
                         amount,
                         transactionId,
-                        900
+                        900,
+                        idCart
                 );
 
         Assert.assertThrows(
@@ -174,7 +258,7 @@ class NodoOperationsTest {
         String transactionId = UUID.randomUUID().toString();
         String description = "Description";
         int amount = 1000;
-
+        String idCart = "idCart";
         it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
         BigDecimal amountBigDec = BigDecimal.valueOf(amount);
         String fiscalCode = "77777777777";
@@ -208,7 +292,8 @@ class NodoOperationsTest {
                         idempotencyKey,
                         amount,
                         transactionId,
-                        900
+                        900,
+                        idCart
                 );
 
         InvalidNodoResponseException exception = Assert.assertThrows(
@@ -244,7 +329,7 @@ class NodoOperationsTest {
         String paTaxCode = "77777777777";
         String description = "Description";
         Integer amount = 1234;
-
+        String idCart = "idCart";
         it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
 
         BigDecimal amountBigDec = BigDecimal.valueOf(amount.doubleValue() / 100)
@@ -283,7 +368,8 @@ class NodoOperationsTest {
                         idempotencyKey,
                         amount,
                         transactionId,
-                        900
+                        900,
+                        idCart
                 )
                 .block();
 

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -19,6 +19,7 @@ import java.math.RoundingMode;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
 
 @ExtendWith(MockitoExtension.class)
 class NodoOperationsTest {
@@ -94,8 +95,11 @@ class NodoOperationsTest {
         /* preconditions */
         Mockito.when(nodeForPspClient.activatePaymentNoticeV2(Mockito.any()))
                 .thenReturn(Mono.just(activatePaymentRes));
-        Mockito.when(objectFactoryNodeForPsp.createActivatePaymentNoticeV2Request(Mockito.any()))
-                .thenReturn(objectFactoryUtil.createActivatePaymentNoticeV2Request(activatePaymentReq));
+        Mockito.when(
+                        objectFactoryNodeForPsp
+                                .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote().equals(idCart)))
+                )
+                .thenAnswer(args -> objectFactoryUtil.createActivatePaymentNoticeV2Request(args.getArgument(0)));
         Mockito.when(nodoConfig.baseActivatePaymentNoticeV2Request()).thenReturn(new ActivatePaymentNoticeV2Request());
 
         /* test */
@@ -175,8 +179,11 @@ class NodoOperationsTest {
         /* preconditions */
         Mockito.when(nodeForPspClient.activatePaymentNoticeV2(Mockito.any()))
                 .thenReturn(Mono.just(activatePaymentRes));
-        Mockito.when(objectFactoryNodeForPsp.createActivatePaymentNoticeV2Request(Mockito.any()))
-                .thenReturn(objectFactoryUtil.createActivatePaymentNoticeV2Request(activatePaymentReq));
+        Mockito.when(
+                        objectFactoryNodeForPsp
+                                .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote() == null))
+                )
+                .thenAnswer(args -> objectFactoryUtil.createActivatePaymentNoticeV2Request(args.getArgument(0)));
         Mockito.when(nodoConfig.baseActivatePaymentNoticeV2Request()).thenReturn(new ActivatePaymentNoticeV2Request());
 
         /* test */


### PR DESCRIPTION
Pass id cart to activate and save it in transaction view and event store
#### List of Changes

Added new field `idcart` in newTransaction request body
Save it in transaction document and transaction activated event
Pass it to the activate nodo call in the payment note field
Updated junit test
Added postman test

#### Motivation and Context

This field is required to track idcart passed from creditor institution when post carts is invoked

#### How Has This Been Tested?

Test were performed locally

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.