### PR TITLE
feat(monitoring): trace Nodo fault code into custom open telemetry span

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.19.3</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.19.5</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <jacoco.version>0.8.8</jacoco.version>
         <pagopa-ecommerce-commons.version>0.19.3</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
-        <elastic-apm.version>1.38.0</elastic-apm.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
     </properties>
     <dependencies>
@@ -214,11 +213,6 @@
             <artifactId>netty-resolver-dns-native-macos</artifactId>
             <version>4.1.82.Final</version>
             <classifier>osx-aarch_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-agent-api</artifactId>
-            <version>${elastic-apm.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -258,11 +258,13 @@ public class TransactionActivateHandler
              * inside Transaction view
              */
             openTelemetryUtils.addSpanWithAttributes(
-                    "Transaction re-activated",
+                    OpenTelemetryUtils.REPEATED_ACTIVATION_SPAN_NAME,
                     Attributes.of(
-                            AttributeKey.stringKey("paymentToken"),
+                            AttributeKey.stringKey(OpenTelemetryUtils.REPEATED_ACTIVATION_PAYMENT_TOKEN_ATTRIBUTE_KEY),
                             paymentToken,
-                            AttributeKey.longKey("paymentTokenLeftTimeSec"),
+                            AttributeKey.longKey(
+                                    OpenTelemetryUtils.REPEATED_ACTIVATION_PAYMENT_TOKEN_LEFT_TIME_ATTRIBUTE_KEY
+                            ),
                             paymentTokenValidityTimeLeft.getSeconds()
                     )
             );

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -245,6 +245,12 @@ public class TransactionActivateHandler
     private void traceRepeatedActivation(PaymentRequestInfo paymentRequestInfo) {
         String transactionActivationDateString = paymentRequestInfo.activationDate();
         String paymentToken = paymentRequestInfo.paymentToken();
+        /*
+         * Issue https://github.com/elastic/kibana/issues/123256 Span events attached to
+         * the Span.currentSpan() are not visible into Transaction detail so here we
+         * start a new span as workaround in order to make this event visible also
+         * inside Transaction view
+         */
         Span span = openTelemetryTracer.spanBuilder("Transaction re-activated").startSpan();
         try {
             if (transactionActivationDateString != null && paymentToken != null) {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionActivateHandler.java
@@ -278,7 +278,7 @@ public class TransactionActivateHandler
                     paymentRequestInfo.id(),
                     paymentRequestInfo.paymentToken()
             );
-            openTelemetryUtils.addErrorSpanWithError(
+            openTelemetryUtils.addErrorSpanWithException(
                     "Transaction re-activated",
                     new IllegalArgumentException(
                             "Null transaction activation date or payment token for rptId %s in repeated activation"

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -125,9 +125,11 @@ public class NodoOperations {
                                         : Mono.error(new InvalidNodoResponseException("No payment token received"));
                             } else {
                                 openTelemetryUtils.addErrorSpanWithAttributes(
-                                        "Nodo activatePaymentNoticeV2 error",
+                                        OpenTelemetryUtils.NODO_ACTIVATION_ERROR_SPAN_NAME,
                                         Attributes.of(
-                                                AttributeKey.stringKey("faultCode"),
+                                                AttributeKey.stringKey(
+                                                        OpenTelemetryUtils.NODO_ACTIVATION_ERROR_FAULT_CODE_ATTRIBUTE_KEY
+                                                ),
                                                 faultCode
                                         )
                                 );

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -7,16 +7,34 @@ import io.opentelemetry.api.trace.Tracer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Open telemetry utility class used to create spans inside the current
+ * transaction with custom arguments
+ *
+ * @see Tracer
+ * @see Span
+ */
 @Component
 public class OpenTelemetryUtils {
 
     private final Tracer openTelemetryTracer;
 
+    /**
+     * Default constructor
+     *
+     * @param openTelemetryTracer - open telemetry tracer instance
+     */
     @Autowired
     public OpenTelemetryUtils(Tracer openTelemetryTracer) {
         this.openTelemetryTracer = openTelemetryTracer;
     }
 
+    /**
+     * Add span to the current transactions with the input arguments and name
+     *
+     * @param spanName   - span name
+     * @param attributes - span attributes
+     */
     public void addSpanWithAttributes(
                                       String spanName,
                                       Attributes attributes
@@ -28,6 +46,13 @@ public class OpenTelemetryUtils {
 
     }
 
+    /**
+     * Add an error span to the current transaction with the input arguments and
+     * name
+     *
+     * @param spanName   - error span name
+     * @param attributes - error span attributes
+     */
     public void addErrorSpanWithAttributes(
                                            String spanName,
                                            Attributes attributes
@@ -40,14 +65,20 @@ public class OpenTelemetryUtils {
 
     }
 
+    /**
+     * Add an error span to the current transaction with the input name and
+     * throwable stacktrace
+     *
+     * @param spanName  - error span name
+     * @param throwable - error cause Throwable
+     */
     public void addErrorSpanWithException(
                                           String spanName,
                                           Throwable throwable
     ) {
         Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
-        span
-                .setStatus(StatusCode.ERROR)
-                .recordException(throwable);
+        span.setStatus(StatusCode.ERROR);
+        span.recordException(throwable);
         span.end();
     }
 

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -17,6 +17,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class OpenTelemetryUtils {
 
+    /**
+     * Nodo activation
+     */
+    public static final String NODO_ACTIVATION_ERROR_SPAN_NAME = "Nodo activatePaymentNoticeV2 error";
+    public static final String NODO_ACTIVATION_ERROR_FAULT_CODE_ATTRIBUTE_KEY = "faultCode";
+
+    public static final String REPEATED_ACTIVATION_SPAN_NAME = "Transaction re-activated";
+
+    public static final String REPEATED_ACTIVATION_PAYMENT_TOKEN_ATTRIBUTE_KEY = "paymentToken";
+
+    public static final String REPEATED_ACTIVATION_PAYMENT_TOKEN_LEFT_TIME_ATTRIBUTE_KEY = "paymentTokenLeftTimeSec";
+
     private final Tracer openTelemetryTracer;
 
     /**

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -1,0 +1,46 @@
+package it.pagopa.transactions.utils;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenTelemetryUtils {
+
+    private final Tracer openTelemetryTracer;
+
+    @Autowired
+    public OpenTelemetryUtils(Tracer openTelemetryTracer) {
+        this.openTelemetryTracer = openTelemetryTracer;
+    }
+
+    public void addSpanWithAttributes(
+                                      String spanName,
+                                      Attributes attributes
+    ) {
+
+        Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
+        try {
+            span.setAllAttributes(attributes);
+        } finally {
+            span.end();
+        }
+    }
+
+    public void addErrorSpanWithError(
+                                      String spanName,
+                                      Throwable throwable
+    ) {
+        Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
+        try {
+            span
+                    .setStatus(StatusCode.ERROR)
+                    .recordException(throwable);
+        } finally {
+            span.end();
+        }
+    }
+}

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -23,11 +23,9 @@ public class OpenTelemetryUtils {
     ) {
 
         Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
-        try {
-            span.setAllAttributes(attributes);
-        } finally {
-            span.end();
-        }
+        span.setAllAttributes(attributes);
+        span.end();
+
     }
 
     public void addErrorSpanWithError(
@@ -35,12 +33,9 @@ public class OpenTelemetryUtils {
                                       Throwable throwable
     ) {
         Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
-        try {
-            span
-                    .setStatus(StatusCode.ERROR)
-                    .recordException(throwable);
-        } finally {
-            span.end();
-        }
+        span
+                .setStatus(StatusCode.ERROR)
+                .recordException(throwable);
+        span.end();
     }
 }

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -28,9 +28,21 @@ public class OpenTelemetryUtils {
 
     }
 
-    public void addErrorSpanWithError(
-                                      String spanName,
-                                      Throwable throwable
+    public void addErrorSpanWithAttributes(
+                                           String spanName,
+                                           Attributes attributes
+    ) {
+
+        Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
+        span.setAllAttributes(attributes);
+        span.setStatus(StatusCode.ERROR);
+        span.end();
+
+    }
+
+    public void addErrorSpanWithException(
+                                          String spanName,
+                                          Throwable throwable
     ) {
         Span span = openTelemetryTracer.spanBuilder(spanName).startSpan();
         span
@@ -38,4 +50,5 @@ public class OpenTelemetryUtils {
                 .recordException(throwable);
         span.end();
     }
+
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -174,7 +174,7 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(openTelemetryUtils, Mockito.times(0)).addErrorSpanWithError(any(), any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(0)).addErrorSpanWithException(any(), any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 
@@ -266,7 +266,7 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithError(any(), any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithException(any(), any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -175,11 +175,19 @@ class TransactionInitializerHandlerTest {
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
         Mockito.verify(openTelemetryUtils, Mockito.times(1)).addSpanWithAttributes(
-                eq("Transaction re-activated"),
+                eq(OpenTelemetryUtils.REPEATED_ACTIVATION_SPAN_NAME),
                 argThat(
                         arguments -> {
-                            String spanPaymentToken = arguments.get(AttributeKey.stringKey("paymentToken"));
-                            Long spanLeftTime = arguments.get(AttributeKey.longKey("paymentTokenLeftTimeSec"));
+                            String spanPaymentToken = arguments.get(
+                                    AttributeKey.stringKey(
+                                            OpenTelemetryUtils.REPEATED_ACTIVATION_PAYMENT_TOKEN_ATTRIBUTE_KEY
+                                    )
+                            );
+                            Long spanLeftTime = arguments.get(
+                                    AttributeKey.longKey(
+                                            OpenTelemetryUtils.REPEATED_ACTIVATION_PAYMENT_TOKEN_LEFT_TIME_ATTRIBUTE_KEY
+                                    )
+                            );
                             return paymentToken.equals(spanPaymentToken) && spanLeftTime != null;
                         }
                 )
@@ -278,7 +286,7 @@ class TransactionInitializerHandlerTest {
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
         Mockito.verify(openTelemetryUtils, Mockito.times(0)).addSpanWithAttributes(any(), any());
         Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithException(
-                eq("Transaction re-activated"),
+                eq(OpenTelemetryUtils.REPEATED_ACTIVATION_SPAN_NAME),
                 argThat(throwable -> throwable.getMessage().contains(rptId.value()))
         );
         assertNotNull(paymentRequestInfoCached.id());

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -1,5 +1,8 @@
 package it.pagopa.transactions.commands.handlers;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
 import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.IdempotencyKey;
@@ -78,6 +81,12 @@ class TransactionInitializerHandlerTest {
     @Captor
     private ArgumentCaptor<PaymentRequestInfo> paymentRequestInfoArgumentCaptor;
 
+    private final Tracer openTelemetryTracer = Mockito.mock(Tracer.class);
+
+    private final SpanBuilder spanBuilder = Mockito.mock(SpanBuilder.class);
+
+    private final Span span = Mockito.mock(Span.class);
+
     private final TransactionActivateHandler handler = new TransactionActivateHandler(
             paymentRequestInfoRedisTemplateWrapper,
             transactionEventActivatedStoreRepository,
@@ -88,7 +97,8 @@ class TransactionInitializerHandlerTest {
             confidentialMailUtils,
             transientQueueEventsTtlSeconds,
             nodoParallelRequests,
-            tracingUtils
+            tracingUtils,
+            openTelemetryTracer
     );
 
     @Test
@@ -167,6 +177,11 @@ class TransactionInitializerHandlerTest {
 
         Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
+        Mockito.when(openTelemetryTracer.spanBuilder(any())).thenReturn(spanBuilder);
+        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
+        Mockito.when(span.setStatus(any())).thenReturn(span);
+        Mockito.when(span.setAttribute(any(String.class), any())).thenReturn(span);
+
         /* run test */
         Tuple2<Mono<TransactionActivatedEvent>, String> response = handler
                 .handle(command).block();
@@ -174,6 +189,7 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
+        Mockito.verify(span, Mockito.times(0)).recordException(any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 
@@ -258,6 +274,11 @@ class TransactionInitializerHandlerTest {
 
         Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
+        Mockito.when(openTelemetryTracer.spanBuilder(any())).thenReturn(spanBuilder);
+        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
+        Mockito.when(span.setStatus(any())).thenReturn(span);
+        Mockito.when(span.setAttribute(any(String.class), any())).thenReturn(span);
+
         /* run test */
         Tuple2<Mono<TransactionActivatedEvent>, String> response = handler
                 .handle(command).block();
@@ -265,6 +286,7 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
+        Mockito.verify(span, Mockito.times(1)).recordException(any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.commands.handlers;
 
+import io.opentelemetry.api.common.AttributeKey;
 import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.IdempotencyKey;
@@ -39,8 +40,7 @@ import java.util.UUID;
 
 import static it.pagopa.ecommerce.commons.v1.TransactionTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 class TransactionInitializerHandlerTest {
@@ -93,7 +93,7 @@ class TransactionInitializerHandlerTest {
 
     @Test
     void shouldHandleCommandForNM3CachedPaymentRequest() {
-        Duration elapsedTimeFromActivation = Duration.ofMinutes(5);
+        Duration elapsedTimeFromActivation = Duration.ofSeconds(paymentTokenTimeout);
         ZonedDateTime transactionActivatedTime = ZonedDateTime.now().minus(elapsedTimeFromActivation);
         RptId rptId = new RptId(RPT_ID);
         IdempotencyKey idempotencyKey = new IdempotencyKey("32009090901", "aabbccddee");
@@ -174,6 +174,16 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(1)).addSpanWithAttributes(
+                eq("Transaction re-activated"),
+                argThat(
+                        arguments -> {
+                            String spanPaymentToken = arguments.get(AttributeKey.stringKey("paymentToken"));
+                            Long spanLeftTime = arguments.get(AttributeKey.longKey("paymentTokenLeftTimeSec"));
+                            return paymentToken.equals(spanPaymentToken) && spanLeftTime != null;
+                        }
+                )
+        );
         Mockito.verify(openTelemetryUtils, Mockito.times(0)).addErrorSpanWithException(any(), any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
@@ -266,7 +276,11 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithException(any(), any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(0)).addSpanWithAttributes(any(), any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithException(
+                eq("Transaction re-activated"),
+                argThat(throwable -> throwable.getMessage().contains(rptId.value()))
+        );
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -1,8 +1,5 @@
 package it.pagopa.transactions.commands.handlers;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanBuilder;
-import io.opentelemetry.api.trace.Tracer;
 import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.IdempotencyKey;
@@ -81,12 +78,6 @@ class TransactionInitializerHandlerTest {
     @Captor
     private ArgumentCaptor<PaymentRequestInfo> paymentRequestInfoArgumentCaptor;
 
-    private final Tracer openTelemetryTracer = Mockito.mock(Tracer.class);
-
-    private final SpanBuilder spanBuilder = Mockito.mock(SpanBuilder.class);
-
-    private final Span span = Mockito.mock(Span.class);
-
     private final TransactionActivateHandler handler = new TransactionActivateHandler(
             paymentRequestInfoRedisTemplateWrapper,
             transactionEventActivatedStoreRepository,
@@ -97,8 +88,7 @@ class TransactionInitializerHandlerTest {
             confidentialMailUtils,
             transientQueueEventsTtlSeconds,
             nodoParallelRequests,
-            tracingUtils,
-            openTelemetryTracer
+            tracingUtils
     );
 
     @Test
@@ -177,11 +167,6 @@ class TransactionInitializerHandlerTest {
 
         Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
-        Mockito.when(openTelemetryTracer.spanBuilder(any())).thenReturn(spanBuilder);
-        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
-        Mockito.when(span.setStatus(any())).thenReturn(span);
-        Mockito.when(span.setAttribute(any(String.class), any())).thenReturn(span);
-
         /* run test */
         Tuple2<Mono<TransactionActivatedEvent>, String> response = handler
                 .handle(command).block();
@@ -189,7 +174,6 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(span, Mockito.times(0)).recordException(any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 
@@ -274,11 +258,6 @@ class TransactionInitializerHandlerTest {
 
         Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
-        Mockito.when(openTelemetryTracer.spanBuilder(any())).thenReturn(spanBuilder);
-        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
-        Mockito.when(span.setStatus(any())).thenReturn(span);
-        Mockito.when(span.setAttribute(any(String.class), any())).thenReturn(span);
-
         /* run test */
         Tuple2<Mono<TransactionActivatedEvent>, String> response = handler
                 .handle(command).block();
@@ -286,7 +265,6 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(span, Mockito.times(1)).recordException(any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionInitializerHandlerTest.java
@@ -1,8 +1,5 @@
 package it.pagopa.transactions.commands.handlers;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanBuilder;
-import io.opentelemetry.api.trace.Tracer;
 import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.IdempotencyKey;
@@ -23,10 +20,7 @@ import it.pagopa.transactions.exceptions.InvalidNodoResponseException;
 import it.pagopa.transactions.exceptions.JWTTokenGenerationException;
 import it.pagopa.transactions.projections.TransactionsProjection;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
-import it.pagopa.transactions.utils.ConfidentialMailUtils;
-import it.pagopa.transactions.utils.JwtTokenUtils;
-import it.pagopa.transactions.utils.NodoOperations;
-import it.pagopa.transactions.utils.Queues;
+import it.pagopa.transactions.utils.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -81,11 +75,7 @@ class TransactionInitializerHandlerTest {
     @Captor
     private ArgumentCaptor<PaymentRequestInfo> paymentRequestInfoArgumentCaptor;
 
-    private final Tracer openTelemetryTracer = Mockito.mock(Tracer.class);
-
-    private final SpanBuilder spanBuilder = Mockito.mock(SpanBuilder.class);
-
-    private final Span span = Mockito.mock(Span.class);
+    private final OpenTelemetryUtils openTelemetryUtils = Mockito.mock(OpenTelemetryUtils.class);
 
     private final TransactionActivateHandler handler = new TransactionActivateHandler(
             paymentRequestInfoRedisTemplateWrapper,
@@ -98,7 +88,7 @@ class TransactionInitializerHandlerTest {
             transientQueueEventsTtlSeconds,
             nodoParallelRequests,
             tracingUtils,
-            openTelemetryTracer
+            openTelemetryUtils
     );
 
     @Test
@@ -177,11 +167,6 @@ class TransactionInitializerHandlerTest {
 
         Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
-        Mockito.when(openTelemetryTracer.spanBuilder(any())).thenReturn(spanBuilder);
-        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
-        Mockito.when(span.setStatus(any())).thenReturn(span);
-        Mockito.when(span.setAttribute(any(String.class), any())).thenReturn(span);
-
         /* run test */
         Tuple2<Mono<TransactionActivatedEvent>, String> response = handler
                 .handle(command).block();
@@ -189,7 +174,7 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(span, Mockito.times(0)).recordException(any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(0)).addErrorSpanWithError(any(), any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 
@@ -274,11 +259,6 @@ class TransactionInitializerHandlerTest {
 
         Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
-        Mockito.when(openTelemetryTracer.spanBuilder(any())).thenReturn(spanBuilder);
-        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
-        Mockito.when(span.setStatus(any())).thenReturn(span);
-        Mockito.when(span.setAttribute(any(String.class), any())).thenReturn(span);
-
         /* run test */
         Tuple2<Mono<TransactionActivatedEvent>, String> response = handler
                 .handle(command).block();
@@ -286,7 +266,7 @@ class TransactionInitializerHandlerTest {
         /* asserts */
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
         Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(0)).save(any());
-        Mockito.verify(span, Mockito.times(1)).recordException(any());
+        Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithError(any(), any());
         assertNotNull(paymentRequestInfoCached.id());
         TransactionActivatedEvent event = response.getT1().block();
 

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 class NodoOperationsTest {
@@ -1861,16 +1860,15 @@ class NodoOperationsTest {
         /* asserts */
         Mockito.verify(nodeForPspClient, Mockito.times(1)).activatePaymentNoticeV2(Mockito.any());
         Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithAttributes(
-                eq(OpenTelemetryUtils.NODO_ACTIVATION_ERROR_SPAN_NAME),
-                eq(
-                        Attributes
-                                .of(
-                                        AttributeKey.stringKey(
-                                                OpenTelemetryUtils.NODO_ACTIVATION_ERROR_FAULT_CODE_ATTRIBUTE_KEY
-                                        ),
-                                        nodoFaultCode
-                                )
-                )
+                OpenTelemetryUtils.NODO_ACTIVATION_ERROR_SPAN_NAME,
+                Attributes
+                        .of(
+                                AttributeKey.stringKey(
+                                        OpenTelemetryUtils.NODO_ACTIVATION_ERROR_FAULT_CODE_ATTRIBUTE_KEY
+                                ),
+                                nodoFaultCode
+                        )
+
         );
 
     }

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -26,7 +26,8 @@ import java.math.RoundingMode;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 class NodoOperationsTest {
@@ -1860,10 +1861,15 @@ class NodoOperationsTest {
         /* asserts */
         Mockito.verify(nodeForPspClient, Mockito.times(1)).activatePaymentNoticeV2(Mockito.any());
         Mockito.verify(openTelemetryUtils, Mockito.times(1)).addErrorSpanWithAttributes(
-                any(),
+                eq(OpenTelemetryUtils.NODO_ACTIVATION_ERROR_SPAN_NAME),
                 eq(
                         Attributes
-                                .of(AttributeKey.stringKey("faultCode"), nodoFaultCode)
+                                .of(
+                                        AttributeKey.stringKey(
+                                                OpenTelemetryUtils.NODO_ACTIVATION_ERROR_FAULT_CODE_ATTRIBUTE_KEY
+                                        ),
+                                        nodoFaultCode
+                                )
                 )
         );
 

--- a/src/test/java/it/pagopa/transactions/utils/OpenTelemetryUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/OpenTelemetryUtilsTest.java
@@ -1,0 +1,74 @@
+package it.pagopa.transactions.utils;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+
+class OpenTelemetryUtilsTest {
+
+    private final Tracer openTelemetryTracer = Mockito.mock(Tracer.class);
+
+    private final SpanBuilder spanBuilder = Mockito.mock(SpanBuilder.class);
+
+    private final Span span = Mockito.mock(Span.class);
+
+    private final OpenTelemetryUtils openTelemetryUtils = new OpenTelemetryUtils(openTelemetryTracer);
+
+    @Test
+    void shouldCreateSpanWithAttributes() {
+        // prerequisite
+        String spanName = "spanName";
+        Attributes attributes = Attributes.of(AttributeKey.stringKey("key"), "value");
+        Mockito.when(openTelemetryTracer.spanBuilder(spanName)).thenReturn(spanBuilder);
+        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
+        Mockito.when(span.setAllAttributes(any())).thenReturn(span);
+        // test
+        openTelemetryUtils.addSpanWithAttributes(spanName, attributes);
+        // assertions
+        Mockito.verify(openTelemetryTracer, Mockito.times(1)).spanBuilder(spanName);
+        Mockito.verify(span, Mockito.times(1)).setAllAttributes(attributes);
+        Mockito.verify(span, Mockito.times(1)).end();
+    }
+
+    @Test
+    void shouldCreateErrorSpanWithAttributes() {
+        // prerequisite
+        String spanName = "spanName";
+        Attributes attributes = Attributes.of(AttributeKey.stringKey("key"), "value");
+        Mockito.when(openTelemetryTracer.spanBuilder(spanName)).thenReturn(spanBuilder);
+        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
+        Mockito.when(span.setAllAttributes(any())).thenReturn(span);
+        // test
+        openTelemetryUtils.addErrorSpanWithAttributes(spanName, attributes);
+        // assertions
+        Mockito.verify(openTelemetryTracer, Mockito.times(1)).spanBuilder(spanName);
+        Mockito.verify(span, Mockito.times(1)).setAllAttributes(attributes);
+        Mockito.verify(span, Mockito.times(1)).setStatus(StatusCode.ERROR);
+        Mockito.verify(span, Mockito.times(1)).end();
+    }
+
+    @Test
+    void shouldCreateErrorSpanWithThrowable() {
+        // prerequisite
+        String spanName = "spanName";
+        Throwable throwable = new RuntimeException("test exception");
+        Mockito.when(openTelemetryTracer.spanBuilder(spanName)).thenReturn(spanBuilder);
+        Mockito.when(spanBuilder.startSpan()).thenReturn(span);
+        Mockito.when(span.setAllAttributes(any())).thenReturn(span);
+        // test
+        openTelemetryUtils.addErrorSpanWithException(spanName, throwable);
+        // assertions
+        Mockito.verify(openTelemetryTracer, Mockito.times(1)).spanBuilder(spanName);
+        Mockito.verify(span, Mockito.times(1)).setStatus(StatusCode.ERROR);
+        Mockito.verify(span, Mockito.times(1)).recordException(throwable);
+        Mockito.verify(span, Mockito.times(1)).end();
+    }
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Add logic for add open telemetry span during a transaction
2. Add span for trace Nodo fault codes received during transaction activation
3. Convert span creation logic for repeated activations for the same RptId from apm to open telemetry

<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed to monitor Nodo fault codes received during transaction activation process and for monitor transaction payment token validity time left for re-activated transactions
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + test in dev enviroment with check on Kibana transactions
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
Span details for an error received from Nodo on activatePaymentNoticeV2 call
![Screenshot 2023-07-27 alle 12 17 04](https://github.com/pagopa/pagopa-ecommerce-transactions-service/assets/115724836/0bf391f2-21d0-4221-9158-0630a5d0ea12)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.