### PR TITLE
[CHK 2443] used correlation saved into activated event into NPG call

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandler.java
@@ -89,7 +89,10 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                 .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.XPAY));
         Mono<Tuple3<String, String, PaymentGateway>> monoVPOS = vposAuthRequestPipeline(authorizationRequestData)
                 .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.VPOS));
-        Mono<Tuple3<String, String, PaymentGateway>> monoNpgCards = npgAuthRequestPipeline(authorizationRequestData)
+        Mono<Tuple3<String, String, PaymentGateway>> monoNpgCards = npgAuthRequestPipeline(
+                authorizationRequestData,
+                null
+        )
                 .map(tuple -> Tuples.of(tuple.getT1(), tuple.getT2(), PaymentGateway.NPG));
         List<Mono<Tuple3<String, String, PaymentGateway>>> gatewayRequests = List
                 .of(monoPostePay, monoXPay, monoVPOS, monoNpgCards);

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -547,7 +547,7 @@ class PaymentGatewayClientTest {
         Mockito.when(npgClient.confirmPayment(any(), any(), any(), any())).thenReturn(Mono.just(ngpStateResponse));
 
         /* test */
-        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData))
+        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData, UUID.randomUUID().toString()))
                 .expectNext(ngpStateResponse)
                 .verifyComplete();
         String expectedApiKey = npgPspApiKeysConfig.get(authorizationData.pspId()).get();
@@ -629,7 +629,7 @@ class PaymentGatewayClientTest {
                 );
         /* test */
 
-        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData))
+        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData, UUID.randomUUID().toString()))
                 .expectErrorMatches(
                         error -> error instanceof AlreadyProcessedException &&
                                 ((AlreadyProcessedException) error).getTransactionId()
@@ -703,7 +703,7 @@ class PaymentGatewayClientTest {
                         )
                 );
         /* test */
-        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData))
+        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData, UUID.randomUUID().toString()))
                 .expectErrorMatches(
                         error -> error instanceof BadGatewayException
                 )
@@ -775,7 +775,7 @@ class PaymentGatewayClientTest {
                         )
                 );
         /* test */
-        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData))
+        StepVerifier.create(client.requestNpgCardsAuthorization(authorizationData, UUID.randomUUID().toString()))
                 .expectErrorMatches(
                         error -> error instanceof BadGatewayException
                 )
