### PR TITLE
CHK-1428-management-rrn

### DIFF
--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -536,23 +536,18 @@ components:
       type: object
       description: Request body for updating an authorization for a transaction
       properties:
-        authorizationResult:
-          $ref: '#/components/schemas/AuthorizationResult'
+        outcomeGateway:
+          type: object
+          anyOf:
+            - $ref: '#/components/schemas/OutcomeVposGateway'
+            - $ref: '#/components/schemas/OutcomeXpayGateway'
         timestampOperation:
           type: string
           format: date-time
           description: Payment timestamp
-        authorizationCode:
-          type: string
-          description: Payment gateway-specific authorization code related to the transaction
       required:
-        - authorizationResult
+        - outcomeGateway
         - timestampOperation
-        - authorizationCode
-      example:
-        authorizationResult: OK
-        timestampOperation: 2022-02-11T13:00:00+01:00
-        authorizationCode: auth-code
     AddUserReceiptRequest:
       type: object
       description: Request body for adding a user receipt to a transaction
@@ -971,6 +966,94 @@ components:
         - PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE
         - PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO
         - GENERIC_ERROR
+    OutcomeVposGateway:
+      type: object
+      properties:
+        outcome:
+          type: string
+          enum:
+            - OK
+            - KO
+        rrn:
+          type: string
+        authorizationCode:
+          type: string
+        errorCode:
+          type: string
+          description: error code received from Vpos - https://github.com/pagopa/pagopa-wisp2.0-pp-server/blob/ff0e8e3354fc11d296fe5547b9b00941ead64e96/pp-server/pp-dto/src/main/java/com/pagopa/utils/VposResultCodeEnum.java
+          enum:
+            - '00'
+            - '01'
+            - '02'
+            - '03'
+            - '04'
+            - '05'
+            - '06'
+            - '07'
+            - '08'
+            - '09'
+            - '10'
+            - '11'
+            - '12'
+            - '13'
+            - '16'
+            - '17'
+            - '20'
+            - '21'
+            - '25'
+            - '26'
+            - '35'
+            - '37'
+            - '38'
+            - '40'
+            - '41'
+            - '50'
+            - '51'
+            - '98'
+            - '99'
+      required:
+        - outcome
+    OutcomeXpayGateway:
+      type: object
+      properties:
+        outcome:
+          type: string
+          enum:
+            - OK
+            - KO
+        authorizationCode:
+          type: string
+        errorCode:
+          type: number
+          description: error code received from XPay - https://ecommerce.nexi.it/specifiche-tecniche/tabelleecodifiche/codicierroreapirestful.html
+          enum:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 7
+            - 8
+            - 9
+            - 12
+            - 13
+            - 14
+            - 15
+            - 16
+            - 17
+            - 18
+            - 19
+            - 20
+            - 21
+            - 22
+            - 50
+            - 96
+            - 97
+            - 98
+            - 99
+            - 100
+      required:
+        - outcome
   requestBodies:
     NewTransactionRequest:
       required: true

--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -538,9 +538,14 @@ components:
       properties:
         outcomeGateway:
           type: object
-          anyOf:
+          oneOf:
             - $ref: '#/components/schemas/OutcomeVposGateway'
             - $ref: '#/components/schemas/OutcomeXpayGateway'
+          discriminator:
+            propertyName: paymentGatewayType
+            mapping:
+              xpay: "#/components/schemas/OutcomeXpayGateway"
+              vpos: "#/components/schemas/OutcomeVposGateway"
         timestampOperation:
           type: string
           format: date-time
@@ -969,6 +974,8 @@ components:
     OutcomeVposGateway:
       type: object
       properties:
+        paymentGatewayType:
+          type: string
         outcome:
           type: string
           enum:
@@ -1012,10 +1019,13 @@ components:
             - '98'
             - '99'
       required:
+        - paymentGatewayType
         - outcome
     OutcomeXpayGateway:
       type: object
       properties:
+        paymentGatewayType:
+          type: string
         outcome:
           type: string
           enum:
@@ -1053,6 +1063,7 @@ components:
             - 99
             - 100
       required:
+        - paymentGatewayType
         - outcome
   requestBodies:
     NewTransactionRequest:

--- a/api-spec/transactions-api.yaml
+++ b/api-spec/transactions-api.yaml
@@ -544,8 +544,8 @@ components:
           discriminator:
             propertyName: paymentGatewayType
             mapping:
-              xpay: "#/components/schemas/OutcomeXpayGateway"
-              vpos: "#/components/schemas/OutcomeVposGateway"
+              XPAY: "#/components/schemas/OutcomeXpayGateway"
+              VPOS: "#/components/schemas/OutcomeVposGateway"
         timestampOperation:
           type: string
           format: date-time
@@ -976,6 +976,7 @@ components:
       properties:
         paymentGatewayType:
           type: string
+          example: 'VPOS'
         outcome:
           type: string
           enum:
@@ -1021,11 +1022,13 @@ components:
       required:
         - paymentGatewayType
         - outcome
+        - rrn
     OutcomeXpayGateway:
       type: object
       properties:
         paymentGatewayType:
           type: string
+          example: 'XPAY'
         outcome:
           type: string
           enum:

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.11.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.12.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
     </properties>
     <dependencies>
@@ -401,8 +401,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-1427-save-rrn-information</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -401,8 +401,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-1427-save-rrn-information</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -150,7 +150,7 @@ public class TransactionSendClosureHandler implements
                                             transactionAuthorizationCompletedData.getAuthorizationResultDto()
                                                     .toString(),
                                             "authorizationCode",
