### PR TITLE
[CHK-1692] fix(activation): propagate verification due date

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -111,6 +111,8 @@ public class TransactionActivateHandler
                                     final PaymentNoticeInfoDto paymentNotice = paymentRequest.getT1();
                                     final Optional<PaymentRequestInfo> maybePaymentRequestInfo = paymentRequest
                                             .getT2();
+                                    final String dueDate = maybePaymentRequestInfo.map(PaymentRequestInfo::dueDate)
+                                            .orElse(null);
                                     return Mono.just(
                                             Tuples.of(
                                                     paymentNotice,
@@ -130,7 +132,7 @@ public class TransactionActivateHandler
                                                                                 null,
                                                                                 null,
                                                                                 null,
-                                                                                null,
+                                                                                dueDate,
                                                                                 null,
                                                                                 null,
                                                                                 new IdempotencyKey(
@@ -185,7 +187,8 @@ public class TransactionActivateHandler
                                                                     paymentNotice.getAmount(),
                                                                     transactionId.value(),
                                                                     paymentTokenTimeout,
-                                                                    newTransactionRequestDto.getIdCart()
+                                                                    newTransactionRequestDto.getIdCart(),
+                                                                    partialPaymentRequestInfo.dueDate()
                                                             )
                                                             .doOnSuccess(
                                                                     p -> {

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import javax.crypto.SecretKey;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -62,7 +61,8 @@ public class NodoOperations {
                                                            Integer amount,
                                                            String transactionId,
                                                            Integer paymentTokenTimeout,
-                                                           String idCart
+                                                           String idCart,
+                                                           String dueDate
     ) {
 
         final BigDecimal amountAsBigDecimal = BigDecimal.valueOf(amount.doubleValue() / 100)
@@ -74,7 +74,8 @@ public class NodoOperations {
                 idempotencyKey.rawValue(),
                 transactionId,
                 paymentTokenTimeout,
-                idCart
+                idCart,
+                dueDate
         );
     }
 
@@ -84,7 +85,8 @@ public class NodoOperations {
                                                                         String idempotencyKey,
                                                                         String transactionId,
                                                                         Integer paymentTokenTimeout,
-                                                                        String idCart
+                                                                        String idCart,
+                                                                        String dueDate
     ) {
         CtQrCode qrCode = new CtQrCode();
         qrCode.setFiscalCode(rptId.getFiscalCode());
@@ -126,7 +128,7 @@ public class NodoOperations {
                                 response.getCompanyName(),
                                 response.getPaymentDescription(),
                                 getEuroCentsFromNodoAmount(response.getTotalAmount()),
-                                null,
+                                dueDate,
                                 response.getPaymentToken(),
                                 ZonedDateTime.now().toString(),
                                 new IdempotencyKey(idempotencyKey),

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.transactions.utils;
 
-import it.pagopa.ecommerce.commons.domain.v1.*;
+import it.pagopa.ecommerce.commons.domain.v1.IdempotencyKey;
+import it.pagopa.ecommerce.commons.domain.v1.RptId;
 import it.pagopa.ecommerce.commons.repositories.PaymentRequestInfo;
 import it.pagopa.generated.transactions.model.*;
 import it.pagopa.transactions.client.NodeForPspClient;
@@ -10,7 +11,10 @@ import it.pagopa.transactions.exceptions.NodoErrorException;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
@@ -37,6 +41,8 @@ class NodoOperationsTest {
 
     @Captor
     ArgumentCaptor<ActivatePaymentNoticeV2Request> activatePaymentNoticeReqArgumentCaptor;
+
+    private final String dueDate = "2031-12-31";
 
     void instantiateNodoOperations(boolean lightAllCCPCheck) {
         nodoOperations = new NodoOperations(
@@ -119,7 +125,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -218,7 +225,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -317,7 +325,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -395,7 +404,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -484,7 +494,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -562,7 +573,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -653,7 +665,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -752,7 +765,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -851,7 +865,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -950,7 +965,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -1049,7 +1065,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -1148,7 +1165,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -1243,7 +1261,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -1338,7 +1357,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -1424,7 +1444,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        null
+                        null,
+                        dueDate
                 )
                 .block();
 
@@ -1479,7 +1500,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 );
 
         Assert.assertThrows(
@@ -1531,7 +1553,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 );
 
         InvalidNodoResponseException exception = Assert.assertThrows(
@@ -1608,7 +1631,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 
@@ -1731,7 +1755,8 @@ class NodoOperationsTest {
                         amount,
                         transactionId,
                         900,
-                        idCart
+                        idCart,
+                        dueDate
                 )
                 .block();
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Propagate dueDate saved during verification process into cache informations saved after Nodo activate call.
<!--- Describe your changes in detail -->

#### Motivation and Context
In the current transaction activation flow, due date is overridden by transaction service that set this field forcibly to null.
This way, a new verification performed after transaction activation, that will not communicate with Nodo because of cache hit, will return a response without the dueDate field valued
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.