### PR TITLE
feat(closepayment): CHK-1769 base64 transactionId as rrn for xpay

### DIFF
--- a/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
@@ -6,11 +6,21 @@ import it.pagopa.generated.transactions.server.model.OutcomeXpayGatewayDto;
 import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestDto;
 import it.pagopa.transactions.exceptions.InvalidRequestException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class AuthRequestDataUtils {
+
+    private final UUIDUtils uuidUtils;
+
+    @Autowired
+    public AuthRequestDataUtils(
+            UUIDUtils uuidUtils
+    ) {
+        this.uuidUtils = uuidUtils;
+    }
 
     public record AuthRequestData(
             String authorizationCode,
@@ -28,7 +38,7 @@ public class AuthRequestDataUtils {
                 result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(),t.getRrn(), t.getErrorCode() != null ? t.getErrorCode().getValue() : null);
             }
             case OutcomeXpayGatewayDto t -> {
-                result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(), transactionId.value().substring(0,7), t.getErrorCode() != null ? t.getErrorCode().getValue().toString() : null);
+                result = new AuthRequestData(t.getAuthorizationCode(),t.getOutcome().toString(), uuidUtils.uuidToBase64(transactionId.uuid()), t.getErrorCode() != null ? t.getErrorCode().getValue().toString() : null);
             }
             default ->
                     throw new InvalidRequestException("Unexpected value: " + updateAuthorizationRequest.getOutcomeGateway());

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -32,6 +32,7 @@ import it.pagopa.transactions.exceptions.BadGatewayException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.utils.AuthRequestDataUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
+import it.pagopa.transactions.utils.UUIDUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -79,7 +80,10 @@ class TransactionSendClosureHandlerTest {
             .mock(TransactionsEventStoreRepository.class);
 
     private final TransactionsUtils transactionsUtils = new TransactionsUtils(eventStoreRepository, "3020");
-    private final AuthRequestDataUtils authRequestDataUtils = new AuthRequestDataUtils();
+
+    private final UUIDUtils mockUuidUtils = Mockito.mock(UUIDUtils.class);
+
+    private final AuthRequestDataUtils authRequestDataUtils = new AuthRequestDataUtils(mockUuidUtils);
     private final NodeForPspClient nodeForPspClient = Mockito.mock(NodeForPspClient.class);
 
     private final QueueAsyncClient transactionClosureSentEventQueueClient = Mockito.mock(QueueAsyncClient.class);
@@ -1202,7 +1206,6 @@ class TransactionSendClosureHandlerTest {
                 transactionClosureSentEventQueueClient
                         .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
         ).thenReturn(queueSuccessfulResponse());
-
         Hooks.onOperatorDebug();
 
         /* test */

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionSendClosureHandlerTest.java
@@ -81,9 +81,8 @@ class TransactionSendClosureHandlerTest {
 
     private final TransactionsUtils transactionsUtils = new TransactionsUtils(eventStoreRepository, "3020");
 
-    private final UUIDUtils mockUuidUtils = Mockito.mock(UUIDUtils.class);
-
-    private final AuthRequestDataUtils authRequestDataUtils = new AuthRequestDataUtils(mockUuidUtils);
+    private final UUIDUtils uuidUtils = new UUIDUtils();
+    private final AuthRequestDataUtils authRequestDataUtils = new AuthRequestDataUtils(uuidUtils);
     private final NodeForPspClient nodeForPspClient = Mockito.mock(NodeForPspClient.class);
 
     private final QueueAsyncClient transactionClosureSentEventQueueClient = Mockito.mock(QueueAsyncClient.class);
@@ -119,8 +118,7 @@ class TransactionSendClosureHandlerTest {
     );
 
     private final TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
-
-    private final String ECOMMERCE_RRN = transactionId.value().substring(0, 7);
+    private final String ECOMMERCE_RRN = uuidUtils.uuidToBase64(transactionId.uuid());
 
     private static MockedStatic<OffsetDateTime> offsetDateTimeMockedStatic;
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -75,7 +75,7 @@ class TransactionUpdateAuthorizationHandlerTest {
         /* preconditions */
         Mockito.when(transactionEventStoreRepository.save(any())).thenReturn(Mono.just(event));
         Mockito.when(mockUuidUtils.uuidToBase64(transactionId.uuid()))
-                .thenReturn(String.valueOf(transactionId.uuid().toString()));
+                .thenReturn(transactionId.uuid().toString());
         /* test */
         StepVerifier.create(updateAuthorizationHandler.handle(requestAuthorizationCommand))
                 .expectNextMatches(authorizationStatusUpdatedEvent -> authorizationStatusUpdatedEvent.equals(event))

--- a/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/TransactionUpdateAuthorizationHandlerTest.java
@@ -16,6 +16,7 @@ import it.pagopa.transactions.commands.data.UpdateAuthorizationStatusData;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.utils.AuthRequestDataUtils;
+import it.pagopa.transactions.utils.UUIDUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -35,9 +36,12 @@ class TransactionUpdateAuthorizationHandlerTest {
     private TransactionsEventStoreRepository<TransactionAuthorizationCompletedData> transactionEventStoreRepository = Mockito
             .mock(TransactionsEventStoreRepository.class);
     private TransactionId transactionId = new TransactionId(TransactionTestUtils.TRANSACTION_ID);
+
+    private final UUIDUtils mockUuidUtils = Mockito.mock(UUIDUtils.class);;
+
     private TransactionUpdateAuthorizationHandler updateAuthorizationHandler = new TransactionUpdateAuthorizationHandler(
             transactionEventStoreRepository,
-            new AuthRequestDataUtils()
+            new AuthRequestDataUtils(mockUuidUtils)
     );
 
     @Test
@@ -70,7 +74,8 @@ class TransactionUpdateAuthorizationHandlerTest {
 
         /* preconditions */
         Mockito.when(transactionEventStoreRepository.save(any())).thenReturn(Mono.just(event));
-
+        Mockito.when(mockUuidUtils.uuidToBase64(transactionId.uuid()))
+                .thenReturn(String.valueOf(transactionId.uuid().toString()));
         /* test */
         StepVerifier.create(updateAuthorizationHandler.handle(requestAuthorizationCommand))
                 .expectNextMatches(authorizationStatusUpdatedEvent -> authorizationStatusUpdatedEvent.equals(event))

--- a/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/AuthRequestDataUtilsTest.java
@@ -7,20 +7,24 @@ import it.pagopa.generated.transactions.server.model.UpdateAuthorizationRequestD
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 class AuthRequestDataUtilsTest {
 
     @InjectMocks
-    AuthRequestDataUtils authRequestDataUtils;
+    private AuthRequestDataUtils authRequestDataUtils;
+    @Mock
+    private UUIDUtils uuidUtils;
+
+    private static final String TRANSACTION_ID_ENCODED = "transactionIdEncoded";
 
     @Test
     void shouldExtractVposInformation() {
@@ -86,10 +90,11 @@ class AuthRequestDataUtilsTest {
                 .timestampOperation(OffsetDateTime.now());
 
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
+        Mockito.when(uuidUtils.uuidToBase64(transactionId.uuid())).thenReturn(TRANSACTION_ID_ENCODED);
         AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils
                 .from(updateAuthorizationRequest, transactionId);
 
-        assertEquals(data.rrn(), transactionId.value().substring(0, 7));
+        assertEquals(data.rrn(), TRANSACTION_ID_ENCODED);
         assertEquals(
                 data.authorizationCode(),
                 ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode()
@@ -110,10 +115,11 @@ class AuthRequestDataUtilsTest {
                 )
                 .timestampOperation(OffsetDateTime.now());
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
+        Mockito.when(uuidUtils.uuidToBase64(transactionId.uuid())).thenReturn(TRANSACTION_ID_ENCODED);
         AuthRequestDataUtils.AuthRequestData data = authRequestDataUtils
                 .from(updateAuthorizationRequest, transactionId);
 
-        assertEquals(data.rrn(), transactionId.value().substring(0, 7));
+        assertEquals(data.rrn(), TRANSACTION_ID_ENCODED);
         assertEquals(
                 data.authorizationCode(),
                 ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- base64 transactionId as rrn for xpay 

#### Motivation and Context

The RRN field of `closePayment` in case of xpay payments are the first 6 byte of the `idTransaction`. 
The goal of this PR is to define the `RRN` to be passed to `closePayement` as the `idTransaction` in Base64 (according to https://github.com/pagopa/pagopa-ecommerce-transactions-service/blob/main/src/main/java/it/pagopa/transactions/utils/UUIDUtils.java) as it is passed to xpay in the authorization step (ie the order number). 
This makes it possible to reconcile xpay psp/acquirer payments.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.