-                                            updateAuthorizationRequestDto.getAuthorizationCode(),
+                                            updateAuthorizationRequestDto.getOutcomeGateway().getAuthorizationCode(),
                                             "rrn",
                                             ECOMMERCE_RRN,
                                             "fee",

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -11,8 +11,6 @@ import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.repositories.PaymentRequestsInfoRepository;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
-import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
-import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.commands.TransactionClosureSendCommand;
@@ -119,7 +117,7 @@ public class TransactionSendClosureHandler implements
                 .flatMap(tx -> {
                     UpdateAuthorizationRequestDto updateAuthorizationRequestDto = command.getData()
                             .updateAuthorizationRequest();
-                    AuthRequestDataUtils.DataAuthRequest authRequestDataExtracted = authRequestDataUtils
+                    AuthRequestDataUtils.AuthRequestData authRequestDataExtracted = authRequestDataUtils
                             .extract(updateAuthorizationRequestDto);
                     TransactionAuthorizationRequestData transactionAuthorizationRequestData = tx
                             .getTransactionAuthorizationRequestData();
@@ -157,7 +155,7 @@ public class TransactionSendClosureHandler implements
                                             transactionAuthorizationCompletedData.getAuthorizationResultDto()
                                                     .toString(),
                                             "authorizationCode",
-                                            authRequestDataExtracted.authorizationCode,
+                                            authRequestDataExtracted.authorizationCode(),
                                             "rrn",
                                             ECOMMERCE_RRN,
                                             "fee",

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -117,8 +117,8 @@ public class TransactionSendClosureHandler implements
                 .flatMap(tx -> {
                     UpdateAuthorizationRequestDto updateAuthorizationRequestDto = command.getData()
                             .updateAuthorizationRequest();
-                    AuthRequestDataUtils.AuthRequestData authRequestDataExtracted = authRequestDataUtils
-                            .extract(updateAuthorizationRequestDto);
+                    AuthRequestDataUtils.AuthRequestData authRequestData = authRequestDataUtils
+                            .from(updateAuthorizationRequestDto);
                     TransactionAuthorizationRequestData transactionAuthorizationRequestData = tx
                             .getTransactionAuthorizationRequestData();
                     TransactionAuthorizationCompletedData transactionAuthorizationCompletedData = tx
@@ -155,7 +155,7 @@ public class TransactionSendClosureHandler implements
                                             transactionAuthorizationCompletedData.getAuthorizationResultDto()
                                                     .toString(),
                                             "authorizationCode",
-                                            authRequestDataExtracted.authorizationCode(),
+                                            authRequestData.authorizationCode(),
                                             "rrn",
                                             ECOMMERCE_RRN,
                                             "fee",

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
@@ -46,7 +46,7 @@ public class TransactionUpdateAuthorizationHandler
                 )
                 .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getTransactionId())));
         AuthRequestDataUtils.AuthRequestData authRequestDataExtracted = extractAuthRequestData
-                .extract(command.getData().updateAuthorizationRequest());
+                .from(command.getData().updateAuthorizationRequest());
         return transaction
                 .filter(
                         t -> t.getStatus() == TransactionStatusDto.AUTHORIZATION_REQUESTED

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
@@ -53,7 +53,9 @@ public class TransactionUpdateAuthorizationHandler
                         transactionWithRequestedAuthorization -> Tuples.of(
                                 transactionWithRequestedAuthorization,
                                 AuthorizationResultDto
-                                        .fromValue(updateAuthorizationRequest.getAuthorizationResult().toString())
+                                        .fromValue(
+                                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString()
+                                        )
                         )
                 )
                 .flatMap(args -> {
@@ -63,7 +65,7 @@ public class TransactionUpdateAuthorizationHandler
                             new TransactionAuthorizationCompletedEvent(
                                     transactionWithRequestedAuthorization.getTransactionId().value().toString(),
                                     new TransactionAuthorizationCompletedData(
-                                            updateAuthorizationRequest.getAuthorizationCode(),
+                                            updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                             authorizationResultDto
                                     )
                             )

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
@@ -66,6 +66,7 @@ public class TransactionUpdateAuthorizationHandler
                                     transactionWithRequestedAuthorization.getTransactionId().value().toString(),
                                     new TransactionAuthorizationCompletedData(
                                             updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                            updateAuthorizationRequest.getOutcomeGateway().getRrn(),
                                             authorizationResultDto
                                     )
                             )

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
@@ -45,7 +45,7 @@ public class TransactionUpdateAuthorizationHandler
                         )
                 )
                 .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getTransactionId())));
-        AuthRequestDataUtils.DataAuthRequest authRequestDataExtracted = extractAuthRequestData
+        AuthRequestDataUtils.AuthRequestData authRequestDataExtracted = extractAuthRequestData
                 .extract(command.getData().updateAuthorizationRequest());
         return transaction
                 .filter(
@@ -58,7 +58,7 @@ public class TransactionUpdateAuthorizationHandler
                                 transactionWithRequestedAuthorization,
                                 AuthorizationResultDto
                                         .fromValue(
-                                                authRequestDataExtracted.outcome
+                                                authRequestDataExtracted.outcome()
                                         )
                         )
                 )
