### PR TITLE
feat(ff): send payment result after expiration for v2 events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>1.9.6</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.10.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
         <mock-web-server.version>4.11.0</mock-web-server.version>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandler.java
@@ -71,6 +71,10 @@ public class TransactionRequestUserReceiptHandler extends TransactionRequestUser
                 )
                 .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getTransactionId())));
         return transaction
+                .map(
+                        tx -> tx instanceof it.pagopa.ecommerce.commons.domain.v2.TransactionExpired txExpired
+                                && sendPaymentResultForTxExpiredEnabled ? txExpired.getTransactionAtPreviousState() : tx
+                )
                 .filter(
                         t -> t.getStatus() == TransactionStatusDto.CLOSED &&
                                 t instanceof it.pagopa.ecommerce.commons.domain.v2.TransactionClosed transactionClosed

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandlerTest.java
@@ -437,4 +437,176 @@ class TransactionRequestUserReceiptHandlerTest {
 
         Mockito.verify(userReceiptDataEventRepository, Mockito.times(0)).save(any());
     }
+
+    @Test
+    void shouldSendEventForSendPaymentOutcomeOkForTxExpired() {
+        TransactionActivatedEvent transactionActivatedEvent = transactionActivateEvent();
+
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = transactionAuthorizationRequestedEvent();
+
+        TransactionAuthorizationCompletedEvent authorizationCompletedEvent = transactionAuthorizationCompletedEvent(
+                new PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK)
+        );
+
+        TransactionClosureRequestedEvent closureRequestedEvent = TransactionTestUtils
+                .transactionClosureRequestedEvent();
+
+        TransactionClosedEvent closureSentEvent = TransactionTestUtils
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
+
+        AddUserReceiptRequestDto addUserReceiptRequest = new AddUserReceiptRequestDto()
+                .outcome(AddUserReceiptRequestDto.OutcomeEnum.OK)
+                .paymentDate(OffsetDateTime.now())
+                .addPaymentsItem(
+                        new AddUserReceiptRequestPaymentsInnerDto()
+                                .paymentToken("paymentToken")
+                                .companyName("companyName")
+                                .creditorReferenceId("creditorReferenceId")
+                                .description("description")
+                                .debtor("debtor")
+                                .fiscalCode("fiscalCode")
+                                .officeName("officeName")
+                );
+
+        TransactionActivated transaction = transactionActivated(ZonedDateTime.now().toString());
+
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(transaction);
+
+        AddUserReceiptData addUserReceiptData = new AddUserReceiptData(
+                transaction.getTransactionId(),
+                addUserReceiptRequest
+        );
+
+        TransactionAddUserReceiptCommand addUserReceiptCommand = new TransactionAddUserReceiptCommand(
+                transaction.getPaymentNotices().get(0).rptId(),
+                addUserReceiptData
+        );
+
+        TransactionUserReceiptRequestedEvent event = transactionUserReceiptRequestedEvent(
+                TransactionTestUtils.transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK)
+        );
+
+        Flux<BaseTransactionEvent<Object>> events = ((Flux) Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizationCompletedEvent,
+                closureRequestedEvent,
+                closureSentEvent,
+                transactionExpiredEvent
+        ));
+
+        /* preconditions */
+        Mockito.when(userReceiptDataEventRepository.save(any())).thenReturn(Mono.just(event));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)).thenReturn(events);
+        Mockito.when(
+                queueAsyncClient
+                        .sendMessageWithResponse(queueArgumentCaptor.capture(), any(), durationArgumentCaptor.capture())
+        )
+                .thenReturn(QUEUE_SUCCESSFUL_RESPONSE);
+        /* test */
+        StepVerifier.create(updateStatusHandler.handle(addUserReceiptCommand))
+                .expectNext(event)
+                .verifyComplete();
+
+        Mockito.verify(userReceiptDataEventRepository, Mockito.times(1)).save(
+                argThat(
+                        eventArg -> TransactionEventCode.TRANSACTION_USER_RECEIPT_REQUESTED_EVENT.toString()
+                                .equals(eventArg.getEventCode())
+                )
+        );
+        Mockito.verify(queueAsyncClient, Mockito.times(1)).sendMessageWithResponse(any(), any(), any());
+        TransactionUserReceiptRequestedEvent queueEvent = ((TransactionUserReceiptRequestedEvent) queueArgumentCaptor
+                .getValue().event());
+        assertEquals(
+                TransactionEventCode.TRANSACTION_USER_RECEIPT_REQUESTED_EVENT.toString(),
+                queueEvent.getEventCode()
+        );
+        assertEquals(event.getData(), queueEvent.getData());
+        assertEquals(Duration.ofSeconds(transientQueueEventsTtlSeconds), durationArgumentCaptor.getValue());
+    }
+
+    @Test
+    void shouldRejectSendPaymentResultAfterExpirationForDisabledFeatureFlag() {
+        TransactionActivatedEvent transactionActivatedEvent = transactionActivateEvent();
+
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = transactionAuthorizationRequestedEvent();
+
+        TransactionAuthorizationCompletedEvent authorizationCompletedEvent = transactionAuthorizationCompletedEvent(
+                new PgsTransactionGatewayAuthorizationData(null, AuthorizationResultDto.OK)
+        );
+
+        TransactionClosureRequestedEvent closureRequestedEvent = TransactionTestUtils
+                .transactionClosureRequestedEvent();
+
+        TransactionClosedEvent closureSentEvent = TransactionTestUtils
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
+
+        AddUserReceiptRequestDto addUserReceiptRequest = new AddUserReceiptRequestDto()
+                .outcome(AddUserReceiptRequestDto.OutcomeEnum.OK)
+                .paymentDate(OffsetDateTime.now())
+                .addPaymentsItem(
+                        new AddUserReceiptRequestPaymentsInnerDto()
+                                .paymentToken("paymentToken")
+                                .companyName("companyName")
+                                .creditorReferenceId("creditorReferenceId")
+                                .description("description")
+                                .debtor("debtor")
+                                .fiscalCode("fiscalCode")
+                                .officeName("officeName")
+                );
+
+        TransactionActivated transaction = transactionActivated(ZonedDateTime.now().toString());
+
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(transaction);
+
+        AddUserReceiptData addUserReceiptData = new AddUserReceiptData(
+                transaction.getTransactionId(),
+                addUserReceiptRequest
+        );
+
+        TransactionAddUserReceiptCommand addUserReceiptCommand = new TransactionAddUserReceiptCommand(
+                transaction.getPaymentNotices().get(0).rptId(),
+                addUserReceiptData
+        );
+
+        TransactionUserReceiptRequestedEvent event = transactionUserReceiptRequestedEvent(
+                TransactionTestUtils.transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK)
+        );
+
+        Flux<BaseTransactionEvent<Object>> events = ((Flux) Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizationCompletedEvent,
+                closureRequestedEvent,
+                closureSentEvent,
+                transactionExpiredEvent
+        ));
+
+        /* preconditions */
+        Mockito.when(userReceiptDataEventRepository.save(any())).thenReturn(Mono.just(event));
+        Mockito.when(eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(TRANSACTION_ID)).thenReturn(events);
+        Mockito.when(
+                queueAsyncClient
+                        .sendMessageWithResponse(queueArgumentCaptor.capture(), any(), durationArgumentCaptor.capture())
+        )
+                .thenReturn(QUEUE_SUCCESSFUL_RESPONSE);
+        TransactionRequestUserReceiptHandler updateStatusHandler = new TransactionRequestUserReceiptHandler(
+                userReceiptDataEventRepository,
+                transactionsUtils,
+                queueAsyncClient,
+                transientQueueEventsTtlSeconds,
+                tracingUtils,
+                false
+        );
+        /* test */
+        StepVerifier.create(updateStatusHandler.handle(addUserReceiptCommand))
+                .expectError(AlreadyProcessedException.class)
+                .verify();
+
+        Mockito.verify(userReceiptDataEventRepository, Mockito.times(0)).save(
+                any()
+        );
+        Mockito.verify(queueAsyncClient, Mockito.times(0)).sendMessageWithResponse(any(), any(), any());
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Porting of feature flag for accept send payment result after transaction expiration 
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is required in order to accept send payment result received after transaction expiration also for event v2 transactions
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.