### PR TITLE
feat: NPG error code mapping

### DIFF
--- a/api-spec/v1/transactions-api.yaml
+++ b/api-spec/v1/transactions-api.yaml
@@ -722,6 +722,9 @@ components:
               type: string
             errorCode:
               type: string
+            gatewayAuthorizationStatus:
+              type: string
+              description: payment gateway authorization status
           required:
             - status
     AmountEuroCents:

--- a/pom.xml
+++ b/pom.xml
@@ -509,8 +509,6 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-2419-npg-error-code</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>1.7.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.8.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
         <mock-web-server.version>4.11.0</mock-web-server.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>1.6.1</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.7.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
         <mock-web-server.version>4.11.0</mock-web-server.version>
@@ -509,6 +509,8 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-2419-npg-error-code</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionUpdateAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionUpdateAuthorizationHandler.java
@@ -64,7 +64,8 @@ public class TransactionUpdateAuthorizationHandler extends TransactionUpdateAuth
                 authorizationData = new NpgTransactionGatewayAuthorizationData(
                         OperationResultDto.valueOf(outcomeNpgGateway.getOperationResult().toString()),
                         outcomeNpgGateway.getOperationId(),
-                        outcomeNpgGateway.getPaymentEndToEndId()
+                        outcomeNpgGateway.getPaymentEndToEndId(),
+                        authRequestDataExtracted.errorCode()
                 );
             } else if (outcomeGateway instanceof OutcomeXpayGatewayDto
                     || outcomeGateway instanceof OutcomeVposGatewayDto) {

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -410,7 +410,8 @@ public class TransactionsService {
                                     .valueOf(transaction.getSendPaymentResultOutcome().name())
                     )
                     .authorizationCode(transaction.getAuthorizationCode())
-                    .errorCode(transaction.getAuthorizationErrorCode());
+                    .errorCode(transaction.getAuthorizationErrorCode())
+                    .gatewayAuthorizationStatus(transaction.getGatewayAuthorizationStatus());
             default -> throw new IllegalStateException("Unexpected value: " + baseTransactionView);
         };
     }

--- a/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/AuthRequestDataUtils.java
@@ -46,7 +46,14 @@ public class AuthRequestDataUtils {
                 result = new AuthRequestData(t.getAuthorizationCode(), t.getOutcome().toString(), uuidUtils.uuidToBase64(transactionId.uuid()), t.getErrorCode() != null ? t.getErrorCode().getValue().toString() : null);
             }
             case OutcomeNpgGatewayDto t -> {
-                result = new AuthRequestData(t.getAuthorizationCode(), npgResultToOutcome(t.getOperationResult()), t.getRrn(), null);
+                String authorizationCode = null;
+                String errorCode = null;
+                if (t.getOperationResult() == OutcomeNpgGatewayDto.OperationResultEnum.EXECUTED) {
+                    authorizationCode = t.getAuthorizationCode();
+                } else {
+                    errorCode = t.getAuthorizationCode();
+                }
+                result = new AuthRequestData(authorizationCode, npgResultToOutcome(t.getOperationResult()), t.getRrn(), errorCode);
             }
             default ->
                     throw new InvalidRequestException("Unexpected value: " + updateAuthorizationRequest.getOutcomeGateway());

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandlerTest.java
@@ -65,6 +65,7 @@ class AuthorizationUpdateProjectionHandlerTest {
         expectedDocument.setPaymentGateway(null);
         expectedDocument.setAuthorizationCode("authorizationCode");
         expectedDocument.setAuthorizationErrorCode(null);
+        expectedDocument.setGatewayAuthorizationStatus("OK");
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
                 ((OutcomeXpayGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode(),
@@ -153,6 +154,7 @@ class AuthorizationUpdateProjectionHandlerTest {
         expectedDocument.setPaymentGateway(null);
         expectedDocument.setAuthorizationCode("authorizationCode");
         expectedDocument.setAuthorizationErrorCode(null);
+        expectedDocument.setGatewayAuthorizationStatus("OK");
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
                 ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway()).getAuthorizationCode(),
@@ -234,6 +236,7 @@ class AuthorizationUpdateProjectionHandlerTest {
         expectedDocument.setPaymentGateway(null);
         expectedDocument.setAuthorizationCode("authorizationCode");
         expectedDocument.setAuthorizationErrorCode(null);
+        expectedDocument.setGatewayAuthorizationStatus("EXECUTED");
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
                 "authorizationCode",
@@ -312,6 +315,7 @@ class AuthorizationUpdateProjectionHandlerTest {
         expectedDocument.setPaymentGateway(null);
         expectedDocument.setAuthorizationCode("authorizationCode");
         expectedDocument.setAuthorizationErrorCode(authorizationErrorCode);
+        expectedDocument.setGatewayAuthorizationStatus("KO");
 
         TransactionAuthorizationCompletedData statusAuthCompleted = new TransactionAuthorizationCompletedData(
                 "authorizationCode",

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandlerTest.java
@@ -245,7 +245,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 new NpgTransactionGatewayAuthorizationData(
                         OperationResultDto.EXECUTED,
                         "operationId",
-                        "paymentEndToEndId"
+                        "paymentEndToEndId",
+                        null
                 )
 
         );


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/174
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add `gatewayAuthorizationStatus` field into transaction view and `GET transactions` response body.
This field is valued with payment gateway status received into `PATCH authorizations` requests.
Add handling for NPG error code saving this information into AUTHORIZATION_COMPLETED events and returned into GET transactions api call.

<!--- Describe your changes in detail -->

#### Motivation and Context
Both error code and gateway authorization status allow to perform authorization outcome to proper error to be shown to the final user (such as invalid card data and so on) 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local tests with eCommerce local
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.