### PR TITLE
Chk-2465: restrict refund in closure handler

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -80,8 +80,8 @@ microservice-chart:
     NODO_HOSTNAME: https://api.uat.platform.pagopa.it
     NODE_FOR_PSP_URI: /nodo/node-for-psp/v1
     NODO_PER_PM_URI: /nodo/nodo-per-pm/v2
-    NODO_READ_TIMEOUT: "10000"
-    NODO_CONNECTION_TIMEOUT: "10000"
+    NODO_READ_TIMEOUT: "14000"
+    NODO_CONNECTION_TIMEOUT: "14000"
     NODO_PARALLEL_REQUESTS: "5"
     NODO_ALL_CCP_ON_TRANSFER_IBAN_ENABLED: "true"
     NODO_ECOMMERCE_CLIENT_ID: ecommdev

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -27,8 +27,8 @@ microservice-chart:
       NODO_HOSTNAME: https://api.platform.pagopa.it
       NODE_FOR_PSP_URI: /nodo/node-for-psp/v1
       NODO_PER_PM_URI: /nodo/nodo-per-pm/v2
-      NODO_READ_TIMEOUT: "10000"
-      NODO_CONNECTION_TIMEOUT: "10000"
+      NODO_READ_TIMEOUT: "14000"
+      NODO_CONNECTION_TIMEOUT: "14000"
       NODO_PARALLEL_REQUESTS: "5"
       NODO_ALL_CCP_ON_TRANSFER_IBAN_ENABLED: "true"
       NODO_ECOMMERCE_CLIENT_ID: ecomm
@@ -184,8 +184,8 @@ microservice-chart:
     NODO_HOSTNAME: https://api.platform.pagopa.it
     NODE_FOR_PSP_URI: /nodo/node-for-psp/v1
     NODO_PER_PM_URI: /nodo/nodo-per-pm/v2
-    NODO_READ_TIMEOUT: "10000"
-    NODO_CONNECTION_TIMEOUT: "10000"
+    NODO_READ_TIMEOUT: "14000"
+    NODO_CONNECTION_TIMEOUT: "14000"
     NODO_PARALLEL_REQUESTS: "5"
     NODO_ALL_CCP_ON_TRANSFER_IBAN_ENABLED: "true"
     NODO_ECOMMERCE_CLIENT_ID: ecomm

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -27,8 +27,8 @@ microservice-chart:
       NODO_HOSTNAME: https://api.uat.platform.pagopa.it
       NODE_FOR_PSP_URI: /nodo/node-for-psp/v1
       NODO_PER_PM_URI: /nodo/nodo-per-pm/v2
-      NODO_READ_TIMEOUT: "10000"
-      NODO_CONNECTION_TIMEOUT: "10000"
+      NODO_READ_TIMEOUT: "14000"
+      NODO_CONNECTION_TIMEOUT: "14000"
       NODO_PARALLEL_REQUESTS: "5"
       NODO_ALL_CCP_ON_TRANSFER_IBAN_ENABLED: "true"
       NODO_ECOMMERCE_CLIENT_ID: ecomm
@@ -178,8 +178,8 @@ microservice-chart:
     NODO_HOSTNAME: https://api.uat.platform.pagopa.it
     NODE_FOR_PSP_URI: /nodo/node-for-psp/v1
     NODO_PER_PM_URI: /nodo/nodo-per-pm/v2
-    NODO_READ_TIMEOUT: "10000"
-    NODO_CONNECTION_TIMEOUT: "10000"
+    NODO_READ_TIMEOUT: "14000"
+    NODO_CONNECTION_TIMEOUT: "14000"
     NODO_PARALLEL_REQUESTS: "5"
     NODO_ALL_CCP_ON_TRANSFER_IBAN_ENABLED: "true"
     NODO_ECOMMERCE_CLIENT_ID: ecomm

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                                <inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-infra/eff0d7e961328c9888d73dc17d96695301df1861/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl</inputSpec>
+                                <inputSpec>https://raw.githubusercontent.com/pagopa/pagopa-infra/51569d014c17d0808d8e08be11d05b32f83bf8a6/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl</inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/src/main/java/it/pagopa/transactions/client/NodeForPspClient.java
+++ b/src/main/java/it/pagopa/transactions/client/NodeForPspClient.java
@@ -150,7 +150,7 @@ public class NodeForPspClient {
                                 );
                             } catch (JsonProcessingException e) {
 
-                                return new BadGatewayException(null, error.getStatus());
+                                return new BadGatewayException(error.getReason(), error.getStatus());
                             }
 
                         }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandler.java
