### PR TITLE
feat: specify mongo read preference mode

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ notificationsService.readTimeout=${NOTIFICATIONS_SERVICE_READ_TIMEOUT}
 notificationsService.connectionTimeout=${NOTIFICATIONS_SERVICE_CONNECTION_TIMEOUT}
 notificationsService.apiKey=${NOTIFICATIONS_SERVICE_API_KEY}
 
-spring.data.mongodb.uri=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/?ssl=${MONGO_SSL_ENABLED}
+spring.data.mongodb.uri=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/?ssl=${MONGO_SSL_ENABLED}&readPreference=primaryPreferred&maxStalenessSeconds=90
 spring.data.mongodb.database=ecommerce
 
 management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Change mongo readPreference to `primaryPreferred`

With this mode all read operations will be redirect to primary partition if available with fallback on secondary ones.
The `maxStalenessSeconds` parameter is set to it's the minimum value of 90 seconds in order to block reads from a replica older that 90 seconds

See https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/readpreference-global-distribution#read-using-read-preference-mode
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to redirect all read operations to the primary replica and lower the required consistency level
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.