### PR TITLE
fix: additionalPaymentInformations.timestampOperation format

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -32,6 +32,8 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 @Component
@@ -154,9 +156,12 @@ public class TransactionSendClosureHandler implements
                                             "fee",
                                             fee.toString(),
                                             "timestampOperation",
-                                            OffsetDateTime.now().toString(), // FIXME Pass
-                                                                             // the timestamp of the authorization
-                                                                             // result
+                                            // FIXME Pass the timestamp of the authorization result
+                                            // bug CHK-1410: date formatted to yyyy-MM-ddTHH:mm:ss truncating millis
+                                            OffsetDateTime.now()
+                                                    .toLocalDateTime()
+                                                    .truncatedTo(ChronoUnit.SECONDS)
+                                                    .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                                             "totalAmount",
                                             totalAmount.toString()
                                     )
@@ -410,4 +415,5 @@ public class TransactionSendClosureHandler implements
             );
         }
     }
+
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static it.pagopa.transactions.commands.handlers.TransactionSendClosureHandler.ECOMMERCE_RRN;
-import static it.pagopa.transactions.commands.handlers.TransactionSendClosureHandler.TIPO_VERSAMENTO_CP;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 
@@ -98,10 +97,14 @@ class TransactionSendClosureHandlerTest {
 
     private static MockedStatic<OffsetDateTime> offsetDateTimeMockedStatic;
 
+    private static final String expectedOperationTimestamp = "2023-01-01T01:02:03";
+    private static final OffsetDateTime operationTimestamp = OffsetDateTime.parse(expectedOperationTimestamp.concat("+01:00"));
+
+
     @BeforeAll
     static void init() {
         offsetDateTimeMockedStatic = Mockito.mockStatic(OffsetDateTime.class);
-        offsetDateTimeMockedStatic.when(OffsetDateTime::now).thenReturn(OffsetDateTime.MIN);
+        offsetDateTimeMockedStatic.when(OffsetDateTime::now).thenReturn(operationTimestamp);
     }
 
     @AfterAll
@@ -347,7 +350,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// 2023-04-03T15:42:22
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -502,7 +505,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(),
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -657,7 +660,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -811,7 +814,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(),
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -975,7 +978,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(),
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1146,7 +1149,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1327,7 +1330,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1508,7 +1511,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1686,7 +1689,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1855,7 +1858,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1979,7 +1982,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -2105,7 +2108,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -2241,7 +2244,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(), // 2023-04-03T15:42:22.826Z
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -2357,7 +2360,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                OffsetDateTime.now().toString(),
+                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -98,8 +98,8 @@ class TransactionSendClosureHandlerTest {
     private static MockedStatic<OffsetDateTime> offsetDateTimeMockedStatic;
 
     private static final String expectedOperationTimestamp = "2023-01-01T01:02:03";
-    private static final OffsetDateTime operationTimestamp = OffsetDateTime.parse(expectedOperationTimestamp.concat("+01:00"));
-
+    private static final OffsetDateTime operationTimestamp = OffsetDateTime
+            .parse(expectedOperationTimestamp.concat("+01:00"));
 
     @BeforeAll
     static void init() {
@@ -350,7 +350,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// 2023-04-03T15:42:22
+                                expectedOperationTimestamp, // 2023-04-03T15:42:22
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -505,7 +505,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -660,7 +660,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -814,7 +814,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -978,7 +978,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1149,7 +1149,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1330,7 +1330,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1511,7 +1511,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1689,7 +1689,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1858,7 +1858,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -1982,7 +1982,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -2108,7 +2108,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -2244,7 +2244,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
@@ -2360,7 +2360,7 @@ class TransactionSendClosureHandlerTest {
                                 "fee",
                                 EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()).toString(),
                                 "timestampOperation",
-                                expectedOperationTimestamp,// yyyy-MM-ddThh:mm:ss
+                                expectedOperationTimestamp, // yyyy-MM-ddThh:mm:ss
                                 "totalAmount",
                                 EuroUtils.euroCentsToEuro(
                                         ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Fix ClosePaymentRequest additionalInformations.timestampOperation date format to be formatted in `yyyy-MM-ddThh:mm:ss` format
#### Motivation and Context
Those modifications are needed to format `timestampOperation` closePayment field correctly
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.