@@ -373,7 +373,10 @@ public class TransactionSendClosureHandler extends TransactionSendClosureHandler
                                  * status code. The transaction status remains AUTHORIZATION_COMPLETED
                                  */
                                 return Mono.error(
-                                        exception
+                                        new BadGatewayException(
+                                                "Error while invoke Nodo closePayment",
+                                                HttpStatus.BAD_GATEWAY
+                                        )
                                 );
 
                             });

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandler.java
@@ -241,8 +241,8 @@ public class TransactionSendClosureHandler extends TransactionSendClosureHandler
                                         && "Node did not receive RPT yet".equals(responseStatusException.getDetail());
 
                                 log.error(
-                                        "Got exception while invoking closePaymentV2 unrecoverable error: %s"
-                                                .formatted(unrecoverableError),
+                                        "Got exception while invoking closePaymentV2 unrecoverable error: %s - isRefundable: %s "
+                                                .formatted(unrecoverableError, isRefundable),
                                         exception
                                 );
                                 // the closure error event is build and sent iff the transaction was previously

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandler.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
@@ -232,6 +233,13 @@ public class TransactionSendClosureHandler extends TransactionSendClosureHandler
                                 boolean unrecoverableError = exception instanceof BadGatewayException responseStatusException
                                         && responseStatusException.getHttpStatus().is4xxClientError();
 
+                                // TODO: waiting for nodo update in order to have an error code to avoid check
+                                // on fixed string
+                                boolean isRefundable = exception instanceof BadGatewayException responseStatusException
+                                        && HttpStatus.UNPROCESSABLE_ENTITY
+                                                .equals(responseStatusException.getHttpStatus())
+                                        && "Node did not receive RPT yet".equals(responseStatusException.getDetail());
+
                                 log.error(
                                         "Got exception while invoking closePaymentV2 unrecoverable error: %s"
                                                 .formatted(unrecoverableError),
@@ -324,37 +332,49 @@ public class TransactionSendClosureHandler extends TransactionSendClosureHandler
                                             )
                                     );
                                 }
+
                                 // Unrecoverable error calling Nodo for perform close payment.
                                 // Generate closure event setting closure outcome to KO
                                 // and enqueue refund request event
-                                return eventSaved
-                                        .flatMap(
+                                if (isRefundable) {
+                                    return eventSaved
+                                            .flatMap(
 
-                                                closureErrorEvent -> sendRefundRequestEvent(
-                                                        Either.left(closureErrorEvent),
-                                                        transactionAuthorizationCompletedData
-                                                                .getAuthorizationResultDto(),
-                                                        tx.getTransactionId()
-                                                ).map(
-                                                        (refundRequestedEvent) -> Tuples.of(
-                                                                Optional.<BaseTransactionEvent<?>>of(
-                                                                        refundRequestedEvent
-                                                                ),
-                                                                Either.<BaseTransactionEvent<?>, BaseTransactionEvent<?>>left(
-                                                                        closureErrorEvent
-                                                                )
-                                                        )
+                                                    closureErrorEvent -> sendRefundRequestEvent(
+                                                            Either.left(closureErrorEvent),
+                                                            transactionAuthorizationCompletedData
+                                                                    .getAuthorizationResultDto(),
+                                                            tx.getTransactionId()
+                                                    ).map(
+                                                            (refundRequestedEvent) -> Tuples.of(
+                                                                    Optional.<BaseTransactionEvent<?>>of(
+                                                                            refundRequestedEvent
+                                                                    ),
+                                                                    Either.<BaseTransactionEvent<?>, BaseTransactionEvent<?>>left(
+                                                                            closureErrorEvent
+                                                                    )
+                                                            )
 
-                                                ).switchIfEmpty(
-                                                        Mono.just(
-                                                                Tuples.of(
-                                                                        Optional.empty(),
-                                                                        Either.left(closureErrorEvent)
-                                                                )
-                                                        )
+                                                    ).switchIfEmpty(
+                                                            Mono.just(
+                                                                    Tuples.of(
+                                                                            Optional.empty(),
+                                                                            Either.left(closureErrorEvent)
+                                                                    )
+                                                            )
 
-                                                )
-                                        );
+                                                    )
+                                            );
+                                }
+
+                                /*
+                                 * When a transaction is not recoverable through retries and cannot be refunded,
+                                 * then the API returns a 502 status code along with the reason from the Node's
+                                 * status code. The transaction status remains AUTHORIZATION_COMPLETED
+                                 */
+                                return Mono.error(
+                                        exception
+                                );
 
                             });
                 });

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandlerTest.java
@@ -3502,6 +3502,231 @@ class TransactionSendClosureHandlerTest {
                 .verify();
     }
 
