### PR TITLE
feat: add payment token validity time into event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,8 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-1551-add-payment-token-validity-time</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.16.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.16.1</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
     </properties>
     <dependencies>
@@ -403,8 +403,6 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-1551-add-payment-token-validity-time</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -26,6 +26,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import java.math.BigInteger;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -219,7 +220,8 @@ public class TransactionActivateHandler
                                                             transactionId.value(),
                                                             newTransactionRequestDto.getEmail(),
                                                             command.getClientId(),
-                                                            newTransactionRequestDto.getIdCart()
+                                                            newTransactionRequestDto.getIdCart(),
+                                                            paymentTokenTimeout
                                                     ),
                                                     authToken
                                             )
@@ -249,7 +251,8 @@ public class TransactionActivateHandler
                                                                          String transactionId,
                                                                          String email,
                                                                          Transaction.ClientId clientId,
-                                                                         String idCart
+                                                                         String idCart,
+                                                                         Integer paymentTokenTimeout
     ) {
         List<PaymentNotice> paymentNotices = toPaymentNoticeList(paymentRequestsInfo);
         Mono<TransactionActivatedData> data = confidentialMailUtils.toConfidential(email).map(
@@ -259,7 +262,8 @@ public class TransactionActivateHandler
                         null,
                         null,
                         clientId,
-                        idCart
+                        idCart,
+                        BigInteger.valueOf(paymentTokenTimeout)
                 )
         );
 

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -26,7 +26,6 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import java.math.BigInteger;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -263,7 +262,7 @@ public class TransactionActivateHandler
                         null,
                         clientId,
                         idCart,
-                        BigInteger.valueOf(paymentTokenTimeout)
+                        paymentTokenTimeout
                 )
         );
 

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import java.math.BigInteger;
 import java.time.ZonedDateTime;
 
 @Component
@@ -75,7 +74,7 @@ public class AuthorizationUpdateProjectionHandler
                                 ZonedDateTime.parse(transactionDocument.getCreationDate()),
                                 transactionDocument.getClientId(),
                                 transactionDocument.getIdCart(),
