### PR TITLE
CHK-1301-refund_requested_optional

### DIFF
--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -523,11 +523,15 @@ public class TransactionsService {
                 )
                 )
                 .flatMap(
-                        el -> el.getT1().isEmpty() ? el.getT2().fold(
-                                closureErrorEvent -> closureErrorProjectionHandler.handle(closureErrorEvent),
-                                closureDataTransactionEvent -> closureSendProjectionHandler
-                                        .handle(closureDataTransactionEvent)
-                        ) : refundRequestProjectionHandler.handle(el.getT1().get())
+                        el -> el.getT1().map(
+                                refundEvent -> refundRequestProjectionHandler.handle(refundEvent)
+                        ).orElse(
+                                el.getT2().fold(
+                                        closureErrorEvent -> closureErrorProjectionHandler.handle(closureErrorEvent),
+                                        closureDataTransactionEvent -> closureSendProjectionHandler
+                                                .handle(closureDataTransactionEvent)
+                                )
+                        )
 
                 );
     }

--- a/src/main/java/it/pagopa/transactions/services/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/TransactionsService.java
@@ -523,18 +523,12 @@ public class TransactionsService {
                 )
                 )
                 .flatMap(
-                        result -> result.fold(
-                                errorEvent -> errorEvent.fold(
-                                        errorEventRefunded -> refundRequestProjectionHandler.handle(errorEventRefunded),
-                                        errorEventNoRefund -> closureErrorProjectionHandler.handle(errorEventNoRefund)
-                                ),
-                                closureSentEvent -> closureSentEvent.fold(
-                                        closureSentEventRefunded -> refundRequestProjectionHandler
-                                                .handle(closureSentEventRefunded),
-                                        closureDataTransactionEvent -> closureSendProjectionHandler
-                                                .handle(closureDataTransactionEvent)
-                                )
-                        )
+                        el -> el.getT1().isEmpty() ? el.getT2().fold(
+                                closureErrorEvent -> closureErrorProjectionHandler.handle(closureErrorEvent),
+                                closureDataTransactionEvent -> closureSendProjectionHandler
+                                        .handle(closureDataTransactionEvent)
+                        ) : refundRequestProjectionHandler.handle(el.getT1().get())
+
                 );
     }
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -390,11 +390,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -546,11 +549,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -788,11 +794,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2().get());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1022,10 +1031,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1279,10 +1288,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1530,10 +1539,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.getLeft().getLeft().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.getLeft().getLeft().getTransactionId());
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1705,10 +1714,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -1875,10 +1884,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2145,10 +2154,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2395,10 +2404,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2591,10 +2600,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.get().getLeft().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.get().getLeft().getTransactionId());
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2804,10 +2813,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.getLeft().getLeft().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.getLeft().getLeft().getTransactionId());
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -2928,11 +2937,14 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isRight());
-                    assertNotNull(next.get());
-                    assertEquals(event.getData().getResponseOutcome(), next.get().get().getData().getResponseOutcome());
-                    assertEquals(event.getEventCode(), next.get().get().getEventCode());
-                    assertEquals(event.getTransactionId(), next.get().get().getTransactionId());
+                    assertTrue(next.getT2().isRight());
+                    assertNotNull(next.getT2().get());
+                    assertEquals(
+                            event.getData().getResponseOutcome(),
+                            next.getT2().get().getData().getResponseOutcome()
+                    );
+                    assertEquals(event.getEventCode(), next.getT2().get().getEventCode());
+                    assertEquals(event.getTransactionId(), next.getT2().get().getTransactionId());
                 })
                 .verifyComplete();
 
@@ -3041,10 +3053,10 @@ class TransactionSendClosureHandlerTest {
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
                 .consumeNextWith(next -> {
-                    assertTrue(next.isLeft());
-                    assertNotNull(next.getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getLeft().get().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getLeft().get().getTransactionId());
+                    assertTrue(next.getT2().isLeft());
+                    assertNotNull(next.getT2().getLeft());
+                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
+                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
                 })
                 .verifyComplete();
 

--- a/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/TransactionServiceTests.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.services;
 
+import io.vavr.Tuple;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.v1.Transaction;
 import it.pagopa.ecommerce.commons.documents.v1.*;
@@ -36,10 +37,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -460,7 +464,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(Either.right(closureSentEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.empty(), Either.right(closureSentEvent))));
 
         Mockito.when(closureSendProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(closedTransactionDocument));
@@ -1174,7 +1178,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.left(Either.left(refundRequestedEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.of(refundRequestedEvent), Either.right(null))));
 
         Mockito.when(refundRequestProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(refundedRequestedTransactionDocument));
@@ -1265,7 +1269,7 @@ class TransactionServiceTests {
                 statusUpdateData
         );
 
-        TransactionClosureErrorEvent closureSentEvent = TransactionTestUtils
+        TransactionClosureErrorEvent closureErrorSentEvent = TransactionTestUtils
                 .transactionClosureErrorEvent();
 
         TransactionInfoDto expectedResponse = new TransactionInfoDto()
@@ -1301,7 +1305,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.left(Either.right(closureSentEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.empty(), Either.left(closureErrorSentEvent))));
 
         Mockito.when(closureErrorProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(refundedRequestedTransactionDocument));
@@ -1430,7 +1434,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(Either.left(refundRequestedEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.of(refundRequestedEvent), Either.left(null))));
 
         Mockito.when(refundRequestProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(refundedRequestedTransactionDocument));
@@ -1557,7 +1561,7 @@ class TransactionServiceTests {
         Mockito.when(authorizationUpdateProjectionHandler.handle(any())).thenReturn(Mono.just(transaction));
 
         Mockito.when(transactionSendClosureHandler.handle(any()))
-                .thenReturn(Mono.just(Either.right(Either.right(closureSentEvent))));
+                .thenReturn(Mono.just(Tuples.of(Optional.empty(), Either.right(closureSentEvent))));
 
         Mockito.when(closureSendProjectionHandler.handle(any()))
                 .thenReturn(Mono.just(requestedTransactionDocument));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added a new projectionHandler for handling view update at **REFUND_REQUESTED**.
Updated transaction refund logic, specifically:
- In case of an unrecoverable error of the closePayment request you have to perform a transaction refund and update to view to **REFUND_REQUESTED**.
- In case of a recoverable error of the closePayment request you have to add the event in the retry queue and update the view state to **CLOSURE_ERROR**.
- In case of closePayment with a KO by the node if the transaction was authorized by the **PGS** a refund request must be made and the view updated to **REFUND_REQUESTED**.
-  In case of closePayment with a KO by the node if the transaction was not authorized by the **PGS** update the view to **UNAUTHORIZED**..
- In case of closePayment OK by the node you have to update the view with **CLOSED** status.
<!--- Describe your changes in detail -->

#### Motivation and Context
The goal of the activity was to manage the close payment response so that the view was updated with the correct state.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
The tests were carried out in local with ecommerce-local.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.