### PR TITLE
CHK-1301-refund_requested

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -2,7 +2,6 @@ package it.pagopa.transactions.commands.handlers;
 
 import com.azure.core.util.BinaryData;
 import com.azure.storage.queue.QueueAsyncClient;
-import io.vavr.Tuple;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.TransactionAuthorizationCompleted;

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -70,7 +70,7 @@ public class TransactionSendClosureHandler implements
             PaymentRequestInfoRedisTemplateWrapper paymentRequestInfoRedisTemplateWrapper,
             NodeForPspClient nodeForPspClient,
             @Qualifier(
-                    "transactionClosureRetryQueueAsyncClient"
+                "transactionClosureRetryQueueAsyncClient"
             ) QueueAsyncClient closureRetryQueueAsyncClient,
             @Value("${payment.token.validity}") Integer paymentTokenValidity,
             @Value("${transactions.ecommerce.retry.offset}") Integer softTimeoutOffset,
@@ -95,7 +95,7 @@ public class TransactionSendClosureHandler implements
 
     @Override
     public Mono<Either<Either<TransactionRefundRequestedEvent, TransactionClosureErrorEvent>, Either<TransactionRefundRequestedEvent, TransactionEvent<TransactionClosureData>>>> handle(
-            TransactionClosureSendCommand command
+                                                                                                                                                                                         TransactionClosureSendCommand command
     ) {
         Mono<BaseTransaction> transaction = transactionsUtils.reduceEvents(
                 command.getData().transaction().getTransactionId()
@@ -264,8 +264,8 @@ public class TransactionSendClosureHandler implements
                                                             refundRequestedEvent
                                                     )
                                                     : Either.<TransactionRefundRequestedEvent, TransactionEvent<TransactionClosureData>>right(
-                                                    closureEvent
-                                            ))
+                                                            closureEvent
+                                                    ))
                                     )
                             )
                             .map(
@@ -382,24 +382,24 @@ public class TransactionSendClosureHandler implements
                                                                         refundRequestedEvent
                                                                 )
                                                                 : Either.<TransactionRefundRequestedEvent, TransactionClosureErrorEvent>right(
-                                                                closureErrorEvent
-                                                        ))
+                                                                        closureErrorEvent
+                                                                ))
                                                 )
                                         ).map((event) -> Either.left(event));
 
                             })
                             .doFinally(response -> {
                                 tx.getPaymentNotices().forEach(el -> {
-                                            log.info("Invalidate cache for RptId : {}", el.rptId().value());
-                                            paymentRequestInfoRedisTemplateWrapper.deleteById(el.rptId().value());
-                                        }
+                                    log.info("Invalidate cache for RptId : {}", el.rptId().value());
+                                    paymentRequestInfoRedisTemplateWrapper.deleteById(el.rptId().value());
+                                }
                                 );
                             });
                 });
     }
 
     private ClosePaymentRequestV2Dto.OutcomeEnum authorizationResultToOutcomeV2(
-            AuthorizationResultDto authorizationResult
+                                                                                AuthorizationResultDto authorizationResult
     ) {
         switch (authorizationResult) {
             case OK -> {
@@ -415,8 +415,8 @@ public class TransactionSendClosureHandler implements
     }
 
     private Mono<TransactionRefundRequestedEvent> sendRefundRequestEvent(
-            Either<TransactionClosureErrorEvent, TransactionEvent<TransactionClosureData>> closureOutcomeEvent,
-            AuthorizationResultDto authorizationResult
+                                                                         Either<TransactionClosureErrorEvent, TransactionEvent<TransactionClosureData>> closureOutcomeEvent,
+                                                                         AuthorizationResultDto authorizationResult
     ) {
         return Mono.just(closureOutcomeEvent)
                 .filter(
@@ -496,7 +496,7 @@ public class TransactionSendClosureHandler implements
     }
 
     private TransactionClosureData.Outcome outcomeV2ToTransactionClosureDataOutcome(
-            ClosePaymentResponseDto.OutcomeEnum closePaymentOutcome
+                                                                                    ClosePaymentResponseDto.OutcomeEnum closePaymentOutcome
     ) {
         switch (closePaymentOutcome) {
             case OK -> {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -258,15 +258,11 @@ public class TransactionSendClosureHandler implements
                                     (closureEvent) -> sendRefundRequestEvent(
                                             Either.right(closureEvent),
                                             transactionAuthorizationCompletedData.getAuthorizationResultDto()
-                                    ).map(
-                                            (refundRequestedEvent) -> (refundRequestedEvent != null ? Either
-                                                    .<TransactionRefundRequestedEvent, TransactionEvent<TransactionClosureData>>left(
-                                                            refundRequestedEvent
-                                                    )
-                                                    : Either.<TransactionRefundRequestedEvent, TransactionEvent<TransactionClosureData>>right(
-                                                            closureEvent
-                                                    ))
                                     )
+                                            .map(
+                                                    Either::<TransactionRefundRequestedEvent, TransactionEvent<TransactionClosureData>>left
+
+                                            ).switchIfEmpty(Mono.just(Either.right(closureEvent)))
                             )
                             .map(
                                     (event) -> Either
@@ -377,13 +373,11 @@ public class TransactionSendClosureHandler implements
                                                         transactionAuthorizationCompletedData
                                                                 .getAuthorizationResultDto()
                                                 ).map(
-                                                        (refundRequestedEvent) -> (refundRequestedEvent != null ? Either
-                                                                .<TransactionRefundRequestedEvent, TransactionClosureErrorEvent>left(
-                                                                        refundRequestedEvent
-                                                                )
-                                                                : Either.<TransactionRefundRequestedEvent, TransactionClosureErrorEvent>right(
-                                                                        closureErrorEvent
-                                                                ))
+                                                        Either::<TransactionRefundRequestedEvent, TransactionClosureErrorEvent>left
+
+                                                ).switchIfEmpty(
+                                                        Mono.just(Either.right(closureErrorEvent))
+
                                                 )
                                         ).map((event) -> Either.left(event));
 

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -255,7 +255,7 @@ public class TransactionSendClosureHandler implements
                                     )
                             )
                             .flatMap(
-                                    (closureEvent) -> sendRefundRequestEvent(
+                                    closureEvent -> sendRefundRequestEvent(
                                             Either.right(closureEvent),
                                             transactionAuthorizationCompletedData.getAuthorizationResultDto()
                                     )
@@ -265,7 +265,7 @@ public class TransactionSendClosureHandler implements
                                             ).switchIfEmpty(Mono.just(Either.right(closureEvent)))
                             )
                             .map(
-                                    (event) -> Either
+                                    event -> Either
                                             .<Either<TransactionRefundRequestedEvent, TransactionClosureErrorEvent>, Either<TransactionRefundRequestedEvent, TransactionEvent<TransactionClosureData>>>right(
                                                     event
                                             )

--- a/src/main/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandler.java
@@ -24,7 +24,7 @@ public class ClosureErrorProjectionHandler
                         Mono.error(new TransactionNotFoundException(event.getTransactionId()))
                 )
                 .flatMap(transactionDocument -> {
-                    transactionDocument.setStatus(TransactionStatusDto.REFUND_REQUESTED);
+                    transactionDocument.setStatus(TransactionStatusDto.CLOSURE_ERROR);
                     return transactionsViewRepository.save(transactionDocument);
                 });
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandler.java
@@ -2,13 +2,16 @@ package it.pagopa.transactions.projections.handlers;
 
 import it.pagopa.ecommerce.commons.documents.v1.Transaction;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundRequestedEvent;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionUserCanceledEvent;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+@Component
+@Slf4j
 public class RefundRequestProjectionHandler
         implements ProjectionHandler<TransactionRefundRequestedEvent, Mono<Transaction>> {
 

--- a/src/main/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandler.java
@@ -1,0 +1,33 @@
+package it.pagopa.transactions.projections.handlers;
+
+import it.pagopa.ecommerce.commons.documents.v1.Transaction;
+import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundRequestedEvent;
+import it.pagopa.ecommerce.commons.documents.v1.TransactionUserCanceledEvent;
+import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
+import it.pagopa.transactions.exceptions.TransactionNotFoundException;
+import it.pagopa.transactions.repositories.TransactionsViewRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Mono;
+
+public class RefundRequestProjectionHandler
+        implements ProjectionHandler<TransactionRefundRequestedEvent, Mono<Transaction>> {
+
+    @Autowired
+    private TransactionsViewRepository transactionsViewRepository;
+
+    @Override
+    public Mono<Transaction> handle(TransactionRefundRequestedEvent transactionRefundRequestedEvent) {
+        return transactionsViewRepository.findById(transactionRefundRequestedEvent.getTransactionId())
+                .switchIfEmpty(
+                        Mono.error(
+                                new TransactionNotFoundException(
+                                        transactionRefundRequestedEvent.getTransactionId()
+                                )
+                        )
+                )
+                .flatMap(transactionDocument -> {
+                    transactionDocument.setStatus(TransactionStatusDto.REFUND_REQUESTED);
+                    return transactionsViewRepository.save(transactionDocument);
+                });
+    }
+}

--- a/src/main/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandler.java
@@ -15,8 +15,14 @@ import reactor.core.publisher.Mono;
 public class RefundRequestProjectionHandler
         implements ProjectionHandler<TransactionRefundRequestedEvent, Mono<Transaction>> {
 
+    private final TransactionsViewRepository transactionsViewRepository;
+
     @Autowired
-    private TransactionsViewRepository transactionsViewRepository;
+    public RefundRequestProjectionHandler(
+            TransactionsViewRepository transactionsViewRepository
+    ) {
+        this.transactionsViewRepository = transactionsViewRepository;
+    }
 
     @Override
     public Mono<Transaction> handle(TransactionRefundRequestedEvent transactionRefundRequestedEvent) {

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -518,8 +518,8 @@ public class TransactionsService {
                                 closureSentEvent -> closureSentEvent.fold(
                                         closureSentEventRefunded -> refundRequestProjectionHandler
                                                 .handle(closureSentEventRefunded),
-                                        closureSentEventNoRefunded -> closureSendProjectionHandler
-                                                .handle(closureSentEventNoRefunded)
+                                        closureDataTransactionEvent -> closureSendProjectionHandler
+                                                .handle(closureDataTransactionEvent)
                                 )
                         )
                 );

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -523,18 +523,16 @@ public class TransactionsService {
                 )
                 )
                 .flatMap(
-                        result -> result.fold(
-                                errorEvent -> errorEvent.fold(
-                                        errorEventRefunded -> refundRequestProjectionHandler.handle(errorEventRefunded),
-                                        errorEventNoRefund -> closureErrorProjectionHandler.handle(errorEventNoRefund)
-                                ),
-                                closureSentEvent -> closureSentEvent.fold(
-                                        closureSentEventRefunded -> refundRequestProjectionHandler
-                                                .handle(closureSentEventRefunded),
+                        el -> el.getT1().map(
+                                refundEvent -> refundRequestProjectionHandler.handle(refundEvent)
+                        ).orElse(
+                                el.getT2().fold(
+                                        closureErrorEvent -> closureErrorProjectionHandler.handle(closureErrorEvent),
                                         closureDataTransactionEvent -> closureSendProjectionHandler
                                                 .handle(closureDataTransactionEvent)
                                 )
                         )
+
                 );
     }
 

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -72,6 +72,9 @@ public class TransactionsService {
     private TransactionUserReceiptProjectionHandler transactionUserReceiptProjectionHandler;
 
     @Autowired
+    private RefundRequestProjectionHandler refundRequestProjectionHandler;
+
+    @Autowired
     private ClosureSendProjectionHandler closureSendProjectionHandler;
 
     @Autowired
@@ -509,11 +512,12 @@ public class TransactionsService {
                 .flatMap(
                         result -> result.fold(
                                 errorEvent -> errorEvent.fold(
-                                        errorEventRefunded -> null, // TODO aggiornare la pagina con REFUND STATUS
+                                        errorEventRefunded -> refundRequestProjectionHandler.handle(errorEventRefunded),
                                         errorEventNoRefund -> closureErrorProjectionHandler.handle(errorEventNoRefund)
                                 ),
                                 closureSentEvent -> closureSentEvent.fold(
-                                        closureSentEventRefunded -> null, // TODO aggiornare la pagina con REFUND STATUS
+                                        closureSentEventRefunded -> refundRequestProjectionHandler
+                                                .handle(closureSentEventRefunded),
                                         closureSentEventNoRefunded -> closureSendProjectionHandler
                                                 .handle(closureSentEventNoRefunded)
                                 )

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -101,8 +101,8 @@ public class TransactionsService {
     @CircuitBreaker(name = "node-backend")
     @Retry(name = "newTransaction")
     public Mono<NewTransactionResponseDto> newTransaction(
-            NewTransactionRequestDto newTransactionRequestDto,
-            ClientIdDto clientIdDto
+                                                          NewTransactionRequestDto newTransactionRequestDto,
+                                                          ClientIdDto clientIdDto
     ) {
         ClientId clientId = ClientId.fromString(
                 Optional.ofNullable(clientIdDto)
@@ -206,9 +206,9 @@ public class TransactionsService {
     @CircuitBreaker(name = "transactions-backend")
     @Retry(name = "requestTransactionAuthorization")
     public Mono<RequestAuthorizationResponseDto> requestTransactionAuthorization(
-            String transactionId,
-            String paymentGatewayId,
-            RequestAuthorizationRequestDto requestAuthorizationRequestDto
+                                                                                 String transactionId,
+                                                                                 String paymentGatewayId,
+                                                                                 RequestAuthorizationRequestDto requestAuthorizationRequestDto
     ) {
         return transactionsViewRepository
                 .findById(transactionId)
@@ -225,11 +225,11 @@ public class TransactionsService {
                             );
                             return !amountTotal.equals(requestAuthorizationRequestDto.getAmount())
                                     ? Mono.error(
-                                    new TransactionAmountMismatchException(
-                                            requestAuthorizationRequestDto.getAmount(),
-                                            amountTotal
+                                            new TransactionAmountMismatchException(
+                                                    requestAuthorizationRequestDto.getAmount(),
+                                                    amountTotal
+                                            )
                                     )
-                            )
                                     : Mono.just(transaction);
                         }
                 )
@@ -283,12 +283,12 @@ public class TransactionsService {
                                                                                             .getPspId()
                                                                             )
                                                                             && psp.getTaxPayerFee()
-                                                                            .equals(
-                                                                                    Long.valueOf(
-                                                                                            requestAuthorizationRequestDto
-                                                                                                    .getFee()
+                                                                                    .equals(
+                                                                                            Long.valueOf(
+                                                                                                    requestAuthorizationRequestDto
+                                                                                                            .getFee()
+                                                                                            )
                                                                                     )
-                                                                            )
                                                             ).findFirst()
                                             )
                                     )
@@ -403,8 +403,8 @@ public class TransactionsService {
     @CircuitBreaker(name = "node-backend")
     @Retry(name = "updateTransactionAuthorization")
     public Mono<TransactionInfoDto> updateTransactionAuthorization(
-            String encodedTransactionId,
-            UpdateAuthorizationRequestDto updateAuthorizationRequestDto
+                                                                   String encodedTransactionId,
+                                                                   UpdateAuthorizationRequestDto updateAuthorizationRequestDto
     ) {
         return uuidUtils.uuidFromBase64(encodedTransactionId)
                 .fold(
@@ -455,8 +455,8 @@ public class TransactionsService {
     }
 
     private Mono<TransactionActivated> updateTransactionAuthorizationStatus(
-            BaseTransaction transaction,
-            UpdateAuthorizationRequestDto updateAuthorizationRequestDto
+                                                                            BaseTransaction transaction,
+                                                                            UpdateAuthorizationRequestDto updateAuthorizationRequestDto
     ) {
         UpdateAuthorizationStatusData updateAuthorizationStatusData = new UpdateAuthorizationStatusData(
                 transaction,
@@ -484,8 +484,8 @@ public class TransactionsService {
     }
 
     private Mono<it.pagopa.ecommerce.commons.documents.v1.Transaction> closePayment(
-            BaseTransactionWithPaymentToken transaction,
-            UpdateAuthorizationRequestDto updateAuthorizationRequestDto
+                                                                                    BaseTransactionWithPaymentToken transaction,
+                                                                                    UpdateAuthorizationRequestDto updateAuthorizationRequestDto
     ) {
         ClosureSendData closureSendData = new ClosureSendData(
                 transaction,
@@ -500,11 +500,11 @@ public class TransactionsService {
         return transactionSendClosureHandler
                 .handle(transactionClosureSendCommand)
                 .doOnNext(closureSentEvent ->
-                        // FIXME Handle multiple rtpId
-                        log.info(
-                                "Requested transaction closure for rptId: {}",
-                                transaction.getPaymentNotices().get(0).rptId().value()
-                        )
+                // FIXME Handle multiple rtpId
+                log.info(
+                        "Requested transaction closure for rptId: {}",
+                        transaction.getPaymentNotices().get(0).rptId().value()
+                )
                 )
                 .flatMap(
                         result -> result.fold(
@@ -522,7 +522,7 @@ public class TransactionsService {
     }
 
     private TransactionInfoDto buildTransactionInfoDto(
-            it.pagopa.ecommerce.commons.documents.v1.Transaction transactionDocument
+                                                       it.pagopa.ecommerce.commons.documents.v1.Transaction transactionDocument
     ) {
         return new TransactionInfoDto()
                 .transactionId(
@@ -564,7 +564,7 @@ public class TransactionsService {
     }
 
     private Mono<Boolean> wasTransactionAuthorized(
-            TransactionId transactionId
+                                                   TransactionId transactionId
     ) {
         /*
          * @formatter:off
@@ -594,8 +594,8 @@ public class TransactionsService {
     @CircuitBreaker(name = "transactions-backend")
     @Retry(name = "addUserReceipt")
     public Mono<TransactionInfoDto> addUserReceipt(
-            String transactionId,
-            AddUserReceiptRequestDto addUserReceiptRequest
+                                                   String transactionId,
+                                                   AddUserReceiptRequestDto addUserReceiptRequest
     ) {
         return transactionsViewRepository
                 .findById(transactionId)
@@ -683,8 +683,8 @@ public class TransactionsService {
     }
 
     private Mono<NewTransactionResponseDto> projectActivatedEvent(
-            TransactionActivatedEvent transactionActivatedEvent,
-            String authToken
+                                                                  TransactionActivatedEvent transactionActivatedEvent,
+                                                                  String authToken
     ) {
         return transactionsActivationProjectionHandler
                 .handle(transactionActivatedEvent)
@@ -730,7 +730,7 @@ public class TransactionsService {
     }
 
     NewTransactionResponseDto.ClientIdEnum convertClientId(
-            it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId
+                                                           it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId
     ) {
         return Optional.ofNullable(clientId).filter(Objects::nonNull)
                 .map(
@@ -748,8 +748,8 @@ public class TransactionsService {
     private String extractBinFromPan(RequestAuthorizationRequestDto requestAuthorizationRequestDto) {
         return requestAuthorizationRequestDto
                 .getDetails()instanceof CardAuthRequestDetailsDto cardData
-                ? cardData.getPan().substring(0, 6)
-                : null;
+                        ? cardData.getPan().substring(0, 6)
+                        : null;
     }
 
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -390,11 +390,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -546,11 +549,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -788,11 +794,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2().get());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1022,10 +1031,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1279,10 +1288,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1530,10 +1539,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.getLeft().getLeft().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.getLeft().getLeft().getTransactionId());
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1705,10 +1714,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1875,10 +1884,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2145,10 +2154,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2395,10 +2404,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2591,10 +2600,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.get().getLeft().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.get().getLeft().getTransactionId());
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2804,10 +2813,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.getLeft().getLeft().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.getLeft().getLeft().getTransactionId());
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2928,11 +2937,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2().get());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -3041,10 +3053,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureErrorProjectionHandlerTest.java
@@ -41,7 +41,7 @@ class ClosureErrorProjectionHandlerTest {
                 transaction.getPaymentNotices(),
                 transaction.getFeeTotal(),
                 transaction.getEmail(),
-                TransactionStatusDto.REFUND_REQUESTED,
+                TransactionStatusDto.CLOSURE_ERROR,
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
                 transaction.getIdCart(),

--- a/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
@@ -23,11 +23,12 @@ import static org.mockito.ArgumentMatchers.any;
 @ExtendWith(MockitoExtension.class)
 class RefundRequestProjectionHandlerTests {
 
-    @InjectMocks
-    private RefundRequestProjectionHandler refundRequestProjectionHandler;
+    private final TransactionsViewRepository transactionsViewRepository = Mockito
+            .mock(TransactionsViewRepository.class);;
 
-    @Mock
-    private TransactionsViewRepository transactionsViewRepository;
+    private final RefundRequestProjectionHandler refundRequestProjectionHandler = new RefundRequestProjectionHandler(
+            transactionsViewRepository
+    );
 
     @Test
     void shouldHandleProjection() {

--- a/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
@@ -9,8 +9,6 @@ import it.pagopa.transactions.exceptions.TransactionNotFoundException;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;

--- a/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
@@ -1,0 +1,81 @@
+package it.pagopa.transactions.projections.handlers;
+
+import it.pagopa.ecommerce.commons.documents.v1.Transaction;
+import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundRequestedEvent;
+import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundedData;
+import it.pagopa.ecommerce.commons.documents.v1.TransactionUserCanceledEvent;
+import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
+import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
+import it.pagopa.transactions.exceptions.TransactionNotFoundException;
+import it.pagopa.transactions.repositories.TransactionsViewRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.ZonedDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class RefundRequestProjectionHandlerTests {
+
+    @InjectMocks
+    private RefundRequestProjectionHandler refundRequestProjectionHandler;
+
+    @Mock
+    private TransactionsViewRepository transactionsViewRepository;
+
+    @Test
+    void shouldHandleProjection() {
+        Transaction transaction = TransactionTestUtils
+                .transactionDocument(TransactionStatusDto.AUTHORIZATION_COMPLETED, ZonedDateTime.now());
+
+        TransactionRefundRequestedEvent transactionRefundRequestedEvent = new TransactionRefundRequestedEvent(
+                transaction.getTransactionId(),
+                new TransactionRefundedData()
+        );
+
+        Transaction expected = new Transaction(
+                transaction.getTransactionId(),
+                transaction.getPaymentNotices(),
+                transaction.getFeeTotal(),
+                transaction.getEmail(),
+                TransactionStatusDto.REFUND_REQUESTED,
+                Transaction.ClientId.CHECKOUT,
+                transaction.getCreationDate(),
+                transaction.getIdCart(),
+                transaction.getRrn()
+        );
+
+        Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))
+                .thenReturn(Mono.just(transaction));
+        Mockito.when(transactionsViewRepository.save(any()))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(refundRequestProjectionHandler.handle(transactionRefundRequestedEvent))
+                .expectNext(expected)
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnTransactionNotFoundExceptionOnTransactionNotFound() {
+        Transaction transaction = TransactionTestUtils
+                .transactionDocument(TransactionStatusDto.AUTHORIZATION_COMPLETED, ZonedDateTime.now());
+
+        TransactionRefundRequestedEvent transactionRefundRequestedEvent = new TransactionRefundRequestedEvent(
+                transaction.getTransactionId(),
+                new TransactionRefundedData()
+        );
+
+        Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId())).thenReturn(Mono.empty());
+
+        StepVerifier.create(refundRequestProjectionHandler.handle(transactionRefundRequestedEvent))
+                .expectError(TransactionNotFoundException.class)
+                .verify();
+    }
+}

--- a/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/RefundRequestProjectionHandlerTests.java
@@ -3,7 +3,6 @@ package it.pagopa.transactions.projections.handlers;
 import it.pagopa.ecommerce.commons.documents.v1.Transaction;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundRequestedEvent;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundedData;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionUserCanceledEvent;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
@@ -22,7 +21,7 @@ import java.time.ZonedDateTime;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
-public class RefundRequestProjectionHandlerTests {
+class RefundRequestProjectionHandlerTests {
 
     @InjectMocks
     private RefundRequestProjectionHandler refundRequestProjectionHandler;

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -391,7 +391,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(closureSentEvent)));
+                .thenReturn(Mono.just(Either.right(Either.right(closureSentEvent))));
 
         Mockito.when(closureSendProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(closedTransactionDocument));
@@ -1102,7 +1102,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.left(closureSentEvent)));
+                .thenReturn(Mono.just(Either.left(Either.right(closureSentEvent))));
 
         Mockito.when(closureErrorProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(closedTransactionDocument));

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -105,6 +105,9 @@ class TransactionServiceTests {
     private TransactionUserReceiptProjectionHandler transactionUserReceiptProjectionHandler;
 
     @MockBean
+    private RefundRequestProjectionHandler refundRequestProjectionHandler;
+
+    @MockBean
     private TransactionsEventStoreRepository transactionsEventStoreRepository;
 
     @MockBean

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -1107,7 +1107,8 @@ class TransactionServiceTests {
                 "faultCode",
                 "faultCodeString",
                 Transaction.ClientId.CHECKOUT,
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -1362,7 +1363,8 @@ class TransactionServiceTests {
                 "faultCode",
                 "faultCodeString",
                 Transaction.ClientId.CHECKOUT,
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -1490,7 +1492,8 @@ class TransactionServiceTests {
                 "faultCode",
                 "faultCodeString",
                 Transaction.ClientId.CHECKOUT,
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.services;
 
+import io.vavr.Tuple;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.v1.Transaction;
 import it.pagopa.ecommerce.commons.documents.v1.*;
@@ -36,10 +37,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -460,7 +464,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(Either.right(closureSentEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.empty(), Either.right(closureSentEvent))));
 
         Mockito.when(closureSendProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(closedTransactionDocument));
@@ -1174,7 +1178,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.left(Either.left(refundRequestedEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.of(refundRequestedEvent), Either.right(null))));
 
         Mockito.when(refundRequestProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(refundedRequestedTransactionDocument));
@@ -1265,7 +1269,7 @@ class TransactionServiceTests {
                 statusUpdateData
         );
 
-        TransactionClosureErrorEvent closureSentEvent = TransactionTestUtils
+        TransactionClosureErrorEvent closureErrorSentEvent = TransactionTestUtils
                 .transactionClosureErrorEvent();
 
         TransactionInfoDto expectedResponse = new TransactionInfoDto()
@@ -1301,7 +1305,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.left(Either.right(closureSentEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.empty(), Either.left(closureErrorSentEvent))));
 
         Mockito.when(closureErrorProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(refundedRequestedTransactionDocument));
@@ -1430,7 +1434,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(Either.left(refundRequestedEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.of(refundRequestedEvent), Either.left(null))));
 
         Mockito.when(refundRequestProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(refundedRequestedTransactionDocument));
@@ -1557,7 +1561,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(Either.right(closureSentEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.empty(), Either.right(closureSentEvent))));
 
         Mockito.when(closureSendProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(requestedTransactionDocument));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added a new projectionHandler for handling view update at **REFUND_REQUESTED**.
Updated transaction refund logic, specifically:
- In case of an unrecoverable error of the closePayment request you have to perform a transaction refund and update to view to **REFUND_REQUESTED**.
- In case of a recoverable error of the closePayment request you have to add the event in the retry queue and update the view state to **CLOSURE_ERROR**.
- In case of closePayment with a KO by the node if the transaction was authorized by the **PGS** a refund request must be made and the view updated to **REFUND_REQUESTED**.
-  In case of closePayment with a KO by the node if the transaction was not authorized by the **PGS** update the view to **UNAUTHORIZED**..
- In case of closePayment OK by the node you have to update the view with **CLOSED** status.
<!--- Describe your changes in detail -->

#### Motivation and Context
The goal of the activity was to manage the close payment response so that the view was updated with the correct state.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
The tests were carried out in local with ecommerce-local.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.