@@ -1784,6 +1784,7 @@ class PaymentGatewayClientTest {
         String orderId = "orderIdGenerated";
         String sessionId = "sessionId";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1832,7 +1833,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildForm(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -1847,7 +1848,7 @@ class PaymentGatewayClientTest {
 
         Tuple2<String, FieldsDto> responseRequestNpgBuildSession = Tuples.of(orderId, npgBuildSessionResponse);
         /* test */
-        StepVerifier.create(client.requestNpgBuildSession(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildSession(authorizationData, correlationId, true))
                 .expectNext(responseRequestNpgBuildSession)
                 .verifyComplete();
 
@@ -1906,6 +1907,7 @@ class PaymentGatewayClientTest {
         String walletId = UUID.randomUUID().toString();
         String orderId = "orderIdGenerated";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1952,7 +1954,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildForm(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -1983,7 +1985,7 @@ class PaymentGatewayClientTest {
                 );
         /* test */
 
-        StepVerifier.create(client.requestNpgBuildSession(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildSession(authorizationData, correlationId, true))
                 .expectErrorMatches(
                         error -> error instanceof AlreadyProcessedException &&
                                 ((AlreadyProcessedException) error).getTransactionId()
@@ -1997,6 +1999,7 @@ class PaymentGatewayClientTest {
         String walletId = UUID.randomUUID().toString();
         String orderId = "orderIdGenerated";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2043,7 +2046,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildForm(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -2073,7 +2076,7 @@ class PaymentGatewayClientTest {
                         )
                 );
         /* test */
-        StepVerifier.create(client.requestNpgBuildSession(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildSession(authorizationData, correlationId, true))
                 .expectErrorMatches(
                         error -> error instanceof BadGatewayException
                 )
@@ -2085,6 +2088,7 @@ class PaymentGatewayClientTest {
         String walletId = UUID.randomUUID().toString();
         String orderId = "orderIdGenerated";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2131,7 +2135,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildForm(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -2161,7 +2165,7 @@ class PaymentGatewayClientTest {
                         )
                 );
         /* test */
-        StepVerifier.create(client.requestNpgBuildSession(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildSession(authorizationData, correlationId, true))
                 .expectErrorMatches(
                         error -> error instanceof BadGatewayException
                 )
@@ -2174,6 +2178,7 @@ class PaymentGatewayClientTest {
         String walletId = UUID.randomUUID().toString();
         String orderId = "orderIdGenerated";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2220,7 +2225,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildForm(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -2233,7 +2238,7 @@ class PaymentGatewayClientTest {
                 )
         ).thenReturn(Mono.just(npgBuildSessionResponse));
 
-        StepVerifier.create(client.requestNpgBuildSession(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildSession(authorizationData, correlationId, true))
                 .expectErrorMatches(error -> error instanceof BadGatewayException)
                 .verify();
         String npgNotificationUrl = UriComponentsBuilder
@@ -2313,6 +2318,7 @@ class PaymentGatewayClientTest {
         String orderId = "orderIdGenerated";
         String sessionId = "sessionId";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2366,7 +2372,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildFormForPayment(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -2382,7 +2388,7 @@ class PaymentGatewayClientTest {
 
         Tuple2<String, FieldsDto> responseRequestNpgBuildSession = Tuples.of(orderId, npgBuildSessionResponse);
         /* test */
-        StepVerifier.create(client.requestNpgBuildApmPayment(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildApmPayment(authorizationData, correlationId, true))
                 .expectNext(responseRequestNpgBuildSession)
                 .verifyComplete();
 
@@ -2442,6 +2448,7 @@ class PaymentGatewayClientTest {
         String orderId = "orderIdGenerated";
         String sessionId = "sessionId";
         String contractId = "contractId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2507,7 +2514,7 @@ class PaymentGatewayClientTest {
                 .substring(0, npgNotificationUrl.indexOf("sessionToken=") + "sessionToken=".length());
         Mockito.when(
                 npgClient.buildFormForPayment(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         eq(URI.create(sessionUrlConfig.basePath())),
                         eq(
                                 URI
@@ -2542,7 +2549,7 @@ class PaymentGatewayClientTest {
         ).thenReturn(Mono.just(npgBuildSessionResponse));
 
         /* test */
-        StepVerifier.create(client.requestNpgBuildApmPayment(authorizationData, true))
+        StepVerifier.create(client.requestNpgBuildApmPayment(authorizationData, correlationId, true))
                 .expectError(NpgApiKeyMissingPspRequestedException.class)
                 .verify();
 
@@ -2557,6 +2564,7 @@ class PaymentGatewayClientTest {
         String walletId = UUID.randomUUID().toString();
         String orderId = "orderIdGenerated";
         String sessionId = "sessionId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2609,7 +2617,7 @@ class PaymentGatewayClientTest {
         /* preconditions */
         Mockito.when(
                 npgClient.buildFormForPayment(
-                        any(),
+                        eq(UUID.fromString(correlationId)),
                         any(),
                         any(),
                         any(),
@@ -2625,7 +2633,7 @@ class PaymentGatewayClientTest {
 
         Tuple2<String, FieldsDto> responseRequestNpgBuildSession = Tuples.of(orderId, npgBuildSessionResponse);
         /* test */
-        StepVerifier.create(client.requestNpgBuildApmPayment(authorizationData, false))
+        StepVerifier.create(client.requestNpgBuildApmPayment(authorizationData, correlationId, false))
                 .expectNext(responseRequestNpgBuildSession)
                 .verifyComplete();
 

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandlerTest.java
@@ -378,7 +378,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, null))
                 .thenReturn(Mono.just(stateResponseDto));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
                 .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
@@ -482,7 +482,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, null))
                 .thenReturn(Mono.just(stateResponseDto));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
                 .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
@@ -586,7 +586,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, null))
                 .thenReturn(Mono.just(stateResponseDto));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
                 .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
@@ -691,7 +691,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, null))
                 .thenReturn(Mono.just(stateResponseDto));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
                 .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
@@ -1170,9 +1170,11 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgBuildSession(authorizationData, true))
+        Mockito.when(paymentGatewayClient.requestNpgBuildSession(authorizationData, null, true))
                 .thenReturn(Mono.just(responseRequestNpgBuildSession));
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationDataAfterBuildSession))
+        Mockito.when(
+                paymentGatewayClient.requestNpgCardsAuthorization(authorizationDataAfterBuildSession, null)
+        )
                 .thenReturn(Mono.just(stateResponseDto));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
                 .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -407,6 +407,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -456,7 +458,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -474,10 +476,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.when(
@@ -517,6 +525,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -566,7 +576,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -588,10 +598,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.when(
@@ -631,6 +647,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -680,7 +698,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -702,10 +720,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.when(
@@ -750,6 +774,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -799,7 +825,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -817,10 +843,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
                 .expectErrorMatches(error -> error instanceof BadGatewayException)
@@ -1204,6 +1236,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1253,7 +1287,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -1270,10 +1304,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
 
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
@@ -1297,6 +1337,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1346,7 +1388,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -1364,10 +1406,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
 
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
@@ -1393,6 +1441,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1461,10 +1511,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
 
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
@@ -1490,6 +1546,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1539,7 +1597,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -1558,10 +1616,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
 
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
@@ -1587,6 +1651,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1636,7 +1702,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -1654,10 +1720,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
 
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
@@ -1683,6 +1755,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1751,10 +1825,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.when(
@@ -1797,6 +1877,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1846,7 +1928,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -1869,10 +1951,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.when(
@@ -1915,6 +2003,8 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String orderId = "orderId";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -1964,7 +2054,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 Optional.of(UUID.randomUUID().toString()),
                 Optional.empty(),
                 "VISA",
-                new CardsAuthRequestDetailsDto().orderId("orderId")
+                new CardsAuthRequestDetailsDto().orderId(orderId)
         );
 
         TransactionRequestAuthorizationCommand requestAuthorizationCommand = new TransactionRequestAuthorizationCommand(
@@ -1987,10 +2077,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData))
+        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationData, correlationId))
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         Mockito.when(
@@ -2042,6 +2138,7 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2138,12 +2235,20 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgBuildSession(authorizationData, true))
+        Mockito.when(paymentGatewayClient.requestNpgBuildSession(authorizationData, correlationId, true))
                 .thenReturn(Mono.just(responseRequestNpgBuildSession));
-        Mockito.when(paymentGatewayClient.requestNpgCardsAuthorization(authorizationDataAfterBuildSession))
+        Mockito.when(
+                paymentGatewayClient.requestNpgCardsAuthorization(authorizationDataAfterBuildSession, correlationId)
+        )
                 .thenReturn(Mono.just(stateResponseDto));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
 
@@ -2260,8 +2365,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 .expectErrorMatches(error -> error instanceof BadRequestException)
                 .verify();
 
-        Mockito.verify(paymentGatewayClient, Mockito.times(0)).requestNpgBuildSession(any(), eq(true));
-        Mockito.verify(paymentGatewayClient, Mockito.times(0)).requestNpgCardsAuthorization(any());
+        Mockito.verify(paymentGatewayClient, Mockito.times(0)).requestNpgBuildSession(any(), any(), eq(true));
+        Mockito.verify(paymentGatewayClient, Mockito.times(0)).requestNpgCardsAuthorization(any(), any());
         Mockito.verify(transactionEventStoreRepository, Mockito.times(0)).save(any());
         Mockito.verify(transactionTemplateWrapper, Mockito.times(0)).save(any());
 
@@ -2281,6 +2386,7 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2300,7 +2406,7 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                new NpgTransactionGatewayActivationData("orderId", correlationId)
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2350,10 +2456,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgBuildApmPayment(authorizationData, true))
+        Mockito.when(paymentGatewayClient.requestNpgBuildApmPayment(authorizationData, correlationId, true))
                 .thenReturn(Mono.just(responseRequestNpgBuildSession));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
 
@@ -2391,6 +2503,7 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2460,10 +2573,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgBuildApmPayment(authorizationData, false))
+        Mockito.when(paymentGatewayClient.requestNpgBuildApmPayment(authorizationData, correlationId, false))
                 .thenReturn(Mono.just(responseRequestNpgBuildSession));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
         Mockito.when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
 
@@ -2504,6 +2623,7 @@ class TransactionRequestAuthorizationHandlerTest {
         Confidential<Email> email = TransactionTestUtils.EMAIL;
         PaymentContextCode nullPaymentContextCode = new PaymentContextCode(null);
         String idCart = "idCart";
+        String correlationId = UUID.randomUUID().toString();
         TransactionActivated transaction = new TransactionActivated(
                 transactionId,
                 List.of(
@@ -2573,10 +2693,16 @@ class TransactionRequestAuthorizationHandlerTest {
                 .thenReturn(Mono.empty());
         Mockito.when(paymentGatewayClient.requestCreditCardAuthorization(authorizationData))
                 .thenReturn(Mono.empty());
-        Mockito.when(paymentGatewayClient.requestNpgBuildApmPayment(authorizationData, true))
+        Mockito.when(paymentGatewayClient.requestNpgBuildApmPayment(authorizationData, correlationId, true))
                 .thenReturn(Mono.just(responseRequestNpgBuildSession));
-        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value().toString()))
-                .thenReturn((Flux) Flux.just(TransactionTestUtils.transactionActivateEvent()));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(
+                        (Flux) Flux.just(
+                                TransactionTestUtils.transactionActivateEvent(
+                                        new NpgTransactionGatewayActivationData(orderId, correlationId)
+                                )
+                        )
+                );
 
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))


### PR DESCRIPTION
depend on https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/420
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Used the correlationId saved in the activation event during the call flow to NPG.
<!--- Describe your changes in detail -->

#### Motivation and Context
The change was made to use the same correlationId in all calls to NPG
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.