### PR TITLE
[CHK-1482] fix: set notice amount from nodoActivation response

### DIFF
--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -108,7 +108,7 @@ public class NodoOperations {
                                 response.getFiscalCodePA(),
                                 response.getCompanyName(),
                                 response.getPaymentDescription(),
-                                amount.multiply(BigDecimal.valueOf(100)).intValue(),
+                                getEuroCentsFromNodoAmount(response.getTotalAmount()),
                                 null,
                                 response.getPaymentToken(),
                                 ZonedDateTime.now().toString(),

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -7,6 +7,7 @@ import it.pagopa.transactions.client.NodeForPspClient;
 import it.pagopa.transactions.configurations.NodoConfig;
 import it.pagopa.transactions.exceptions.InvalidNodoResponseException;
 import it.pagopa.transactions.exceptions.NodoErrorException;
+import org.jetbrains.annotations.TestOnly;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.UUID;
 
@@ -422,5 +424,92 @@ class NodoOperationsTest {
 
         /* asserts */
         assertEquals(10, randomStringToIdempotencyKey.length());
+    }
+
+    @Test
+    void shouldGetTheUpdatedAmount() {
+        RptId rptId = new RptId("77777777777302016723749670035");
+        IdempotencyKey idempotencyKey = new IdempotencyKey("32009090901", "aabbccddee");
+        String paymentToken = UUID.randomUUID().toString();
+        String transactionId = UUID.randomUUID().toString();
+        String paTaxCode = "77777777777";
+        String description = "Description";
+        int amount = 1000;
+        String idCart = "idCart";
+        it.pagopa.generated.transactions.model.ObjectFactory objectFactoryUtil = new it.pagopa.generated.transactions.model.ObjectFactory();
+        BigDecimal outdatedAmount = BigDecimal.valueOf(amount);
+        BigDecimal updatedAmount = BigDecimal.valueOf(amount + 100);
+        String fiscalCode = "77777777777";
+        String paymentNotice = "302000100000009424";
+        CtTransferListPSPV2 ctTransferListPSPV2 = objectFactoryUtil.createCtTransferListPSPV2();
+        CtTransferPSPV2 ctTransferPSPV2 = objectFactoryUtil.createCtTransferPSPV2();
+        ctTransferPSPV2.setIdTransfer(1);
+        ctTransferPSPV2.setFiscalCodePA(fiscalCode);
+        ctTransferPSPV2.setTransferAmount(BigDecimal.valueOf(amount));
+        ctTransferPSPV2.setIBAN("It41B0000000000000000899876543234567");
+        ctTransferPSPV2.setRemittanceInformation("test1");
+        byte[] testByte = new byte[] {
+                0,
+                1,
+                2,
+                3
+        };
+        CtRichiestaMarcaDaBollo ctRichiestaMarcaDaBollo = objectFactoryUtil.createCtRichiestaMarcaDaBollo();
+        ctRichiestaMarcaDaBollo.setTipoBollo("Tipo Bollo");
+        ctRichiestaMarcaDaBollo.setProvinciaResidenza("RM");
+        ctRichiestaMarcaDaBollo.setHashDocumento(testByte);
+        CtTransferPSPV2 ctTransferPSPV2_1 = objectFactoryUtil.createCtTransferPSPV2();
+        ctTransferPSPV2_1.setIdTransfer(1);
+        ctTransferPSPV2_1.setFiscalCodePA(fiscalCode);
+        ctTransferPSPV2_1.setTransferAmount(BigDecimal.valueOf(amount));
+        ctTransferPSPV2_1.setRichiestaMarcaDaBollo(ctRichiestaMarcaDaBollo);
+        ctTransferPSPV2_1.setRemittanceInformation("test1");
+        ctTransferListPSPV2.getTransfer().add(ctTransferPSPV2);
+        ctTransferListPSPV2.getTransfer().add(ctTransferPSPV2_1);
+        ActivatePaymentNoticeV2Request activatePaymentReq = objectFactoryUtil.createActivatePaymentNoticeV2Request();
+        CtQrCode qrCode = new CtQrCode();
+        qrCode.setFiscalCode(fiscalCode);
+        qrCode.setNoticeNumber(paymentNotice);
+        activatePaymentReq.setAmount(outdatedAmount);
+        activatePaymentReq.setQrCode(qrCode);
+
+        ActivatePaymentNoticeV2Response activatePaymentRes = objectFactoryUtil.createActivatePaymentNoticeV2Response();
+        activatePaymentRes.setPaymentToken(paymentToken);
+        activatePaymentRes.setFiscalCodePA(fiscalCode);
+        activatePaymentRes.setTotalAmount(updatedAmount);
+        activatePaymentRes.setPaymentDescription(description);
+        activatePaymentRes.setOutcome(StOutcome.OK);
+        activatePaymentRes.setTransferList(ctTransferListPSPV2);
+        /* preconditions */
+        Mockito.when(nodeForPspClient.activatePaymentNoticeV2(Mockito.any()))
+                .thenReturn(Mono.just(activatePaymentRes));
+        Mockito.when(
+                objectFactoryNodeForPsp
+                        .createActivatePaymentNoticeV2Request(argThat(req -> req.getPaymentNote().equals(idCart)))
+        )
+                .thenAnswer(args -> objectFactoryUtil.createActivatePaymentNoticeV2Request(args.getArgument(0)));
+        Mockito.when(nodoConfig.baseActivatePaymentNoticeV2Request()).thenReturn(new ActivatePaymentNoticeV2Request());
+
+        /* test */
+        PaymentRequestInfo response = nodoOperations
+                .activatePaymentRequest(
+                        rptId,
+                        idempotencyKey,
+                        amount,
+                        transactionId,
+                        900,
+                        idCart
+                )
+                .block();
+
+        /* asserts */
+        Mockito.verify(nodeForPspClient, Mockito.times(1)).activatePaymentNoticeV2(Mockito.any());
+
+        assertEquals(rptId, response.id());
+        assertEquals(paymentToken, response.paymentToken());
+        assertEquals(description, response.description());
+        assertEquals(idempotencyKey, response.idempotencyKey());
+        assertEquals(paTaxCode, response.paFiscalCode());
+        assertEquals(updatedAmount.multiply(BigDecimal.valueOf(100)), BigDecimal.valueOf(response.amount()));
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
After the activation process of a payment notice the input data were used to to populate the redis cache and the view. The solution proposed with this PR uses the data obtained from the nodoActivation response.  

#### List of Changes
<!--- Describe your changes in detail -->
- Update amount from request to nodoActivation rsponse
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Get correct and updated amount

#### How Has This Been Tested?
- Unit
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.