+    @Test
+    void shouldSendRefundRequestedEventOnQueueForAuthorizedTransactionAndNodoClosePaymentRefundableError() {
+
+        TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
+
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = TransactionTestUtils
+                .transactionAuthorizationRequestedEvent();
+
+        TransactionAuthorizationCompletedEvent authorizationCompletedEvent = TransactionTestUtils
+                .transactionAuthorizationCompletedEvent(AuthorizationResultDto.OK);
+        UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
+                .outcomeGateway(
+                        new OutcomeVposGatewayDto()
+                                .outcome(OutcomeVposGatewayDto.OutcomeEnum.OK)
+                                .authorizationCode(AUTHORIZATION_CODE)
+                                .rrn(ECOMMERCE_RRN)
+                )
+                .timestampOperation(operationTimestamp);
+
+        Flux<BaseTransactionEvent<Object>> events = ((Flux) Flux
+                .just(transactionActivatedEvent, authorizationRequestedEvent, authorizationCompletedEvent));
+
+        it.pagopa.ecommerce.commons.domain.v1.Transaction transaction = events
+                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent).block();
+
+        ClosureSendData closureSendData = new ClosureSendData(
+                transactionId,
+                updateAuthorizationRequest
+        );
+
+        TransactionClosureSendCommand closureSendCommand = new TransactionClosureSendCommand(
+                new RptId(transactionActivatedEvent.getData().getPaymentNotices().get(0).getRptId()),
+                closureSendData
+        );
+
+        TransactionAuthorizationRequestData authorizationRequestData = authorizationRequestedEvent.getData();
+        Integer amount = ((BaseTransactionWithPaymentToken) transaction).getPaymentNotices().stream()
+                .mapToInt(
+                        paymentNotice -> paymentNotice.transactionAmount().value()
+                ).sum();
+        Integer fee = authorizationRequestData.getFee();
+        Integer totalAmount = amount + fee;
+
+        BigDecimal amountEuroCents = BigDecimal.valueOf(
+                amount
+        );
+        BigDecimal feeEuroCents = BigDecimal.valueOf(fee);
+        BigDecimal totalAmountEuroCents = BigDecimal.valueOf(totalAmount);
+
+        BigDecimal feeEuro = EuroUtils.euroCentsToEuro(fee);
+        BigDecimal totalAmountEuro = EuroUtils.euroCentsToEuro(totalAmount);
+        ClosePaymentRequestV2Dto closePaymentRequest = new ClosePaymentRequestV2Dto()
+                .paymentTokens(
+                        List.of(
+                                ((BaseTransactionWithPaymentToken) transaction).getTransactionActivatedData()
+                                        .getPaymentNotices().get(0).getPaymentToken()
+                        )
+                )
+                .outcome(ClosePaymentRequestV2Dto.OutcomeEnum.OK)
+                .idPSP(authorizationRequestData.getPspId())
+                .idBrokerPSP(authorizationRequestData.getBrokerName())
+                .idChannel(authorizationRequestData.getPspChannelCode())
+                .transactionId(((BaseTransactionWithPaymentToken) transaction).getTransactionId().value())
+                .totalAmount(
+                        totalAmountEuro
+                )
+                .fee(feeEuro)
+                .timestampOperation(updateAuthorizationRequest.getTimestampOperation())
+                .paymentMethod(authorizationRequestData.getPaymentTypeCode())
+                .additionalPaymentInformations(
+                        new AdditionalPaymentInformationsDto()
+                                .outcomePaymentGateway(
+                                        AdditionalPaymentInformationsDto.OutcomePaymentGatewayEnum.fromValue(
+                                                ((OutcomeVposGatewayDto) updateAuthorizationRequest.getOutcomeGateway())
+                                                        .getOutcome().toString()
+                                        )
+                                )
+                                .authorizationCode(
+                                        AUTHORIZATION_CODE
+                                )
+                                .rrn(ECOMMERCE_RRN)
+                                .fee(
+                                        feeEuro
+                                                .toString()
+                                )
+                                .timestampOperation(
+                                        expectedOperationTimestamp
+                                )
+                                .totalAmount(totalAmountEuro.toString())
+                ).transactionDetails(
+                        new TransactionDetailsDto()
+                                .transaction(
+                                        new TransactionDto()
+                                                .transactionId(
+                                                        ((BaseTransactionWithPaymentToken) transaction)
+                                                                .getTransactionId().value()
+                                                )
+                                                .transactionStatus("Confermato")
+                                                .fee(feeEuroCents)
+                                                .paymentGateway(authorizationRequestData.getPaymentGateway().name())
+                                                .timestampOperation(
+                                                        authorizationCompletedEvent.getData().getTimestampOperation()
+                                                )
+                                                .amount(
+                                                        amountEuroCents
+                                                )
+                                                .grandTotal(
+                                                        totalAmountEuroCents
+                                                )
+                                                .rrn(
+                                                        ECOMMERCE_RRN
+                                                )
+                                                .authorizationCode(
+                                                        AUTHORIZATION_CODE
+                                                )
+                                                .creationDate(
+                                                        ZonedDateTime.parse(
+                                                                transactionActivatedEvent
+                                                                        .getCreationDate()
+                                                        ).toOffsetDateTime()
+                                                )
+                                                .psp(
+                                                        new PspDto()
+                                                                .idPsp(
+                                                                        authorizationRequestData
+                                                                                .getPspId()
+                                                                )
+                                                                .idChannel(
+                                                                        authorizationRequestData
+                                                                                .getPspChannelCode()
+                                                                )
+                                                                .businessName(
+                                                                        authorizationRequestData
+                                                                                .getPspBusinessName()
+                                                                )
+                                                                .brokerName(authorizationRequestData.getBrokerName())
+                                                                .pspOnUs(authorizationRequestData.isPspOnUs())
+                                                )
+                                )
+                                .info(
+                                        new InfoDto()
+                                                .type(
+                                                        authorizationRequestData
+                                                                .getPaymentTypeCode()
+                                                )
+                                                .brandLogo(
+                                                        authorizationRequestData.getLogo()
+                                                                .toString()
+                                                )
+                                                .brand(authorizationRequestData.getBrand().name())
+                                                .paymentMethodName(authorizationRequestData.getPaymentMethodName())
+                                                .clientId(
+                                                        ((BaseTransactionWithPaymentToken) transaction).getClientId()
+                                                                .name()
+                                                )
+                                )
+                                .user(new UserDto().type(UserDto.TypeEnum.GUEST))
+
+                );
+
+        RuntimeException closePaymentError = new BadGatewayException(
+                "Node did not receive RPT yet",
+                HttpStatus.UNPROCESSABLE_ENTITY
+        );
+
+        TransactionClosureErrorEvent errorEvent = new TransactionClosureErrorEvent(
+                transactionId.value()
+        );
+
+        TransactionRefundRequestedEvent refundRequestedEvent = new TransactionRefundRequestedEvent(
+                transactionId.value(),
+                new TransactionRefundedData()
+        );
+
+        /* preconditions */
+        Mockito.when(transactionEventStoreRepository.save(any())).thenAnswer(a -> Mono.just(a.getArgument(0)));
+        Mockito.when(nodeForPspClient.closePaymentV2(closePaymentRequest)).thenReturn(Mono.error(closePaymentError));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
+                .thenReturn(events);
+        Mockito.when(
+                refundQueueAsyncClient
+                        .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
+        ).thenReturn(queueSuccessfulResponse());
+        Mockito.when(transactionRefundedEventStoreRepository.save(any())).thenReturn(Mono.just(refundRequestedEvent));
+        Mockito.when(transactionClosureErrorEventStoreRepository.save(any()))
+                .thenAnswer(a -> Mono.just(a.getArgument(0)));
+
+        /* test */
+        StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
+                .consumeNextWith(next -> {
+                    assertTrue(next.getT1().isPresent());
+                    assertNotNull(next.getT1().get());
+                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
+                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
+                })
+                .verifyComplete();
+
+        /*
+         * check that the closure event with outcome KO is sent in the transaction
+         * activated queue
+         */
+        Mockito.verify(refundQueueAsyncClient, times(1))
+                .sendMessageWithResponse(
+                        argThat(
+                                (
+                                 QueueEvent<TransactionRefundRequestedEvent> e
+                                ) -> e.event().getTransactionId().equals(transactionId.value()) && e.event().getData()
+                                        .getStatusBeforeRefunded().equals(TransactionStatusDto.CLOSURE_ERROR)
+                        ),
+                        eq(Duration.ZERO),
+                        any()
+                );
+
+        /*
+         * check that no event is sent on the closure error queue
+         */
+        Mockito.verify(transactionClosureSentEventQueueClient, times(0))
+                .sendMessageWithResponse(
+                        any(),
+                        any(),
+                        isNull()
+                );
+        assertEquals(Duration.ofSeconds(transientQueueEventsTtlSeconds), durationArgumentCaptor.getValue());
+    }
+
     private static Mono<Response<SendMessageResult>> queueSuccessfulResponse() {
         return Mono.just(new Response<>() {
             @Override

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandlerTest.java
@@ -1539,7 +1539,7 @@ class TransactionSendClosureHandlerTest {
     }
 
     @Test
-    void shouldNotEnqueueErrorEventOnNodoUnrecoverableFailureTransactionAuthorized() {
+    void shouldNotEnqueueErrorEventOnNodoUnrecoverableAndNotRefundableFailureTransactionAuthorized() {
         PaymentToken paymentToken = new PaymentToken("paymentToken");
         RptId rptId = new RptId("77777777777111111111111111111");
         TransactionDescription description = new TransactionDescription("description");
@@ -1758,14 +1758,6 @@ class TransactionSendClosureHandlerTest {
                                 .user(new UserDto().type(UserDto.TypeEnum.GUEST))
 
                 );
-        TransactionClosureErrorEvent errorEvent = new TransactionClosureErrorEvent(
-                transactionId.value()
-        );
-
-        TransactionRefundRequestedEvent refundRequestedEvent = new TransactionRefundRequestedEvent(
-                transactionId.value(),
-                new TransactionRefundedData()
-        );
 
         RuntimeException closePaymentError = new BadGatewayException("Bad request error", HttpStatus.BAD_REQUEST);
 
@@ -1774,59 +1766,17 @@ class TransactionSendClosureHandlerTest {
         Mockito.when(nodeForPspClient.closePaymentV2(closePaymentRequest)).thenReturn(Mono.error(closePaymentError));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
                 .thenReturn(events);
-        Mockito.when(transactionClosureErrorEventStoreRepository.save(any())).thenReturn(Mono.just(errorEvent));
-        Mockito.when(
-                transactionClosureSentEventQueueClient
-                        .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
-        ).thenReturn(queueSuccessfulResponse());
-        Mockito.when(transactionRefundedEventStoreRepository.save(any())).thenReturn(Mono.just(refundRequestedEvent));
-        Mockito.when(
-                refundQueueAsyncClient
-                        .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
-
-        ).thenReturn(queueSuccessfulResponse());
 
         Hooks.onOperatorDebug();
 
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
-                .consumeNextWith(next -> {
-                    assertTrue(next.getT1().isPresent());
-                    assertNotNull(next.getT1().get());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
-                })
-                .verifyComplete();
-
-        Mockito.verify(
-                refundQueueAsyncClient,
-                times(1)
-        ).sendMessageWithResponse(
-                argThat(
-                        (QueueEvent<TransactionRefundRequestedEvent> e) -> e.event().getData()
-                                .getStatusBeforeRefunded().equals(TransactionStatusDto.CLOSURE_ERROR)
-                ),
-                any(),
-                any()
-        );
-        // check that one closure error event is saved and none is sent to event
-        // dispatcher
-        Mockito.verify(transactionClosureErrorEventStoreRepository, times(1))
-                .save(any());
-        Mockito.verify(transactionClosureSentEventQueueClient, times(0))
-                .sendMessageWithResponse(
-                        argThat(
-                                (QueueEvent<TransactionClosureErrorEvent> e) -> e.event().equals(errorEvent)
-                        ),
-                        argThat(d -> d.compareTo(Duration.ofSeconds(RETRY_TIMEOUT_INTERVAL)) <= 0),
-                        isNull()
-                );
-        durationArgumentCaptor.getAllValues()
-                .forEach(duration -> assertEquals(Duration.ofSeconds(transientQueueEventsTtlSeconds), duration));
+                .expectErrorMatches(error -> error instanceof BadGatewayException)
+                .verify();
     }
 
     @Test
-    void shouldNotEnqueueErrorEventOnNodoUnrecoverableFailureTransactionNotAuthorized() {
+    void shouldNotEnqueueErrorEventOnNodoUnrecoverableAndNotRefundableFailureTransactionNotAuthorized() {
         PaymentToken paymentToken = new PaymentToken("paymentToken");
         RptId rptId = new RptId("77777777777111111111111111111");
         TransactionDescription description = new TransactionDescription("description");
@@ -2028,10 +1978,6 @@ class TransactionSendClosureHandlerTest {
                                 .user(new UserDto().type(UserDto.TypeEnum.GUEST))
                 );
 
-        TransactionClosureErrorEvent errorEvent = new TransactionClosureErrorEvent(
-                transactionId.value()
-        );
-
         RuntimeException closePaymentError = new BadGatewayException("Bad request error", HttpStatus.BAD_REQUEST);
 
         /* preconditions */
@@ -2039,38 +1985,13 @@ class TransactionSendClosureHandlerTest {
         Mockito.when(nodeForPspClient.closePaymentV2(closePaymentRequest)).thenReturn(Mono.error(closePaymentError));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
                 .thenReturn(events);
-        Mockito.when(transactionClosureErrorEventStoreRepository.save(any())).thenReturn(Mono.just(errorEvent));
-        Mockito.when(transactionRefundedEventStoreRepository.save(any())).thenAnswer(a -> Mono.just(a.getArgument(0)));
-        Mockito.when(
-                refundQueueAsyncClient
-                        .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
-        ).thenReturn(queueSuccessfulResponse());
-
         Hooks.onOperatorDebug();
 
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
-                .consumeNextWith(next -> {
-                    assertTrue(next.getT2().isLeft());
-                    assertNotNull(next.getT2().getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
-                })
-                .verifyComplete();
+                .expectErrorMatches(error -> error instanceof BadGatewayException)
+                .verify();
 
-        // check that no closure error event is saved but not sent to event dispatcher
-        Mockito.verify(transactionClosureErrorEventStoreRepository, times(1))
-                .save(any());
-        Mockito.verify(transactionClosureSentEventQueueClient, times(0))
-                .sendMessageWithResponse(
-                        argThat(
-                                (QueueEvent<TransactionClosureErrorEvent> e) -> e.event().equals(errorEvent)
-                        ),
-                        argThat(d -> d.compareTo(Duration.ofSeconds(RETRY_TIMEOUT_INTERVAL)) <= 0),
-                        isNull()
-                );
-        // check that closure error event is saved
-        Mockito.verify(transactionClosureErrorEventStoreRepository, times(1)).save(any());
     }
 
     @Test
@@ -3109,7 +3030,7 @@ class TransactionSendClosureHandlerTest {
     }
 
     @Test
-    void shouldSendRefundRequestedEventOnQueueForAuthorizedTransactionAndNodoClosePaymentUnrecoverableError() {
+    void shouldNotEnqueueErrorEventOnNodoUnrecoverableAndNotRefundableAuthorized() {
 
         TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
 
@@ -3270,15 +3191,6 @@ class TransactionSendClosureHandlerTest {
 
         RuntimeException closePaymentError = new BadGatewayException("Bad request error", HttpStatus.BAD_REQUEST);
 
-        TransactionClosureErrorEvent errorEvent = new TransactionClosureErrorEvent(
-                transactionId.value()
-        );
-
-        TransactionRefundRequestedEvent refundRequestedEvent = new TransactionRefundRequestedEvent(
-                transactionId.value(),
-                new TransactionRefundedData()
-        );
-
         /* preconditions */
         Mockito.when(transactionEventStoreRepository.save(any())).thenAnswer(a -> Mono.just(a.getArgument(0)));
         Mockito.when(nodeForPspClient.closePaymentV2(closePaymentRequest)).thenReturn(Mono.error(closePaymentError));
@@ -3288,46 +3200,11 @@ class TransactionSendClosureHandlerTest {
                 refundQueueAsyncClient
                         .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
         ).thenReturn(queueSuccessfulResponse());
-        Mockito.when(transactionRefundedEventStoreRepository.save(any())).thenReturn(Mono.just(refundRequestedEvent));
-        Mockito.when(transactionClosureErrorEventStoreRepository.save(any()))
-                .thenAnswer(a -> Mono.just(a.getArgument(0)));
 
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
-                .consumeNextWith(next -> {
-                    assertTrue(next.getT1().isPresent());
-                    assertNotNull(next.getT1().get());
-                    assertEquals(refundRequestedEvent.getEventCode(), next.getT1().get().getEventCode());
-                    assertEquals(refundRequestedEvent.getTransactionId(), next.getT1().get().getTransactionId());
-                })
-                .verifyComplete();
-
-        /*
-         * check that the closure event with outcome KO is sent in the transaction
-         * activated queue
-         */
-        Mockito.verify(refundQueueAsyncClient, times(1))
-                .sendMessageWithResponse(
-                        argThat(
-                                (
-                                 QueueEvent<TransactionRefundRequestedEvent> e
-                                ) -> e.event().getTransactionId().equals(transactionId.value()) && e.event().getData()
-                                        .getStatusBeforeRefunded().equals(TransactionStatusDto.CLOSURE_ERROR)
-                        ),
-                        eq(Duration.ZERO),
-                        any()
-                );
-
-        /*
-         * check that no event is sent on the closure error queue
-         */
-        Mockito.verify(transactionClosureSentEventQueueClient, times(0))
-                .sendMessageWithResponse(
-                        any(),
-                        any(),
-                        isNull()
-                );
-        assertEquals(Duration.ofSeconds(transientQueueEventsTtlSeconds), durationArgumentCaptor.getValue());
+                .expectErrorMatches(error -> error instanceof BadGatewayException)
+                .verify();
     }
 
     @Test
@@ -3618,31 +3495,11 @@ class TransactionSendClosureHandlerTest {
         Mockito.when(nodeForPspClient.closePaymentV2(closePaymentRequest)).thenReturn(Mono.error(closePaymentError));
         Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value()))
                 .thenReturn(events);
-        Mockito.when(
-                refundQueueAsyncClient
-                        .sendMessageWithResponse(any(), any(), durationArgumentCaptor.capture())
-        ).thenReturn(queueSuccessfulResponse());
-        Mockito.when(transactionRefundedEventStoreRepository.save(any())).thenAnswer(a -> Mono.just(a.getArgument(0)));
-        Mockito.when(transactionClosureErrorEventStoreRepository.save(any()))
-                .thenAnswer(a -> Mono.just(a.getArgument(0)));
 
         /* test */
         StepVerifier.create(transactionSendClosureHandler.handle(closureSendCommand))
-                .consumeNextWith(next -> {
-                    assertTrue(next.getT2().isLeft());
-                    assertNotNull(next.getT2().getLeft());
-                    assertEquals(errorEvent.getEventCode(), next.getT2().getLeft().getEventCode());
-                    assertEquals(errorEvent.getTransactionId(), next.getT2().getLeft().getTransactionId());
-                })
-                .verifyComplete();
-
-        Mockito.verify(transactionClosureErrorEventStoreRepository, times(1)).save(any());
-        Mockito.verify(transactionClosureSentEventQueueClient, times(0))
-                .sendMessageWithResponse(
-                        any(),
-                        any(),
-                        any()
-                );
+                .expectErrorMatches(error -> error instanceof BadGatewayException)
+                .verify();
     }
 
     private static Mono<Response<SendMessageResult>> queueSuccessfulResponse() {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- update closureHandler
- increase nodo client timeout

#### Motivation and Context

The goal of the PR is to initiate a refund during the sending of a closePayment only if the status code 422 is encountered, with the following description:

```
Node did not receive RPT yet
```
 waiting a structured error code from the node.

Consequently, unlike before, in the event of a 4xx error, the transaction status remains unchanged at `AUTHORIZATION_COMLETED`, and the API returns a 502 response.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.