### PR TITLE
feat(view): sendPaymentResult outcome NOT_RECEIVED

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.18.1</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.18.2</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <elastic-apm.version>1.38.0</elastic-apm.version>
     </properties>

--- a/src/main/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandler.java
@@ -8,6 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.util.Optional;
 
 @Component
 @Slf4j
@@ -21,14 +25,23 @@ public class ClosureSendProjectionHandler
         return transactionsViewRepository.findById(event.getTransactionId())
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(event.getTransactionId())))
                 .flatMap(transactionDocument -> {
-                    TransactionStatusDto newStatus =
+                    Tuple2<TransactionStatusDto, Optional<TransactionUserReceiptData.Outcome>> viewUpdatedData =
                             switch (event) {
-                                case TransactionClosedEvent e -> TransactionStatusDto.CLOSED;
-                                case TransactionClosureFailedEvent e -> TransactionStatusDto.UNAUTHORIZED;
+                                case TransactionClosedEvent e -> Tuples.of(TransactionStatusDto.CLOSED,
+                                        Optional
+                                                .of(e.getData())
+                                                .map(data -> switch (data.getResponseOutcome()) {
+                                                    case OK -> TransactionUserReceiptData.Outcome.NOT_RECEIVED;
+                                                    case KO -> null;
+                                                })
+                                );
+                                case TransactionClosureFailedEvent e ->
+                                        Tuples.of(TransactionStatusDto.UNAUTHORIZED, Optional.empty());
                                 case default -> throw new IllegalArgumentException("Unexpected event: " + event);
                             };
 
-                    transactionDocument.setStatus(newStatus);
+                    transactionDocument.setStatus(viewUpdatedData.getT1());
+                    transactionDocument.setSendPaymentResultOutcome(viewUpdatedData.getT2().orElse(null));
                     return transactionsViewRepository.save(transactionDocument);
                 });
     }

--- a/src/test/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/ClosureSendProjectionHandlerTests.java
@@ -1,9 +1,6 @@
 package it.pagopa.transactions.projections.handlers;
 
-import it.pagopa.ecommerce.commons.documents.v1.Transaction;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionClosedEvent;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionClosureData;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionClosureFailedEvent;
+import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
@@ -30,12 +27,43 @@ class ClosureSendProjectionHandlerTests {
     private ClosureSendProjectionHandler closureSendProjectionHandler;
 
     @Test
-    void shouldHandleProjectionForClosedEvent() {
+    void shouldHandleProjectionForClosedEventWithResponseOutcomeOK() {
         Transaction transaction = TransactionTestUtils
                 .transactionDocument(TransactionStatusDto.AUTHORIZATION_COMPLETED, ZonedDateTime.now());
 
         TransactionClosedEvent event = TransactionTestUtils
                 .transactionClosedEvent(TransactionClosureData.Outcome.OK);
+
+        Transaction expected = new Transaction(
+                transaction.getTransactionId(),
+                transaction.getPaymentNotices(),
+                transaction.getFeeTotal(),
+                transaction.getEmail(),
+                TransactionStatusDto.CLOSED,
+                Transaction.ClientId.CHECKOUT,
+                transaction.getCreationDate(),
+                transaction.getIdCart(),
+                transaction.getRrn()
+        );
+        expected.setSendPaymentResultOutcome(TransactionUserReceiptData.Outcome.NOT_RECEIVED);
+
+        Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))
+                .thenReturn(Mono.just(transaction));
+        Mockito.when(transactionsViewRepository.save(any()))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(closureSendProjectionHandler.handle(event))
+                .expectNext(expected)
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleProjectionForClosedEventWithResponseOutcomeKO() {
+        Transaction transaction = TransactionTestUtils
+                .transactionDocument(TransactionStatusDto.AUTHORIZATION_COMPLETED, ZonedDateTime.now());
+
+        TransactionClosedEvent event = TransactionTestUtils
+                .transactionClosedEvent(TransactionClosureData.Outcome.KO);
 
         Transaction expected = new Transaction(
                 transaction.getTransactionId(),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Value sendPaymentResultOutcome with NOT_RECEIVED when the received close payment response outcome is OK
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to value transactions-view sendPaymentResultOutcome according to the fact that a send payment result is expected to be received or not
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + tests with ecommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.