@@ -69,8 +69,8 @@ public class TransactionUpdateAuthorizationHandler
                             new TransactionAuthorizationCompletedEvent(
                                     transactionWithRequestedAuthorization.getTransactionId().value().toString(),
                                     new TransactionAuthorizationCompletedData(
-                                            authRequestDataExtracted.authorizationCode,
-                                            authRequestDataExtracted.rrn,
+                                            authRequestDataExtracted.authorizationCode(),
+                                            authRequestDataExtracted.rrn(),
                                             authorizationResultDto
                                     )
                             )

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandler.java
@@ -67,7 +67,7 @@ public class TransactionUpdateAuthorizationHandler
                     AuthorizationResultDto authorizationResultDto = args.getT2();
                     return Mono.just(
                             new TransactionAuthorizationCompletedEvent(
-                                    transactionWithRequestedAuthorization.getTransactionId().value().toString(),
+                                    transactionWithRequestedAuthorization.getTransactionId().value(),
                                     new TransactionAuthorizationCompletedData(
                                             authRequestDataExtracted.authorizationCode(),
                                             authRequestDataExtracted.rrn(),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -26,6 +26,7 @@ public class AuthorizationUpdateProjectionHandler
                         Mono.error(new TransactionNotFoundException(data.getTransactionId()))
                 )
                 .flatMap(transactionDocument -> {
+                    transactionDocument.setRrn(data.getData().getRrn());
                     transactionDocument.setStatus(TransactionStatusDto.AUTHORIZATION_COMPLETED);
                     return transactionsViewRepository.save(transactionDocument);
                 })

--- a/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AuthRequestDataUtils {
 
-    @ValueObject
     public record AuthRequestData(
             String authorizationCode,
             String outcome,

--- a/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
@@ -1,10 +1,9 @@
 package it.pagopa.transactions.utils;
 
+import it.pagopa.ecommerce.commons.annotations.ValueObject;
 import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -12,25 +11,23 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AuthRequestDataUtils {
 
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class DataAuthRequest {
-        public String authorizationCode;
-        public String rrn;
-        public String outcome;
+    @ValueObject
+    public record AuthRequestData(
+            String authorizationCode,
+            String outcome,
+            String rrn
+    ) {
+
     }
 
-    public DataAuthRequest extract(UpdateAuthorizationRequestDto updateAuthorizationRequest) {
-        DataAuthRequest result = new DataAuthRequest();
+    public AuthRequestData extract(UpdateAuthorizationRequestDto updateAuthorizationRequest) {
+        AuthRequestData result = null;
         switch (updateAuthorizationRequest.getOutcomeGateway()) {
             case OutcomeVposGatewayDto t -> {
-                result.outcome = t.getOutcome().toString();
-                result.authorizationCode = t.getAuthorizationCode();
-                result.rrn = t.getRrn();
+                result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(),t.getRrn());
             }
             case OutcomeXpayGatewayDto t -> {
-                result.outcome = t.getOutcome().toString();
-                result.authorizationCode = t.getAuthorizationCode();
+                result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(), null);
             }
             default ->
                     throw new IllegalStateException("Unexpected value: " + updateAuthorizationRequest.getOutcomeGateway());

--- a/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
@@ -4,6 +4,7 @@ import it.pagopa.ecommerce.commons.annotations.ValueObject;
 import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
+import it.pagopa.transactions.exceptions.InvalidRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -20,8 +21,8 @@ public class AuthRequestDataUtils {
 
     }
 
-    public AuthRequestData extract(UpdateAuthorizationRequestDto updateAuthorizationRequest) {
-        AuthRequestData result = null;
+    public AuthRequestData from(UpdateAuthorizationRequestDto updateAuthorizationRequest) {
+        AuthRequestData result;
         switch (updateAuthorizationRequest.getOutcomeGateway()) {
             case OutcomeVposGatewayDto t -> {
                 result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(),t.getRrn());
@@ -30,7 +31,7 @@ public class AuthRequestDataUtils {
                 result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(), null);
             }
             default ->
-                    throw new IllegalStateException("Unexpected value: " + updateAuthorizationRequest.getOutcomeGateway());
+                    throw new InvalidRequestException("Unexpected value: " + updateAuthorizationRequest.getOutcomeGateway());
         }
 
         return result;

--- a/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
@@ -1,0 +1,41 @@
+package it.pagopa.transactions.utils;
+
+import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
+import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
+import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class AuthRequestDataUtils {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DataAuthRequest {
+        public String authorizationCode;
+        public String rrn;
+        public String outcome;
+    }
+
+    public DataAuthRequest extract(UpdateAuthorizationRequestDto updateAuthorizationRequest) {
+        DataAuthRequest result = new DataAuthRequest();
+        switch (updateAuthorizationRequest.getOutcomeGateway()) {
+            case OutcomeVposGatewayDto t -> {
+                result.outcome = t.getOutcome().toString();
+                result.authorizationCode = t.getAuthorizationCode();
+                result.rrn = t.getRrn();
+            }
+            case OutcomeXpayGatewayDto t -> {
+                result.outcome = t.getOutcome().toString();
+                result.authorizationCode = t.getAuthorizationCode();
+            }
+            default ->
+                    throw new IllegalStateException("Unexpected value: " + updateAuthorizationRequest.getOutcomeGateway());
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
@@ -4,14 +4,15 @@ import it.pagopa.ecommerce.commons.domain.v1.EmptyTransaction;
 import it.pagopa.ecommerce.commons.domain.v1.Transaction;
 import it.pagopa.ecommerce.commons.domain.v1.TransactionId;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
-import it.pagopa.generated.transactions.server.model.NewTransactionRequestDto;
-import it.pagopa.generated.transactions.server.model.PaymentNoticeInfoDto;
+import it.pagopa.generated.transactions.server.model.*;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple3;
+import reactor.util.function.Tuples;
 
 import java.util.Collections;
 import java.util.EnumMap;

--- a/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
@@ -11,8 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuple3;
-import reactor.util.function.Tuples;
 
 import java.util.Collections;
 import java.util.EnumMap;

--- a/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
@@ -87,8 +87,8 @@ public class TransactionsUtils {
     }
 
     public Mono<BaseTransaction> reduceEvents(TransactionId transactionId) {
-        return eventStoreRepository.findByTransactionId(transactionId.value().toString())
-                .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId.value().toString())))
+        return eventStoreRepository.findByTransactionId(transactionId.value())
+                .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId.value())))
                 .reduce(new EmptyTransaction(), Transaction::applyEvent)
                 .cast(BaseTransaction.class);
     }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -19,6 +19,8 @@ import it.pagopa.ecommerce.commons.repositories.PaymentRequestsInfoRepository;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
+import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
+import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.client.NodeForPspClient;
@@ -163,8 +165,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -291,15 +293,15 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
-                        "rrn",
+                        null,
                         AuthorizationResultDto.KO
                 )
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -350,9 +352,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -457,8 +461,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -509,9 +513,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -616,8 +622,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -668,9 +674,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -768,15 +776,15 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
-                        "rrn",
+                        null,
                         AuthorizationResultDto.OK
                 )
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -826,9 +834,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -946,8 +956,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -994,9 +1004,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1114,15 +1126,15 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
-                        "rrn",
+                        null,
                         AuthorizationResultDto.OK
                 )
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -1169,9 +1181,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1299,15 +1313,15 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
-                        null,
+                        "rrn",
                         AuthorizationResultDto.KO
                 )
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -1354,9 +1368,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1488,8 +1504,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -1539,9 +1555,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1670,8 +1688,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -1721,9 +1739,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1836,15 +1856,15 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
-                        "rrn",
+                        null,
                         AuthorizationResultDto.OK
                 )
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -1894,9 +1914,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1969,8 +1991,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -2021,9 +2043,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -2101,8 +2125,8 @@ class TransactionSendClosureHandlerTest {
                 .transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK);
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -2150,9 +2174,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -2237,8 +2263,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -2289,9 +2315,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -2359,8 +2387,8 @@ class TransactionSendClosureHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -2408,9 +2436,11 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -29,6 +29,7 @@ import it.pagopa.transactions.commands.data.ClosureSendData;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
 import it.pagopa.transactions.exceptions.BadGatewayException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
