### PR TITLE
feat: [CHK-2004] - save session id returned in NPG confirm payment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>0.25.1</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>0.26.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -462,8 +462,6 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-2004-save-session-id-from-confirm-payment</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -462,6 +462,8 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-2004-save-session-id-from-confirm-payment</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -1,6 +1,7 @@
 package it.pagopa.transactions.commands.handlers;
 
-import it.pagopa.generated.transactions.server.model.CardsAuthRequestDetailsDto;
+import io.vavr.control.Either;
+import it.pagopa.ecommerce.commons.generated.npg.v1.dto.StateResponseDto;
 import it.pagopa.generated.transactions.server.model.RequestAuthorizationResponseDto;
 import it.pagopa.transactions.client.PaymentGatewayClient;
 import it.pagopa.transactions.commands.TransactionRequestAuthorizationCommand;
@@ -82,32 +83,86 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
     protected Mono<Tuple2<String, String>> npgAuthRequestPipeline(AuthorizationRequestData authorizationData) {
         return Mono.just(authorizationData)
                 .flatMap(
-                        paymentGatewayClient::requestNpgCardsAuthorization
+                        this::confirmPayment
                 )
-                .map(
-                        npgCardsResponseDto -> Tuples.of(
-                                // safe cast here, filter against authDetails performed into
-                                // requestNpgCardsAuthorization method
-                                ((CardsAuthRequestDetailsDto) authorizationData.authDetails()).getOrderId(),
-                                switch (npgCardsResponseDto.getState()) {
-                                case GDI_VERIFICATION -> URI.create(checkoutBasePath)
-                                        .resolve(
-                                                CHECKOUT_GDI_CHECK_PATH + Base64.encodeBase64URLSafeString(
-                                                        npgCardsResponseDto.getFieldSet().getFields().get(0).getSrc()
-                                                                .getBytes(StandardCharsets.UTF_8)
+                .flatMap(
+                        npgCardsResponseDto ->
+                                npgCardsResponseDto.fold(
+                                        Mono::error,
+                                        npgResponse -> Mono.just(
+                                                Tuples.of(
+                                                        npgResponse.getFieldSet().getSessionId(),
+                                                        switch (npgResponse.getState()) {
+                                                            case GDI_VERIFICATION -> {
+                                                                if (npgResponse.getFieldSet().getFields() == null || npgResponse.getFieldSet().getFields().get(0) == null) {
+                                                                    throw new BadGatewayException(
+                                                                            "Invalid NPG response for state %s, no fieldSet.field received, excepted 1: ".formatted(npgResponse.getState()),
+                                                                            HttpStatus.BAD_GATEWAY
+                                                                    );
+                                                                }
+                                                                String redirectionUrl = npgResponse.getFieldSet().getFields().get(0).getSrc();
+                                                                if (redirectionUrl == null) {
+                                                                    throw new BadGatewayException(
+                                                                            "Invalid NPG response for state %s, fieldSet.field[0].src is null: ".formatted(npgResponse.getState()),
+                                                                            HttpStatus.BAD_GATEWAY
+                                                                    );
+                                                                }
+                                                                yield URI.create(checkoutBasePath)
+                                                                        .resolve(
+                                                                                CHECKOUT_GDI_CHECK_PATH + Base64.encodeBase64URLSafeString(
+                                                                                        redirectionUrl
+                                                                                                .getBytes(StandardCharsets.UTF_8)
+                                                                                )
+                                                                        ).toString();
+                                                            }
+                                                            case REDIRECTED_TO_EXTERNAL_DOMAIN -> {
+                                                                if (npgResponse.getUrl() == null) {
+                                                                    throw new BadGatewayException(
+                                                                            "Invalid NPG response for state %s, response.url is null: ".formatted(npgResponse.getState()),
+                                                                            HttpStatus.BAD_GATEWAY
+                                                                    );
+                                                                }
+                                                                yield npgResponse.getUrl();
+                                                            }
+                                                            case PAYMENT_COMPLETE ->
+                                                                    URI.create(checkoutBasePath).resolve(CHECKOUT_ESITO_PATH)
+                                                                            .toString();
+                                                            default -> throw new BadGatewayException(
+                                                                    "Invalid NPG confirm payment state response: " + npgResponse.getState(),
+                                                                    HttpStatus.BAD_GATEWAY
+                                                            );
+                                                        }
                                                 )
-                                        ).toString();
-                                case REDIRECTED_TO_EXTERNAL_DOMAIN -> npgCardsResponseDto.getUrl();
-                                case PAYMENT_COMPLETE -> URI.create(checkoutBasePath).resolve(CHECKOUT_ESITO_PATH)
-                                        .toString();
-                                default -> throw new BadGatewayException(
-                                        "Invalid NPG confirm payment state response: " + npgCardsResponseDto.getState(),
-                                        HttpStatus.BAD_GATEWAY
-                                );
-                                }
-                        )
-
+                                        )
+                                )
                 );
+    }
+
+    /**
+     * Perform NPG confirm payment api call.
+     * This method performs basic response validation checking mandatory response fields such as state and sessionId (used for getState api call)
+     *
+     * @param authorizationData - the authorization requested data
+     * @return Either valued with response, if valid, or exception for invalid response received
+     */
+    private Mono<Either<BadGatewayException, StateResponseDto>> confirmPayment(AuthorizationRequestData authorizationData) {
+        return Mono.just(authorizationData)
+                .flatMap(paymentGatewayClient::requestNpgCardsAuthorization)
+                .map(npgStateResponse -> {
+                    if (npgStateResponse == null) {
+                        return Either.left(new BadGatewayException("Invalid NPG confirm payment, no body response received!", HttpStatus.BAD_GATEWAY));
+                    }
+                    if (npgStateResponse.getState() == null) {
+                        return Either.left(new BadGatewayException("Invalid NPG confirm payment, state response null!", HttpStatus.BAD_GATEWAY));
+                    }
+                    if (npgStateResponse.getFieldSet() == null) {
+                        return Either.left(new BadGatewayException("Invalid NPG confirm payment, fieldSet null! ", HttpStatus.BAD_GATEWAY));
+                    }
+                    if (npgStateResponse.getFieldSet().getSessionId() == null) {
+                        return Either.left(new BadGatewayException("Invalid NPG confirm payment, sessionId null! ", HttpStatus.BAD_GATEWAY));
+                    }
+                    return Either.right(npgStateResponse);
+                });
     }
 
     protected URI getLogo(AuthorizationRequestData authorizationRequestData) {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -161,8 +161,7 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
 
     /**
      * Perform NPG confirm payment api call. This method performs basic response
-     * validation checking mandatory response fields such as state and sessionId
-     * (used for getState api call)
+     * validation checking mandatory response fields such as state
      *
      * @param authorizationData - the authorization requested data
      * @return Either valued with response, if valid, or exception for invalid

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -107,10 +107,11 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                                                             .getOrderId(),
                                                     switch (npgResponse.getState()) {
                                         case GDI_VERIFICATION -> {
-                                            if (npgResponse.getFieldSet().getFields() == null
-                                                    || npgResponse.getFieldSet().getFields().get(0) == null) {
+                                            if (npgResponse.getFieldSet() == null
+                                                    || npgResponse.getFieldSet().getFields() == null
+                                                    || npgResponse.getFieldSet().getFields().isEmpty()) {
                                                 throw new BadGatewayException(
-                                                        "Invalid NPG response for state %s, no fieldSet.field received, excepted 1: "
+                                                        "Invalid NPG response for state %s, no fieldSet.field received, excepted 1"
                                                                 .formatted(npgResponse.getState()),
                                                         HttpStatus.BAD_GATEWAY
                                                 );
@@ -119,7 +120,7 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                                                     .getSrc();
                                             if (redirectionUrl == null) {
                                                 throw new BadGatewayException(
-                                                        "Invalid NPG response for state %s, fieldSet.field[0].src is null: "
+                                                        "Invalid NPG response for state %s, fieldSet.field[0].src is null"
                                                                 .formatted(npgResponse.getState()),
                                                         HttpStatus.BAD_GATEWAY
                                                 );
@@ -135,7 +136,7 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                                         case REDIRECTED_TO_EXTERNAL_DOMAIN -> {
                                             if (npgResponse.getUrl() == null) {
                                                 throw new BadGatewayException(
-                                                        "Invalid NPG response for state %s, response.url is null: "
+                                                        "Invalid NPG response for state %s, response.url is null"
                                                                 .formatted(npgResponse.getState()),
                                                         HttpStatus.BAD_GATEWAY
                                                 );
@@ -173,14 +174,6 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
         return Mono.just(authorizationData)
                 .flatMap(paymentGatewayClient::requestNpgCardsAuthorization)
                 .map(npgStateResponse -> {
-                    if (npgStateResponse == null) {
-                        return Either.left(
-                                new BadGatewayException(
-                                        "Invalid NPG confirm payment, no body response received!",
-                                        HttpStatus.BAD_GATEWAY
-                                )
-                        );
-                    }
                     if (npgStateResponse.getState() == null) {
                         return Either.left(
                                 new BadGatewayException(

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -95,10 +95,10 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                         npgCardsResponseDto -> npgCardsResponseDto.fold(
                                 Mono::error,
                                 npgResponse -> {
-                                    Optional<String> authReceivedSessionId = Optional
+                                    Optional<String> confirmPaymentSessionId = Optional
                                             .ofNullable(npgResponse.getFieldSet())
                                             .map(FieldsDto::getSessionId);
-                                    log.info("NGP auth completed session id: {}", authReceivedSessionId);
+                                    log.info("NGP auth completed session id: {}", confirmPaymentSessionId);
                                     return Mono.just(
                                             Tuples.of(
                                                     // safe cast here, filter against authDetails performed into
@@ -151,7 +151,7 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                                                 HttpStatus.BAD_GATEWAY
                                         );
                                     },
-                                                    authReceivedSessionId
+                                                    confirmPaymentSessionId
                                             )
                                     );
                                 }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -111,7 +111,7 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                                                     || npgResponse.getFieldSet().getFields() == null
                                                     || npgResponse.getFieldSet().getFields().isEmpty()) {
                                                 throw new BadGatewayException(
-                                                        "Invalid NPG response for state %s, no fieldSet.field received, excepted 1"
+                                                        "Invalid NPG response for state %s, no fieldSet.field received, expected 1"
                                                                 .formatted(npgResponse.getState()),
                                                         HttpStatus.BAD_GATEWAY
                                                 );

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
@@ -318,7 +318,7 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.valueOf(clientId),
                                 idCart,
                                 paymentTokenTimeout,
-                                orderId != null ? new NpgTransactionGatewayActivationData(orderId, null, null)
+                                orderId != null ? new NpgTransactionGatewayActivationData(orderId, null)
                                         : new EmptyTransactionGatewayActivationData()
                         )
                 );

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
@@ -119,7 +119,8 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                         );
                                         case NPG -> new NpgTransactionGatewayAuthorizationRequestedData(
                                                 logo,
-                                                brand
+                                                brand,
+                                                tuple3.getT1()
                                         );
                                         // TODO remove this after the cancellation of the postepay logic
                                         case POSTEPAY -> null;

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
@@ -18,12 +18,14 @@ import it.pagopa.transactions.commands.TransactionRequestAuthorizationCommand;
 import it.pagopa.transactions.commands.data.AuthorizationRequestData;
 import it.pagopa.transactions.commands.handlers.TransactionRequestAuthorizationHandlerCommon;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
+import it.pagopa.transactions.exceptions.BadGatewayException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.utils.LogoMappingUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple4;
@@ -127,7 +129,12 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                         case NPG -> new NpgTransactionGatewayAuthorizationRequestedData(
                                                 logo,
                                                 brand,
-                                                authorizationRequestData.sessionId().orElse(null),
+                                                authorizationRequestData.sessionId().orElseThrow(
+                                                        () -> new BadGatewayException(
+                                                                "Cannot retrieve session id for transaction",
+                                                                HttpStatus.INTERNAL_SERVER_ERROR
+                                                        )
+                                                ),
                                                 tuple4.getT3().orElse(null)
                                         );
                                         // TODO remove this after the cancellation of the postepay logic

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
@@ -26,11 +26,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuple3;
+import reactor.util.function.Tuple4;
 import reactor.util.function.Tuples;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @Component("TransactionRequestAuthorizationHandlerV2")
 @Slf4j
@@ -81,20 +82,26 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                 .switchIfEmpty(alreadyProcessedError)
                 .cast(TransactionActivated.class);
 
-        Mono<Tuple3<String, String, PaymentGateway>> monoPostePay = postepayAuthRequestPipeline(
+        Mono<Tuple4<String, String, Optional<String>, PaymentGateway>> monoPostePay = postepayAuthRequestPipeline(
                 authorizationRequestData
         )
-                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.POSTEPAY));
-        Mono<Tuple3<String, String, PaymentGateway>> monoXPay = xpayAuthRequestPipeline(authorizationRequestData)
-                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.XPAY));
-        Mono<Tuple3<String, String, PaymentGateway>> monoVPOS = vposAuthRequestPipeline(authorizationRequestData)
-                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.VPOS));
-        Mono<Tuple3<String, String, PaymentGateway>> monoNpgCards = npgAuthRequestPipeline(authorizationRequestData)
-                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.NPG));
-        List<Mono<Tuple3<String, String, PaymentGateway>>> gatewayRequests = List
+                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), Optional.empty(), PaymentGateway.POSTEPAY));
+        Mono<Tuple4<String, String, Optional<String>, PaymentGateway>> monoXPay = xpayAuthRequestPipeline(
+                authorizationRequestData
+        )
+                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), Optional.empty(), PaymentGateway.XPAY));
+        Mono<Tuple4<String, String, Optional<String>, PaymentGateway>> monoVPOS = vposAuthRequestPipeline(
+                authorizationRequestData
+        )
+                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), Optional.empty(), PaymentGateway.VPOS));
+        Mono<Tuple4<String, String, Optional<String>, PaymentGateway>> monoNpgCards = npgAuthRequestPipeline(
+                authorizationRequestData
+        )
+                .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), tuple.getT3(), PaymentGateway.NPG));
+        List<Mono<Tuple4<String, String, Optional<String>, PaymentGateway>>> gatewayRequests = List
                 .of(monoPostePay, monoXPay, monoVPOS, monoNpgCards);
 
-        Mono<Tuple3<String, String, PaymentGateway>> gatewayAttempts = gatewayRequests
+        Mono<Tuple4<String, String, Optional<String>, PaymentGateway>> gatewayAttempts = gatewayRequests
                 .stream()
                 .reduce(
                         Mono::switchIfEmpty
@@ -103,7 +110,7 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
         return transactionActivated
                 .flatMap(
                         t -> gatewayAttempts.switchIfEmpty(Mono.error(new BadRequestException("No gateway matched")))
-                                .flatMap(tuple3 -> {
+                                .flatMap(tuple4 -> {
                                     log.info(
                                             "Logging authorization event for transaction id {}",
                                             t.getTransactionId().value()
@@ -111,8 +118,8 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
 
                                     // TODO remove this after the cancellation of the postepay logic
                                     String brand = authorizationRequestData.brand();
-                                    TransactionGatewayAuthorizationRequestedData transactionGatewayAuthorizationRequestedData = switch (tuple3
-                                            .getT3()) {
+                                    TransactionGatewayAuthorizationRequestedData transactionGatewayAuthorizationRequestedData = switch (tuple4
+                                            .getT4()) {
                                         case VPOS, XPAY -> new PgsTransactionGatewayAuthorizationRequestedData(
                                                 logo,
                                                 PgsTransactionGatewayAuthorizationRequestedData.CardBrand.valueOf(brand)
@@ -120,7 +127,8 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                         case NPG -> new NpgTransactionGatewayAuthorizationRequestedData(
                                                 logo,
                                                 brand,
-                                                tuple3.getT1()
+                                                authorizationRequestData.sessionId().orElse(null),
+                                                tuple4.getT3().orElse(null)
                                         );
                                         // TODO remove this after the cancellation of the postepay logic
                                         case POSTEPAY -> null;
@@ -142,8 +150,8 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                                     command.getData().paymentMethodName(),
                                                     command.getData().pspBusinessName(),
                                                     command.getData().pspOnUs(),
-                                                    tuple3.getT1(),
-                                                    tuple3.getT3(),
+                                                    tuple4.getT1(),
+                                                    tuple4.getT4(),
                                                     command.getData().paymentMethodDescription(),
                                                     transactionGatewayAuthorizationRequestedData
                                             )
@@ -161,11 +169,11 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                             );
                                     return updateSession.then(
                                             transactionEventStoreRepository.save(authorizationEvent)
-                                                    .thenReturn(tuple3)
+                                                    .thenReturn(tuple4)
                                                     .map(
                                                             auth -> new RequestAuthorizationResponseDto()
-                                                                    .authorizationUrl(tuple3.getT2())
-                                                                    .authorizationRequestId(tuple3.getT1())
+                                                                    .authorizationUrl(tuple4.getT2())
+                                                                    .authorizationRequestId(tuple4.getT1())
                                                     )
                                     );
                                 })

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -102,6 +102,7 @@ public class NodoOperations {
         // in seconds
         request.setExpirationTime(BigInteger.valueOf(paymentTokenTimeout).multiply(BigInteger.valueOf(1000)));
         request.setPaymentNote(idCart);
+        //
         // TODO Maybe here more values (all optional) can be passed such as Touchpoint
         // and PaymentMethod
         return nodeForPspClient

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandlerTest.java
@@ -353,7 +353,11 @@ class TransactionRequestAuthorizationHandlerTest {
         );
 
         StateResponseDto stateResponseDto = new StateResponseDto()
-                .state(StateDto.REDIRECTED_TO_EXTERNAL_DOMAIN).url(NPG_URL_IFRAME);
+                .state(StateDto.REDIRECTED_TO_EXTERNAL_DOMAIN).url(NPG_URL_IFRAME)
+                .fieldSet(
+                        new FieldsDto().sessionId("authorizationSessionId")
+                                .addFieldsItem(new FieldDto().src(NPG_URL_IFRAME))
+                );
 
         /* preconditions */
         Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
@@ -452,7 +456,11 @@ class TransactionRequestAuthorizationHandlerTest {
         );
 
         StateResponseDto stateResponseDto = new StateResponseDto()
-                .state(StateDto.PAYMENT_COMPLETE);
+                .state(StateDto.PAYMENT_COMPLETE)
+                .fieldSet(
+                        new FieldsDto().sessionId("authorizationSessionId")
+                                .addFieldsItem(new FieldDto().src(NPG_URL_IFRAME))
+                );
 
         /* preconditions */
         Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
@@ -552,7 +560,10 @@ class TransactionRequestAuthorizationHandlerTest {
 
         StateResponseDto stateResponseDto = new StateResponseDto()
                 .state(StateDto.GDI_VERIFICATION)
-                .fieldSet(new FieldsDto().addFieldsItem(new FieldDto().src(NPG_URL_IFRAME)));
+                .fieldSet(
+                        new FieldsDto().sessionId("authorizationSessionId")
+                                .addFieldsItem(new FieldDto().src(NPG_URL_IFRAME))
+                );
 
         /* preconditions */
         Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -152,7 +152,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
 
         );
 
@@ -237,7 +237,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -323,7 +323,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -410,7 +410,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -446,7 +446,8 @@ class TransactionRequestAuthorizationHandlerTest {
         );
 
         StateResponseDto stateResponseDto = new StateResponseDto()
-                .state(StateDto.REDIRECTED_TO_EXTERNAL_DOMAIN).url(NPG_URL_IFRAME);
+                .state(StateDto.REDIRECTED_TO_EXTERNAL_DOMAIN).url(NPG_URL_IFRAME)
+                .fieldSet(new FieldsDto().sessionId("authorizationSessionId"));
 
         /* preconditions */
         Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
@@ -510,7 +511,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -546,7 +547,11 @@ class TransactionRequestAuthorizationHandlerTest {
         );
 
         StateResponseDto stateResponseDto = new StateResponseDto()
-                .state(StateDto.PAYMENT_COMPLETE);
+                .state(StateDto.PAYMENT_COMPLETE)
+                .fieldSet(
+                        new FieldsDto().sessionId("authorizationSessionId")
+                                .addFieldsItem(new FieldDto().src(NPG_URL_IFRAME))
+                );
 
         /* preconditions */
         Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
@@ -610,7 +615,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -647,7 +652,10 @@ class TransactionRequestAuthorizationHandlerTest {
 
         StateResponseDto stateResponseDto = new StateResponseDto()
                 .state(StateDto.GDI_VERIFICATION)
-                .fieldSet(new FieldsDto().addFieldsItem(new FieldDto().src(NPG_URL_IFRAME)));
+                .fieldSet(
+                        new FieldsDto().sessionId("authorizationSessionId")
+                                .addFieldsItem(new FieldDto().src(NPG_URL_IFRAME))
+                );
 
         /* preconditions */
         Mockito.when(paymentGatewayClient.requestPostepayAuthorization(authorizationData))
@@ -716,7 +724,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -806,7 +814,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -889,7 +897,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -979,7 +987,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", null, null)
+                TransactionTestUtils.npgTransactionGatewayActivationData()
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1077,7 +1085,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData(orderId, null, null)
+                new NpgTransactionGatewayActivationData(orderId, null)
         );
 
         String paymentInstrumentId = "paymentInstrumentId";

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -1353,7 +1353,7 @@ class TransactionRequestAuthorizationHandlerTest {
                         exception -> exception instanceof BadGatewayException bge &&
                                 bge.getHttpStatus() == HttpStatus.BAD_GATEWAY &&
                                 bge.getDetail().equals(
-                                        "Invalid NPG response for state GDI_VERIFICATION, no fieldSet.field received, excepted 1"
+                                        "Invalid NPG response for state GDI_VERIFICATION, no fieldSet.field received, expected 1"
                                 )
                 )
                 .verify();
@@ -1449,7 +1449,7 @@ class TransactionRequestAuthorizationHandlerTest {
                         exception -> exception instanceof BadGatewayException bge &&
                                 bge.getHttpStatus() == HttpStatus.BAD_GATEWAY &&
                                 bge.getDetail().equals(
-                                        "Invalid NPG response for state GDI_VERIFICATION, no fieldSet.field received, excepted 1"
+                                        "Invalid NPG response for state GDI_VERIFICATION, no fieldSet.field received, expected 1"
                                 )
                 )
                 .verify();

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
@@ -47,7 +47,7 @@ class TransactionsActivationProjectionHandlerTest {
         TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
         transactionActivatedData.setEmail(TransactionTestUtils.EMAIL);
         transactionActivatedData
-                .setTransactionGatewayActivationData(new NpgTransactionGatewayActivationData(orderId, null, null));
+                .setTransactionGatewayActivationData(new NpgTransactionGatewayActivationData(orderId, null));
         transactionActivatedData.setPaymentNotices(
                 List.of(
                         new PaymentNotice(
@@ -107,7 +107,7 @@ class TransactionsActivationProjectionHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData(orderId, null, null)
+                new NpgTransactionGatewayActivationData(orderId, null)
         );
 
         it.pagopa.ecommerce.commons.documents.v2.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v2.Transaction


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/149
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to save sessionId received into confirmPayment NPG response.
This response field is optional so it's saved if received, null value is used otherwise.
<!--- Describe your changes in detail -->

#### Motivation and Context
This optional field, once received, is the one that must be used for calling NPG getState api.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local test with eCommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.