### PR TITLE
fix: error mapping for patch auth request with missing auth requested event

### DIFF
--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -724,7 +724,8 @@ public class TransactionsService {
                                 .equals(TransactionEventCode.TRANSACTION_AUTHORIZATION_REQUESTED_EVENT.toString())
                 )
                 .next()
-                .map(authRequestedEvent -> ZonedDateTime.parse(authRequestedEvent.getCreationDate()));
+                .map(authRequestedEvent -> ZonedDateTime.parse(authRequestedEvent.getCreationDate()))
+                .switchIfEmpty(Mono.error(new AlreadyProcessedException(transactionId)));
 
         Mono<Tuple2<it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction, ZonedDateTime>> transactionV1 = transactionsUtils
                 .reduceEvents(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Fixed error code mapping in case of missing AUTHORIZATION_REQUESTED event during a PATCH auth request processing mapping it to 409 instead of 404
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed to properly map error response code in case a PATCH auth request is performed before an authorization request

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.