+import it.pagopa.transactions.utils.AuthRequestDataUtils;
 import it.pagopa.transactions.utils.EuroUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -71,6 +72,7 @@ class TransactionSendClosureHandlerTest {
             .mock(TransactionsEventStoreRepository.class);
 
     private final TransactionsUtils transactionsUtils = new TransactionsUtils(eventStoreRepository, "3020");
+    private final AuthRequestDataUtils authRequestDataUtils = new AuthRequestDataUtils();
     private final NodeForPspClient nodeForPspClient = Mockito.mock(NodeForPspClient.class);
 
     private final QueueAsyncClient transactionClosureSentEventQueueClient = Mockito.mock(QueueAsyncClient.class);
@@ -92,7 +94,8 @@ class TransactionSendClosureHandlerTest {
             SOFT_TIMEOUT_OFFSET,
             RETRY_TIMEOUT_INTERVAL,
             refundQueueAsyncClient,
-            transactionsUtils
+            transactionsUtils,
+            authRequestDataUtils
     );
 
     private final TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -20,6 +20,7 @@ import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentRequestV2Dto;
 import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
+import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.commands.TransactionClosureSendCommand;
 import it.pagopa.transactions.commands.data.ClosureSendData;
@@ -161,8 +162,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         ClosureSendData closureSendData = new ClosureSendData(
@@ -291,8 +295,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -341,9 +348,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -446,8 +453,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -496,9 +506,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -601,8 +611,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -651,9 +664,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -756,8 +769,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -805,9 +821,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -923,8 +939,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -969,9 +988,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1094,8 +1113,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -1140,9 +1162,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1275,8 +1297,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -1321,9 +1346,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1453,8 +1478,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -1502,9 +1530,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1631,8 +1659,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -1680,9 +1711,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1800,8 +1831,11 @@ class TransactionSendClosureHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -1849,9 +1883,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -1923,8 +1957,11 @@ class TransactionSendClosureHandlerTest {
                 .transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK);
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -1973,9 +2010,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -2052,8 +2089,11 @@ class TransactionSendClosureHandlerTest {
         TransactionAuthorizationCompletedEvent authorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK);
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -2099,9 +2139,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -2185,8 +2225,11 @@ class TransactionSendClosureHandlerTest {
                 .transactionAuthorizationCompletedEvent(AuthorizationResultDto.KO);
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -2235,9 +2278,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",
@@ -2304,8 +2347,11 @@ class TransactionSendClosureHandlerTest {
                 );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         Flux<TransactionEvent<Object>> events = ((Flux) Flux
@@ -2351,9 +2397,9 @@ class TransactionSendClosureHandlerTest {
                 .additionalPaymentInformations(
                         Map.of(
                                 "outcomePaymentGateway",
-                                updateAuthorizationRequest.getAuthorizationResult().toString(),
+                                updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString(),
                                 "authorizationCode",
-                                updateAuthorizationRequest.getAuthorizationCode(),
+                                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                                 "rrn",
                                 ECOMMERCE_RRN,
                                 "fee",

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -212,6 +212,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );
@@ -290,6 +291,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.KO
                 )
         );
@@ -448,6 +450,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        null,
                         AuthorizationResultDto.KO
                 )
         );
@@ -606,6 +609,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );
@@ -764,6 +768,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );
@@ -934,6 +939,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );
@@ -1108,6 +1114,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );
@@ -1292,6 +1299,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        null,
                         AuthorizationResultDto.KO
                 )
         );
@@ -1473,6 +1481,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        null,
                         AuthorizationResultDto.KO
                 )
         );
@@ -1654,6 +1663,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );
@@ -1826,6 +1836,7 @@ class TransactionSendClosureHandlerTest {
                 transactionId.value(),
                 new TransactionAuthorizationCompletedData(
                         "authorizationCode",
+                        "rrn",
                         AuthorizationResultDto.OK
                 )
         );

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -10,6 +10,7 @@ import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
+import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.commands.TransactionUpdateAuthorizationCommand;
 import it.pagopa.transactions.commands.data.UpdateAuthorizationStatusData;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