-                                BigInteger.valueOf(paymentTokenValidity)
+                                paymentTokenValidity
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandler.java
@@ -7,17 +7,30 @@ import it.pagopa.transactions.exceptions.TransactionNotFoundException;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.math.BigInteger;
 import java.time.ZonedDateTime;
 
 @Component
 @Slf4j
 public class AuthorizationUpdateProjectionHandler
         implements ProjectionHandler<TransactionAuthorizationCompletedEvent, Mono<TransactionActivated>> {
+
+    private final TransactionsViewRepository transactionsViewRepository;
+
+    private final Integer paymentTokenValidity;
+
     @Autowired
-    private TransactionsViewRepository transactionsViewRepository;
+    public AuthorizationUpdateProjectionHandler(
+            TransactionsViewRepository transactionsViewRepository,
+            @Value("${payment.token.validity}") Integer paymentTokenValidity
+    ) {
+        this.transactionsViewRepository = transactionsViewRepository;
+        this.paymentTokenValidity = paymentTokenValidity;
+    }
 
     @Override
     public Mono<TransactionActivated> handle(TransactionAuthorizationCompletedEvent data) {
@@ -61,7 +74,8 @@ public class AuthorizationUpdateProjectionHandler
                                 null,
                                 ZonedDateTime.parse(transactionDocument.getCreationDate()),
                                 transactionDocument.getClientId(),
-                                transactionDocument.getIdCart()
+                                transactionDocument.getIdCart(),
+                                BigInteger.valueOf(paymentTokenValidity)
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import java.math.BigInteger;
 import java.util.List;
 
 @Component
@@ -48,7 +47,7 @@ public class TransactionsActivationProjectionHandler
         String faultCodeString = event.getData().getFaultCodeString();
         ClientId clientId = event.getData().getClientId();
         String idCart = event.getData().getIdCart();
-        BigInteger paymentTokenValiditySeconds = event.getData().getPaymentTokenValiditySeconds();
+        int paymentTokenValiditySeconds = event.getData().getPaymentTokenValiditySeconds();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 paymentNoticeList,

--- a/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/TransactionsActivationProjectionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.math.BigInteger;
 import java.util.List;
 
 @Component
@@ -47,7 +48,7 @@ public class TransactionsActivationProjectionHandler
         String faultCodeString = event.getData().getFaultCodeString();
         ClientId clientId = event.getData().getClientId();
         String idCart = event.getData().getIdCart();
-
+        BigInteger paymentTokenValiditySeconds = event.getData().getPaymentTokenValiditySeconds();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 paymentNoticeList,
@@ -55,7 +56,8 @@ public class TransactionsActivationProjectionHandler
                 faultCode,
                 faultCodeString,
                 clientId,
-                idCart
+                idCart,
+                paymentTokenValiditySeconds
         );
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v1.Transaction

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -37,7 +37,6 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuples;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -366,7 +365,7 @@ public class TransactionsService {
                                     null,
                                     transactionDocument.getClientId(),
                                     transactionDocument.getIdCart(),
-                                    BigInteger.valueOf(paymentTokenValidity)
+                                    paymentTokenValidity
                             );
 
                             AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -631,7 +630,7 @@ public class TransactionsService {
                                     null,
                                     transactionDocument.getClientId(),
                                     transactionDocument.getIdCart(),
-                                    BigInteger.valueOf(paymentTokenValidity)
+                                    paymentTokenValidity
 
                             );
                             AddUserReceiptData addUserReceiptData = new AddUserReceiptData(

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -32,10 +32,12 @@ import it.pagopa.transactions.utils.TransactionsUtils;
 import it.pagopa.transactions.utils.UUIDUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuples;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -97,6 +99,9 @@ public class TransactionsService {
 
     @Autowired
     private TransactionsEventStoreRepository<TransactionAuthorizationCompletedData> eventStoreRepository;
+
+    @Value("${payment.token.validity}")
+    private Integer paymentTokenValidity;
 
     @CircuitBreaker(name = "node-backend")
     @Retry(name = "newTransaction")
@@ -360,7 +365,8 @@ public class TransactionsService {
                                     null,
                                     null,
                                     transactionDocument.getClientId(),
-                                    transactionDocument.getIdCart()
+                                    transactionDocument.getIdCart(),
+                                    BigInteger.valueOf(paymentTokenValidity)
                             );
 
                             AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -624,7 +630,9 @@ public class TransactionsService {
                                     null,
                                     null,
                                     transactionDocument.getClientId(),
-                                    transactionDocument.getIdCart()
+                                    transactionDocument.getIdCart(),
+                                    BigInteger.valueOf(paymentTokenValidity)
+
                             );
                             AddUserReceiptData addUserReceiptData = new AddUserReceiptData(
                                     transaction,

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -99,7 +99,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -151,7 +152,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -238,7 +240,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -317,7 +320,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -412,7 +416,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .detailType("card")
@@ -510,7 +515,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -598,7 +604,8 @@ class PaymentGatewayClientTest {
                 "faultCode",
                 "faultCodeString",
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -668,7 +675,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -753,7 +761,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -844,7 +853,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -943,7 +953,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -1022,7 +1033,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -1107,7 +1119,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
         CardAuthRequestDetailsDto cardDetails = new CardAuthRequestDetailsDto()
                 .cvv("345")
@@ -1200,7 +1213,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
@@ -1253,7 +1267,8 @@ class PaymentGatewayClientTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -50,19 +50,21 @@ class TransactionInitializerHandlerTest {
 
     private final NodoOperations nodoOperations = Mockito.mock(NodoOperations.class);
 
-    private final QueueAsyncClient transactionClosureSentEventQueueClient = Mockito.mock(QueueAsyncClient.class);
+    private final QueueAsyncClient transactionActivatedQueueAsyncClient = Mockito.mock(QueueAsyncClient.class);
 
     private final JwtTokenUtils jwtTokenUtils = Mockito.mock(JwtTokenUtils.class);
 
     private final ConfidentialMailUtils confidentialMailUtils = Mockito.mock(ConfidentialMailUtils.class);
+
+    private final int paymentTokenTimeout = 120;
 
     private final TransactionActivateHandler handler = new TransactionActivateHandler(
             paymentRequestInfoRedisTemplateWrapper,
             transactionEventActivatedStoreRepository,
             nodoOperations,
             jwtTokenUtils,
-            transactionClosureSentEventQueueClient,
-            120,
+            transactionActivatedQueueAsyncClient,
+            paymentTokenTimeout,
             confidentialMailUtils
     );
 
@@ -121,10 +123,10 @@ class TransactionInitializerHandlerTest {
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
         Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenReturn(Mono.just(transactionActivatedEvent));
+                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper).save(any(PaymentRequestInfo.class));
         Mockito.when(
-                transactionClosureSentEventQueueClient.sendMessageWithResponse(
+                transactionActivatedQueueAsyncClient.sendMessageWithResponse(
                         any(BinaryData.class),
                         any(),
                         any()
@@ -143,6 +145,13 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         assertNotNull(paymentRequestInfoCached.id());
+        TransactionActivatedEvent event = response.getT1().block();
+        Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
+        assertNotNull(event.getTransactionId());
+        assertNotNull(event.getEventCode());
+        assertNotNull(event.getCreationDate());
+        assertNotNull(event.getId());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds().intValue());
     }
 
     @Test
@@ -205,7 +214,7 @@ class TransactionInitializerHandlerTest {
                 .thenReturn(Mono.just(transactionActivatedEvent));
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper).save(any(PaymentRequestInfo.class));
         Mockito.when(
-                transactionClosureSentEventQueueClient.sendMessageWithResponse(
+                transactionActivatedQueueAsyncClient.sendMessageWithResponse(
                         any(BinaryData.class),
                         any(),
                         any()
@@ -363,7 +372,7 @@ class TransactionInitializerHandlerTest {
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoBeforeActivation));
         Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenReturn(Mono.just(transactionActivatedEvent));
+                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper).save(any(PaymentRequestInfo.class));
         Mockito.when(
                 nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any())
@@ -372,7 +381,7 @@ class TransactionInitializerHandlerTest {
         Mockito.when(jwtTokenUtils.generateToken(any()))
                 .thenReturn(Mono.just("authToken"));
         Mockito.when(
-                transactionClosureSentEventQueueClient.sendMessageWithResponse(
+                transactionActivatedQueueAsyncClient.sendMessageWithResponse(
                         any(BinaryData.class),
                         any(),
                         any()
@@ -393,6 +402,7 @@ class TransactionInitializerHandlerTest {
         assertNotNull(event.getEventCode());
         assertNotNull(event.getCreationDate());
         assertNotNull(event.getId());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds().intValue());
     }
 
     @Test
@@ -435,7 +445,7 @@ class TransactionInitializerHandlerTest {
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.empty());
         Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenReturn(Mono.just(transactionActivatedEvent));
+                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper).save(any(PaymentRequestInfo.class));
         Mockito.when(
                 nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any())
@@ -452,7 +462,7 @@ class TransactionInitializerHandlerTest {
         Mockito.when(jwtTokenUtils.generateToken(any()))
                 .thenReturn(Mono.just("authToken"));
         Mockito.when(
-                transactionClosureSentEventQueueClient.sendMessageWithResponse(
+                transactionActivatedQueueAsyncClient.sendMessageWithResponse(
                         any(BinaryData.class),
                         any(),
                         any()
@@ -474,5 +484,6 @@ class TransactionInitializerHandlerTest {
         assertNotNull(event.getEventCode());
         assertNotNull(event.getCreationDate());
         assertNotNull(event.getId());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds().intValue());
     }
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -151,7 +151,7 @@ class TransactionInitializerHandlerTest {
         assertNotNull(event.getEventCode());
         assertNotNull(event.getCreationDate());
         assertNotNull(event.getId());
-        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds().intValue());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds());
     }
 
     @Test
@@ -402,7 +402,7 @@ class TransactionInitializerHandlerTest {
         assertNotNull(event.getEventCode());
         assertNotNull(event.getCreationDate());
         assertNotNull(event.getId());
-        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds().intValue());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds());
     }
 
     @Test
@@ -484,6 +484,6 @@ class TransactionInitializerHandlerTest {
         assertNotNull(event.getEventCode());
         assertNotNull(event.getCreationDate());
         assertNotNull(event.getId());
-        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds().intValue());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds());
     }
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizizationHandlerTest.java
@@ -134,7 +134,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -209,7 +210,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -288,7 +290,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 faultCode,
                 faultCodeString,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -361,7 +364,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 faultCode,
                 faultCodeString,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -440,7 +444,8 @@ class TransactionRequestAuthorizizationHandlerTest {
                 null,
                 null,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -166,7 +166,8 @@ class TransactionSendClosureHandlerTest {
                 faultCode,
                 faultCodeString,
                 Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -195,7 +196,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -278,7 +280,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -433,7 +436,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -588,7 +592,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -829,7 +834,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -1066,7 +1072,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -1323,7 +1330,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -1580,7 +1588,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -1755,7 +1764,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -1930,7 +1940,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 
@@ -2190,7 +2201,8 @@ class TransactionSendClosureHandlerTest {
                         faultCode,
                         faultCodeString,
                         Transaction.ClientId.CHECKOUT,
-                        idCart
+                        idCart,
+                        TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
                 )
         );
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -115,7 +115,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                 faultCode,
                 faultCodeString,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionsActivationProjectionHandlerTest.java
@@ -99,7 +99,8 @@ class TransactionsActivationProjectionHandlerTest {
                 faultCode,
                 faultCodeString,
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         it.pagopa.ecommerce.commons.documents.v1.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v1.Transaction

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -166,7 +165,8 @@ class TransactionDocumentTest {
                 faultCode,
                 faultCodeString,
                 Transaction.ClientId.CHECKOUT,
-                idCart
+                idCart,
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         Transaction transactionDocument = Transaction.from(transaction);

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 
@@ -25,7 +24,7 @@ class AuthorizationUpdateProjectionHandlerTest {
 
     private final TransactionsViewRepository viewRepository = Mockito.mock(TransactionsViewRepository.class);
 
-    private final int paymentTokenValidity = TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC.intValue();
+    private final int paymentTokenValidity = TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC;
 
     private final AuthorizationUpdateProjectionHandler authorizationUpdateProjectionHandler = new AuthorizationUpdateProjectionHandler(
             viewRepository,
@@ -89,7 +88,7 @@ class AuthorizationUpdateProjectionHandlerTest {
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
-                BigInteger.valueOf(paymentTokenValidity)
+                paymentTokenValidity
         );
 
         /*
@@ -173,7 +172,7 @@ class AuthorizationUpdateProjectionHandlerTest {
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
-                BigInteger.valueOf(paymentTokenValidity)
+                paymentTokenValidity
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/AuthorizationUpdateProjectionHandlerTest.java
@@ -5,37 +5,32 @@ import it.pagopa.ecommerce.commons.documents.v1.TransactionAuthorizationComplete
 import it.pagopa.ecommerce.commons.domain.v1.TransactionActivated;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
-import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.transactions.server.model.OutcomeVposGatewayDto;
 import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 
 import static org.mockito.ArgumentMatchers.argThat;
 
-@ExtendWith(MockitoExtension.class)
 class AuthorizationUpdateProjectionHandlerTest {
 
-    @InjectMocks
-    private AuthorizationUpdateProjectionHandler authorizationUpdateProjectionHandler;
+    private final TransactionsViewRepository viewRepository = Mockito.mock(TransactionsViewRepository.class);
 
-    @Mock
-    private TransactionsViewRepository viewRepository;
+    private final int paymentTokenValidity = TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC.intValue();
 
-    @Mock
-    private ConfidentialDataManager confidentialDataManager;
+    private final AuthorizationUpdateProjectionHandler authorizationUpdateProjectionHandler = new AuthorizationUpdateProjectionHandler(
+            viewRepository,
+            paymentTokenValidity
+    );
 
     private static final String expectedOperationTimestamp = "2023-01-01T01:02:03";
 
@@ -93,7 +88,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 null,
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                transaction.getTransactionActivatedData().getIdCart()
+                transaction.getTransactionActivatedData().getIdCart(),
+                BigInteger.valueOf(paymentTokenValidity)
         );
 
         /*
@@ -176,7 +172,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 null,
                 ZonedDateTime.parse(expectedDocument.getCreationDate()),
                 it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.CHECKOUT,
-                transaction.getTransactionActivatedData().getIdCart()
+                transaction.getTransactionActivatedData().getIdCart(),
+                BigInteger.valueOf(paymentTokenValidity)
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTest.java
@@ -22,13 +22,11 @@ import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
 import static it.pagopa.ecommerce.commons.v1.TransactionTestUtils.EMAIL_STRING;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,7 +101,8 @@ class TransactionServiceTest {
                 "faultCode",
                 "faultCodeString",
                 Transaction.ClientId.CHECKOUT,
-                "idCart"
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -327,7 +327,8 @@ class TransactionServiceTests {
                 "faultCode",
                 "faultCodeString",
                 Transaction.ClientId.CHECKOUT,
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -1038,7 +1039,8 @@ class TransactionServiceTests {
                 "faultCode",
                 "faultCodeString",
                 Transaction.ClientId.CHECKOUT,
-                transactionDocument.getIdCart()
+                transactionDocument.getIdCart(),
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/84
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add configured payment token validity time into TransactionActivatedEvent
<!--- Describe your changes in detail -->

#### Motivation and Context
Payment token validity time is used by event dispatcher to perform checks before send close payment retry event
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
Tests with ecommerce local -> perform a new transaction checking that payment token validity time is correctly valued into transaction activated event
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.