### PR TITLE
[CHK-1693] update transaction status constant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-infra/df87697f23ac384723c9c63f33201b277a9d59dc/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl</inputSpec>
+                            <inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-infra/eff0d7e961328c9888d73dc17d96695301df1861/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl</inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandler.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
 public class TransactionSendClosureHandler implements
         CommandHandler<TransactionClosureSendCommand, Mono<Tuple2<Optional<TransactionRefundRequestedEvent>, Either<TransactionClosureErrorEvent, TransactionEvent<TransactionClosureData>>>>> {
 
-    private static final String AUTORIZZATO = "Autorizzato";
+    private static final String CONFERMATO = "Confermato";
     private static final String RIFIUTATO = "Rifiutato";
     private final TransactionsEventStoreRepository<TransactionClosureData> transactionEventStoreRepository;
 
@@ -401,7 +401,7 @@ public class TransactionSendClosureHandler implements
     ) {
         return new TransactionDto()
                 .transactionStatus(
-                        ClosePaymentRequestV2Dto.OutcomeEnum.OK.equals(outcomeEnum) ? AUTORIZZATO : RIFIUTATO
+                        ClosePaymentRequestV2Dto.OutcomeEnum.OK.equals(outcomeEnum) ? CONFERMATO : RIFIUTATO
                 )
                 .fee(fee)
                 .amount(amount)

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -842,7 +842,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -1103,7 +1103,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -1364,7 +1364,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -1647,7 +1647,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -2422,7 +2422,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -2693,7 +2693,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -2913,7 +2913,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .amount(
                                                         EuroUtils.euroCentsToEuro(
@@ -3128,7 +3128,7 @@ class TransactionSendClosureHandlerTest {
                                                         ((BaseTransactionWithPaymentToken) transaction)
                                                                 .getTransactionId().value()
                                                 )
-                                                .transactionStatus("Autorizzato")
+                                                .transactionStatus("Confermato")
                                                 .fee(EuroUtils.euroCentsToEuro(authorizationRequestData.getFee()))
                                                 .paymentGateway(authorizationRequestData.getPaymentGateway().name())
                                                 .timestampOperation(


### PR DESCRIPTION
Change transaction details transactionStatus field from "Autorizzato" to "Confermato"

#### List of Changes

Update constant value in closure handler

#### Motivation and Context

This PR address some bizEvent bounds

#### How Has This Been Tested?

Junit tests has been edited and ran

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.