@@ -50,8 +51,11 @@ class TransactionUpdateAuthorizationHandlerTest {
         BaseTransaction transaction = TransactionTestUtils.reduceEvents(activatedEvent, authorizationRequestedEvent);
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         UpdateAuthorizationStatusData updateAuthorizationStatusData = new UpdateAuthorizationStatusData(
@@ -115,8 +119,11 @@ class TransactionUpdateAuthorizationHandlerTest {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         UpdateAuthorizationStatusData updateAuthorizationStatusData = new UpdateAuthorizationStatusData(
@@ -148,8 +155,11 @@ class TransactionUpdateAuthorizationHandlerTest {
         BaseTransaction transaction = TransactionTestUtils.reduceEvents(activatedEvent, authorizationRequestedEvent);
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(it.pagopa.generated.transactions.server.model.AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         UpdateAuthorizationStatusData updateAuthorizationStatusData = new UpdateAuthorizationStatusData(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -9,6 +9,7 @@ import it.pagopa.ecommerce.commons.domain.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
+import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.commands.TransactionUpdateAuthorizationCommand;
@@ -52,8 +53,8 @@ class TransactionUpdateAuthorizationHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -120,8 +121,8 @@ class TransactionUpdateAuthorizationHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -156,8 +157,8 @@ class TransactionUpdateAuthorizationHandlerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.KO)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -11,7 +11,6 @@ import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
-import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.commands.TransactionUpdateAuthorizationCommand;
 import it.pagopa.transactions.commands.data.UpdateAuthorizationStatusData;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
@@ -19,12 +18,8 @@ import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.utils.AuthRequestDataUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -16,12 +16,15 @@ import it.pagopa.transactions.commands.TransactionUpdateAuthorizationCommand;
 import it.pagopa.transactions.commands.data.UpdateAuthorizationStatusData;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
+import it.pagopa.transactions.utils.AuthRequestDataUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -34,12 +37,13 @@ import static org.mockito.ArgumentMatchers.argThat;
 @ExtendWith(MockitoExtension.class)
 class TransactionUpdateAuthorizationHandlerTest {
 
-    @InjectMocks
-    private TransactionUpdateAuthorizationHandler updateAuthorizationHandler;
-    @Mock
-    private TransactionsEventStoreRepository<TransactionAuthorizationCompletedData> transactionEventStoreRepository;
-
+    private TransactionsEventStoreRepository<TransactionAuthorizationCompletedData> transactionEventStoreRepository = Mockito
+            .mock(TransactionsEventStoreRepository.class);
     private TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
+    private TransactionUpdateAuthorizationHandler updateAuthorizationHandler = new TransactionUpdateAuthorizationHandler(
+            transactionEventStoreRepository,
+            new AuthRequestDataUtils()
+    );
 
     @Test
     void shouldSaveSuccessfulUpdate() {

--- a/src/test/java/it/pagopa/transactions/controllers/TransactionsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/TransactionsControllerTest.java
@@ -240,11 +240,10 @@ class TransactionsControllerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
-                )
-                .timestampOperation(OffsetDateTime.now());
+                ).timestampOperation(OffsetDateTime.now());
 
         /* preconditions */
         Mockito.when(transactionsService.updateTransactionAuthorization(paymentToken, updateAuthorizationRequest))
@@ -264,11 +263,10 @@ class TransactionsControllerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
-                )
-                .timestampOperation(OffsetDateTime.now());
+                ).timestampOperation(OffsetDateTime.now());
 
         /* preconditions */
         Mockito.when(transactionsService.updateTransactionAuthorization(paymentToken, updateAuthorizationRequest))
@@ -289,11 +287,10 @@ class TransactionsControllerTest {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
-                )
-                .timestampOperation(OffsetDateTime.now());
+                ).timestampOperation(OffsetDateTime.now());
 
         /* preconditions */
         Mockito.when(transactionsService.updateTransactionAuthorization(paymentToken, updateAuthorizationRequest))

--- a/src/test/java/it/pagopa/transactions/controllers/TransactionsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/TransactionsControllerTest.java
@@ -239,8 +239,11 @@ class TransactionsControllerTest {
                 .status(TransactionStatusDto.AUTHORIZATION_COMPLETED);
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         /* preconditions */
@@ -260,8 +263,11 @@ class TransactionsControllerTest {
         String paymentToken = "paymentToken";
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         /* preconditions */
@@ -282,8 +288,11 @@ class TransactionsControllerTest {
         String paymentToken = "paymentToken";
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         /* preconditions */

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -30,6 +30,7 @@ class TransactionDocumentTest {
         String TEST_RPTID = TEST_PAFISCALCODE + "302016723749670035";
         String TEST_DESC = "";
         String TEST_CART = "TEST_CART";
+        String RRN = "RRN";
         ZonedDateTime TEST_TIME = ZonedDateTime.now();
         Confidential<Email> CONFIDENTIAL_TEST_EMAIL = TransactionTestUtils.EMAIL;
         int TEST_AMOUNT = 1;
@@ -64,7 +65,8 @@ class TransactionDocumentTest {
                 TEST_STATUS,
                 Transaction.ClientId.CHECKOUT,
                 TEST_TIME.toString(),
-                TEST_CART
+                TEST_CART,
+                RRN
         );
 
         Transaction sameTransaction = new Transaction(
@@ -84,7 +86,8 @@ class TransactionDocumentTest {
                 TEST_STATUS,
                 Transaction.ClientId.CHECKOUT,
                 TEST_TIME.toString(),
-                TEST_CART
+                TEST_CART,
+                RRN
         );
 
         // Different transaction (creation date)
@@ -105,7 +108,8 @@ class TransactionDocumentTest {
                 TEST_STATUS,
                 Transaction.ClientId.CHECKOUT,
                 ZonedDateTime.now().toString(),
-                TEST_CART
+                TEST_CART,
+                RRN
         );
         it.pagopa.ecommerce.commons.documents.v1.PaymentNotice paymentNotice = new PaymentNotice(
                 TEST_TOKEN,

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -9,7 +9,6 @@ import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
-import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -6,6 +6,8 @@ import it.pagopa.ecommerce.commons.domain.v1.TransactionActivated;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
+import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
+import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
@@ -36,11 +38,87 @@ class AuthorizationUpdateProjectionHandlerTest {
     private ConfidentialDataManager confidentialDataManager;
 
     @Test
-    void shouldHandleTransaction() {
+    void shouldHandleTransactionXpay() {
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
+                .timestampOperation(OffsetDateTime.now());
+
+        TransactionActivated transaction = TransactionTestUtils.transactionActivated(ZonedDateTime.now().toString());
+
+        it.pagopa.ecommerce.commons.documents.v1.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.v1.Transaction(
+                transaction.getTransactionId().value(),
+                transaction.getTransactionActivatedData().getPaymentNotices(),
+                null,
+                transaction.getEmail(),
+                TransactionStatusDto.AUTHORIZATION_COMPLETED,
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                transaction.getCreationDate().toString(),
+                transaction.getTransactionActivatedData().getIdCart(),
+                null
+        );
+
+        TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
+                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode(),
+                null,
+                it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
+                        .fromValue(
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString()
+                        )
+        );
+
+        TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(
+                transaction.getTransactionId().value(),
+                statusAuthCompleted
+        );
+
+        TransactionActivated expected = new TransactionActivated(
+                transaction.getTransactionId(),
+                transaction.getPaymentNotices(),
+                transaction.getEmail(),
+                null,
+                null,
+                ZonedDateTime.parse(expectedDocument.getCreationDate()),
+                it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
+                transaction.getTransactionActivatedData().getIdCart()
+        );
+
+        /*
+         * Preconditions
+         */
+        Mockito.when(viewRepository.findById(transaction.getTransactionId().value()))
+                .thenReturn(Mono.just(it.pagopa.ecommerce.commons.documents.v1.Transaction.from(transaction)));
+
+        Mockito.when(viewRepository.save(expectedDocument)).thenReturn(Mono.just(expectedDocument));
+
+        /*
+         * Test
+         */
+        StepVerifier.create(authorizationUpdateProjectionHandler.handle(event))
+                .expectNext(expected)
+                .verifyComplete();
+
+        /*
+         * Assertions
+         */
+        Mockito.verify(viewRepository, Mockito.times(1)).save(
+                argThat(
+                        savedTransaction -> savedTransaction.getStatus()
+                                .equals(TransactionStatusDto.AUTHORIZATION_COMPLETED)
+                )
+        );
+    }
+
+    @Test
+    void shouldHandleTransactionVpos() {
+        UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
+                .outcomeGateway(
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -60,10 +138,13 @@ class AuthorizationUpdateProjectionHandlerTest {
         );
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
-                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode(),
                 "rrn",
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
-                        .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
+                        .fromValue(
+                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome()
+                                        .toString()
+                        )
         );
 
         TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -6,8 +6,8 @@ import it.pagopa.ecommerce.commons.domain.v1.TransactionActivated;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
-import it.pagopa.generated.transactions.server.model.AuthorizationResultDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
+import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,8 +38,11 @@ class AuthorizationUpdateProjectionHandlerTest {
     @Test
     void shouldHandleTransaction() {
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("OK")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionActivated transaction = TransactionTestUtils.transactionActivated(ZonedDateTime.now().toString());
@@ -56,9 +59,9 @@ class AuthorizationUpdateProjectionHandlerTest {
         );
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
-                updateAuthorizationRequest.getAuthorizationCode(),
+                updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
-                        .fromValue(updateAuthorizationRequest.getAuthorizationResult().toString())
+                        .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
         );
 
         TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -55,11 +55,13 @@ class AuthorizationUpdateProjectionHandlerTest {
                 TransactionStatusDto.AUTHORIZATION_COMPLETED,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString(),
-                transaction.getTransactionActivatedData().getIdCart()
+                transaction.getTransactionActivatedData().getIdCart(),
+                "rrn"
         );
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
                 updateAuthorizationRequest.getOutcomeGateway().getAuthorizationCode(),
+                "rrn",
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
                         .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
         );

--- a/src/test/java/it/pagopa/transactions/projections/handlers/CancellationRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/CancellationRequestProjectionHandlerTests.java
@@ -45,7 +45,8 @@ public class CancellationRequestProjectionHandlerTests {
                 TransactionStatusDto.CANCELLATION_REQUESTED,
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
-                transaction.getIdCart()
+                transaction.getIdCart(),
+                transaction.getRrn()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
@@ -44,7 +44,8 @@ class ClosureErrorProjectionHandlerTest {
                 TransactionStatusDto.REFUND_REQUESTED,
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
-                transaction.getIdCart()
+                transaction.getIdCart(),
+                transaction.getRrn()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandlerTests.java
@@ -45,7 +45,8 @@ class ClosureSendProjectionHandlerTests {
                 TransactionStatusDto.CLOSED,
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
-                transaction.getIdCart()
+                transaction.getIdCart(),
+                transaction.getRrn()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))
@@ -74,7 +75,8 @@ class ClosureSendProjectionHandlerTests {
                 TransactionStatusDto.UNAUTHORIZED,
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
-                transaction.getIdCart()
+                transaction.getIdCart(),
+                transaction.getRrn()
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/TransactionUserReceiptProjectionHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.projections.handlers;
 
+import it.pagopa.ecommerce.commons.documents.v1.Transaction;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionUserReceiptData;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionUserReceiptRequestedEvent;
 import it.pagopa.ecommerce.commons.domain.v1.TransactionActivated;
@@ -30,17 +31,19 @@ class TransactionUserReceiptProjectionHandlerTest {
 
     @Test
     void shouldHandleTransactionWithOKOutcome() {
-        TransactionActivated transaction = TransactionTestUtils.transactionActivated(ZonedDateTime.now().toString());
+        Transaction transaction = TransactionTestUtils
+                .transactionDocument(TransactionStatusDto.AUTHORIZATION_COMPLETED, ZonedDateTime.now());
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.v1.Transaction(
-                transaction.getTransactionId().value().toString(),
-                transaction.getTransactionActivatedData().getPaymentNotices(),
+                transaction.getTransactionId(),
+                transaction.getPaymentNotices(),
                 null,
                 transaction.getEmail(),
                 TransactionStatusDto.NOTIFICATION_REQUESTED,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                transaction.getCreationDate().toString(),
-                transaction.getTransactionActivatedData().getIdCart()
+                transaction.getCreationDate(),
+                transaction.getIdCart(),
+                "rrn"
         );
 
         TransactionUserReceiptRequestedEvent event = TransactionTestUtils
@@ -51,8 +54,8 @@ class TransactionUserReceiptProjectionHandlerTest {
         /*
          * Preconditions
          */
-        Mockito.when(viewRepository.findById(transaction.getTransactionId().value().toString()))
-                .thenReturn(Mono.just(it.pagopa.ecommerce.commons.documents.v1.Transaction.from(transaction)));
+        Mockito.when(viewRepository.findById(transaction.getTransactionId()))
+                .thenReturn(Mono.just(transaction));
 
         Mockito.when(viewRepository.save(expectedDocument)).thenReturn(Mono.just(expectedDocument));
 
@@ -80,14 +83,15 @@ class TransactionUserReceiptProjectionHandlerTest {
         TransactionActivated transaction = TransactionTestUtils.transactionActivated(ZonedDateTime.now().toString());
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction expectedDocument = new it.pagopa.ecommerce.commons.documents.v1.Transaction(
-                transaction.getTransactionId().value().toString(),
+                transaction.getTransactionId().value(),
                 transaction.getTransactionActivatedData().getPaymentNotices(),
                 null,
                 transaction.getEmail(),
                 TransactionStatusDto.NOTIFICATION_REQUESTED,
                 transaction.getClientId(),
                 transaction.getCreationDate().toString(),
-                transaction.getTransactionActivatedData().getIdCart()
+                transaction.getTransactionActivatedData().getIdCart(),
+                null
         );
 
         TransactionUserReceiptRequestedEvent event = TransactionTestUtils
@@ -98,7 +102,7 @@ class TransactionUserReceiptProjectionHandlerTest {
         /*
          * Preconditions
          */
-        Mockito.when(viewRepository.findById(transaction.getTransactionId().value().toString()))
+        Mockito.when(viewRepository.findById(transaction.getTransactionId().value()))
                 .thenReturn(Mono.just(it.pagopa.ecommerce.commons.documents.v1.Transaction.from(transaction)));
 
         Mockito.when(viewRepository.save(expectedDocument)).thenReturn(Mono.just(expectedDocument));

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -329,17 +329,20 @@ class TransactionServiceTests {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionAuthorizationCompletedData statusUpdateData = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
-                "rrn",
+                null,
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
-                        .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
+                        .fromValue(
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getOutcome().toString()
+                        )
         );
 
         TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(
@@ -417,8 +420,8 @@ class TransactionServiceTests {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -790,8 +793,8 @@ class TransactionServiceTests {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -864,8 +867,8 @@ class TransactionServiceTests {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -938,8 +941,8 @@ class TransactionServiceTests {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
@@ -1035,17 +1038,20 @@ class TransactionServiceTests {
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
                 .outcomeGateway(
-                        new UpdateAuthorizationRequestOutcomeGatewayDto()
-                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionAuthorizationCompletedData statusUpdateData = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
-                "rrn",
+                null,
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
-                        .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
+                        .fromValue(
+                                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                        .getOutcome().toString()
+                        )
         );
 
         TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -337,6 +337,7 @@ class TransactionServiceTests {
 
         TransactionAuthorizationCompletedData statusUpdateData = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
+                "rrn",
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
                         .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
         );
@@ -370,7 +371,8 @@ class TransactionServiceTests {
                 it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.CLOSED,
                 Transaction.ClientId.CHECKOUT,
                 ZonedDateTime.now().toString(),
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                transactionDocument.getRrn()
         );
 
         /* preconditions */
@@ -1041,6 +1043,7 @@ class TransactionServiceTests {
 
         TransactionAuthorizationCompletedData statusUpdateData = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
+                "rrn",
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
                         .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
         );
@@ -1074,7 +1077,8 @@ class TransactionServiceTests {
                 it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.CLOSURE_ERROR,
                 Transaction.ClientId.CHECKOUT,
                 ZonedDateTime.now().toString(),
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                transactionDocument.getRrn()
         );
 
         /* preconditions */

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -328,14 +328,17 @@ class TransactionServiceTests {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionAuthorizationCompletedData statusUpdateData = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
-                        .fromValue(updateAuthorizationRequest.getAuthorizationResult().toString())
+                        .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
         );
 
         TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(
@@ -411,8 +414,11 @@ class TransactionServiceTests {
         String transactionIdEncoded = uuidUtils.uuidToBase64(new TransactionId(TRANSACTION_ID).uuid());
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         /* preconditions */
@@ -781,8 +787,11 @@ class TransactionServiceTests {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionInfoDto expectedResponse = new TransactionInfoDto()
@@ -852,8 +861,11 @@ class TransactionServiceTests {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.KO)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.KO)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionInfoDto expectedResponse = new TransactionInfoDto()
@@ -923,8 +935,11 @@ class TransactionServiceTests {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionInfoDto expectedResponse = new TransactionInfoDto()
@@ -1017,14 +1032,17 @@ class TransactionServiceTests {
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
-                .authorizationResult(AuthorizationResultDto.OK)
-                .authorizationCode("authorizationCode")
+                .outcomeGateway(
+                        new UpdateAuthorizationRequestOutcomeGatewayDto()
+                                .outcome(UpdateAuthorizationRequestOutcomeGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionAuthorizationCompletedData statusUpdateData = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
                 it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
-                        .fromValue(updateAuthorizationRequest.getAuthorizationResult().toString())
+                        .fromValue(updateAuthorizationRequest.getOutcomeGateway().getOutcome().toString())
         );
 
         TransactionAuthorizationCompletedEvent event = new TransactionAuthorizationCompletedEvent(

--- a/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
@@ -1,20 +1,19 @@
 package it.pagopa.transactions.utils;
 
-import io.vavr.control.Either;
 import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
-import it.pagopa.transactions.exceptions.InvalidRequestException;
+import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthRequestDataUtilsTest {
@@ -32,15 +31,15 @@ public class AuthRequestDataUtilsTest {
                                 .rrn("rrn")
                 )
                 .timestampOperation(OffsetDateTime.now());
-        AuthRequestDataUtils.DataAuthRequest data = authRequestDataUtils.extract(updateAuthorizationRequest);
+        AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils.extract(updateAuthorizationRequest);
 
         assertEquals(
-                data.authorizationCode,
+                data.authorizationCode(),
                 ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode()
         );
-        assertEquals(data.rrn, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getRrn());
+        assertEquals(data.rrn(), ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getRrn());
         assertEquals(
-                data.outcome,
+                data.outcome(),
                 ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString()
         );
     }
@@ -54,14 +53,14 @@ public class AuthRequestDataUtilsTest {
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
-        AuthRequestDataUtils.DataAuthRequest data = authRequestDataUtils.extract(updateAuthorizationRequest);
+        AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils.extract(updateAuthorizationRequest);
 
         assertEquals(
-                data.authorizationCode,
+                data.authorizationCode(),
                 ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode()
         );
         assertEquals(
-                data.outcome,
+                data.outcome(),
                 ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString()
         );
     }

--- a/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
@@ -1,0 +1,57 @@
+package it.pagopa.transactions.utils;
+
+import io.vavr.control.Either;
+import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
+import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
+import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
+import it.pagopa.transactions.exceptions.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthRequestDataUtilsTest {
+
+    @InjectMocks
+    AuthRequestDataUtils authRequestDataUtils;
+
+    @Test
+    void shouldExtractVposInformation() {
+        UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
+                .outcomeGateway(
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                                .rrn("rrn")
+                )
+                .timestampOperation(OffsetDateTime.now());
+        AuthRequestDataUtils.DataAuthRequest data = authRequestDataUtils.extract(updateAuthorizationRequest);
+
+        assertEquals(data.authorizationCode, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode());
+        assertEquals(data.rrn, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getRrn());
+        assertEquals(data.outcome, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString());
+    }
+
+    @Test
+    void shouldExtractXpayInformation() {
+        UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
+                .outcomeGateway(
+                        new OutcomeXpayGatewayDto()
+                                .outcome(OutcomeXpayGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode("authorizationCode")
+                )
+                .timestampOperation(OffsetDateTime.now());
+        AuthRequestDataUtils.DataAuthRequest data = authRequestDataUtils.extract(updateAuthorizationRequest);
+
+        assertEquals(data.authorizationCode, ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode());
+        assertEquals(data.outcome, ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString());
+    }
+
+}

--- a/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
@@ -34,9 +34,15 @@ public class AuthRequestDataUtilsTest {
                 .timestampOperation(OffsetDateTime.now());
         AuthRequestDataUtils.DataAuthRequest data = authRequestDataUtils.extract(updateAuthorizationRequest);
 
-        assertEquals(data.authorizationCode, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode());
+        assertEquals(
+                data.authorizationCode,
+                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode()
+        );
         assertEquals(data.rrn, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getRrn());
-        assertEquals(data.outcome, ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString());
+        assertEquals(
+                data.outcome,
+                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString()
+        );
     }
 
     @Test
@@ -50,8 +56,14 @@ public class AuthRequestDataUtilsTest {
                 .timestampOperation(OffsetDateTime.now());
         AuthRequestDataUtils.DataAuthRequest data = authRequestDataUtils.extract(updateAuthorizationRequest);
 
-        assertEquals(data.authorizationCode, ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode());
-        assertEquals(data.outcome, ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString());
+        assertEquals(
+                data.authorizationCode,
+                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode()
+        );
+        assertEquals(
+                data.outcome,
+                ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getOutcome().toString()
+        );
     }
 
 }

--- a/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
-public class AuthRequestDataUtilsTest {
+class AuthRequestDataUtilsTest {
 
     @InjectMocks
     AuthRequestDataUtils authRequestDataUtils;

--- a/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
@@ -3,7 +3,6 @@ package it.pagopa.transactions.utils;
 import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
-import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestOutcomeGatewayDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,7 +30,7 @@ public class AuthRequestDataUtilsTest {
                                 .rrn("rrn")
                 )
                 .timestampOperation(OffsetDateTime.now());
-        AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils.extract(updateAuthorizationRequest);
+        AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils.from(updateAuthorizationRequest);
 
         assertEquals(
                 data.authorizationCode(),
@@ -53,7 +52,7 @@ public class AuthRequestDataUtilsTest {
                                 .authorizationCode("authorizationCode")
                 )
                 .timestampOperation(OffsetDateTime.now());
-        AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils.extract(updateAuthorizationRequest);
+        AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils.from(updateAuthorizationRequest);
 
         assertEquals(
                 data.authorizationCode(),


### PR DESCRIPTION
dependOn https://github.com/pagopa/pagopa-ecommerce-commons/pull/75
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added during **PATCH** the saving of the rrn both in the view and into transactionAuthorizationEvent.
<!--- Describe your changes in detail -->

#### Motivation and Context
Saved in PATCH phase the RRN field value for VPOS payments. The field is optional
The value has been saved both on the transaction view and in the authorization completion event, to allow recovery during the call to the closePayment and sendPaymentResult for sending the mail
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
The tests were carried out locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.