### PR TITLE
feat: save user id into transaction activated event

### DIFF
--- a/api-spec/v2/transactions-api.yaml
+++ b/api-spec/v2/transactions-api.yaml
@@ -39,7 +39,7 @@ paths:
         - in: header
           name: x-user-id
           required: false
-          description: User id (valued for registered payments)
+          description: User id (valued for authenticated payments)
           schema:
             $ref: '#/components/schemas/UserId'
 

--- a/api-spec/v2/transactions-api.yaml
+++ b/api-spec/v2/transactions-api.yaml
@@ -36,6 +36,12 @@ paths:
           description: NPG correlation id
           schema:
             $ref: '#/components/schemas/CorrelationId'
+        - in: header
+          name: x-user-id
+          required: false
+          description: User id (valued for registered payments)
+          schema:
+            $ref: '#/components/schemas/UserId'
 
       summary: Make a new transaction
       requestBody:
@@ -265,6 +271,10 @@ components:
         - IO
         - CHECKOUT
         - CHECKOUT_CART
+    UserId:
+      description: unique user identifier
+      type: string
+      format: uuid
     CorrelationId:
       description: correlationId
       type: string

--- a/pom.xml
+++ b/pom.xml
@@ -510,6 +510,8 @@
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
                     <scmVersionType>tag</scmVersionType>
                     <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-2725-save-user-id</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/TransactionActivateCommand.java
+++ b/src/main/java/it/pagopa/transactions/commands/TransactionActivateCommand.java
@@ -6,6 +6,8 @@ import it.pagopa.transactions.commands.data.NewTransactionRequestData;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class TransactionActivateCommand extends TransactionsCommand<NewTransactionRequestData> {
@@ -14,15 +16,19 @@ public final class TransactionActivateCommand extends TransactionsCommand<NewTra
 
     private final TransactionId transactionId;
 
+    private final UUID userId;
+
     public TransactionActivateCommand(
             RptId rptId,
             NewTransactionRequestData data,
             String clientId,
-            TransactionId transactionId
+            TransactionId transactionId,
+            UUID userId
     ) {
         super(rptId, TransactionsCommandCode.ACTIVATE, data);
         this.clientId = clientId;
         this.transactionId = transactionId;
+        this.userId = userId;
     }
 
 }

--- a/src/main/java/it/pagopa/transactions/commands/data/NewTransactionRequestData.java
+++ b/src/main/java/it/pagopa/transactions/commands/data/NewTransactionRequestData.java
@@ -2,6 +2,7 @@ package it.pagopa.transactions.commands.data;
 
 import it.pagopa.ecommerce.commons.annotations.ValueObject;
 import it.pagopa.ecommerce.commons.domain.PaymentNotice;
+
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
@@ -330,11 +330,10 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                         ? new NpgTransactionGatewayActivationData(
                                                 newTransactionRequestData.orderId(),
                                                 newTransactionRequestData.correlationId().toString()
-                                        )
-                                        : new EmptyTransactionGatewayActivationData() // this logic will be eliminated
-                                                                                      // with task CHK-2286 by handling
-                                                                                      // the saving of correlationId
-                                                                                      // only
+                                        )// this logic will be eliminated with task CHK-2286 by handling the saving of
+                                         // correlationId only
+                                        : new EmptyTransactionGatewayActivationData(),
+                                Optional.ofNullable(command.getUserId()).map(UUID::toString).orElse(null)
                         )
                 );
 

--- a/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
@@ -64,6 +64,7 @@ public class TransactionsController implements V2Api {
                                                                           ClientIdDto xClientId,
                                                                           UUID correlationId,
                                                                           Mono<NewTransactionRequestDto> newTransactionRequest,
+                                                                          UUID xUserId,
                                                                           ServerWebExchange exchange
     ) {
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
@@ -78,7 +79,7 @@ public class TransactionsController implements V2Api {
                             xClientId.getValue()
 
                     );
-                    return transactionsService.newTransaction(ntr, xClientId, correlationId, transactionId);
+                    return transactionsService.newTransaction(ntr, xClientId, correlationId, transactionId, xUserId);
                 })
                 .map(ResponseEntity::ok)
                 .contextWrite(

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandler.java
@@ -105,7 +105,8 @@ public class AuthorizationUpdateProjectionHandler
                                 transactionDocument.getClientId(),
                                 transactionDocument.getIdCart(),
                                 paymentTokenValidity,
-                                new EmptyTransactionGatewayActivationData() // FIXME
+                                new EmptyTransactionGatewayActivationData(), // FIXME
+                                transactionDocument.getUserId()
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v2/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v2/TransactionsActivationProjectionHandler.java
@@ -59,7 +59,8 @@ public class TransactionsActivationProjectionHandler
                 clientId,
                 idCart,
                 paymentTokenValiditySeconds,
-                event.getData().getTransactionGatewayActivationData()
+                event.getData().getTransactionGatewayActivationData(),
+                event.getData().getUserId()
         );
 
         it.pagopa.ecommerce.commons.documents.v2.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v2.Transaction

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -273,7 +273,8 @@ public class TransactionsService {
                         ).toList()
                 ),
                 clientId.name(),
-                transactionId
+                transactionId,
+                null
         );
 
         return switch (eventVersion) {

--- a/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
@@ -4,12 +4,15 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
 import it.pagopa.ecommerce.commons.documents.v2.Transaction;
-import it.pagopa.ecommerce.commons.domain.*;
+import it.pagopa.ecommerce.commons.domain.PaymentNotice;
+import it.pagopa.ecommerce.commons.domain.RptId;
+import it.pagopa.ecommerce.commons.domain.TransactionAmount;
+import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.generated.transactions.v2.server.model.*;
-import it.pagopa.transactions.commands.*;
+import it.pagopa.transactions.commands.TransactionActivateCommand;
 import it.pagopa.transactions.commands.data.NewTransactionRequestData;
 import it.pagopa.transactions.commands.handlers.v2.TransactionActivateHandler;
-import it.pagopa.transactions.exceptions.*;
+import it.pagopa.transactions.exceptions.InvalidRequestException;
 import it.pagopa.transactions.projections.handlers.v2.TransactionsActivationProjectionHandler;
 import it.pagopa.transactions.utils.TransactionsUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +21,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.util.*;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service(TransactionsService.QUALIFIER_NAME)
 @Slf4j
@@ -52,7 +57,8 @@ public class TransactionsService {
                                                           NewTransactionRequestDto newTransactionRequestDto,
                                                           ClientIdDto clientIdDto,
                                                           UUID correlationId,
-                                                          TransactionId transactionId
+                                                          TransactionId transactionId,
+                                                          UUID userId
     ) {
         Transaction.ClientId clientId = Transaction.ClientId.fromString(
                 Optional.ofNullable(clientIdDto)
@@ -84,7 +90,8 @@ public class TransactionsService {
                         ).toList()
                 ),
                 clientId.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         return transactionActivateHandlerV2.handle(transactionActivateCommand)

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandlerTest.java
@@ -17,6 +17,7 @@ import it.pagopa.ecommerce.commons.queues.TracingUtilsTests;
 import it.pagopa.ecommerce.commons.redis.templatewrappers.PaymentRequestInfoRedisTemplateWrapper;
 import it.pagopa.ecommerce.commons.repositories.PaymentRequestInfo;
 import it.pagopa.ecommerce.commons.utils.JwtTokenUtils;
+import it.pagopa.ecommerce.commons.v2.TransactionTestUtils;
 import it.pagopa.generated.transactions.server.model.NewTransactionRequestDto;
 import it.pagopa.generated.transactions.server.model.NewTransactionResponseDto;
 import it.pagopa.generated.transactions.server.model.PaymentInfoDto;
@@ -46,6 +47,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static it.pagopa.ecommerce.commons.v1.TransactionTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -91,6 +93,8 @@ class TransactionActivateHandlerTest {
     private static final int tokenValidityTimeInSeconds = 900;
 
     private final SecretKey jwtSecretKey = new SecretsConfigurations().ecommerceSigningKey(STRONG_KEY);
+
+    private static final UUID userId = UUID.fromString(TransactionTestUtils.USER_ID);
 
     private final it.pagopa.transactions.commands.handlers.v1.TransactionActivateHandler handler = new TransactionActivateHandler(
             paymentRequestInfoRedisTemplateWrapper,
@@ -144,7 +148,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -274,7 +279,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -388,7 +394,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         /* preconditions */
@@ -478,7 +485,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -548,7 +556,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoBeforeActivation = new PaymentRequestInfo(
@@ -662,7 +671,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoBeforeActivation = new PaymentRequestInfo(
@@ -776,7 +786,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoActivation = new PaymentRequestInfo(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
@@ -99,6 +99,8 @@ class TransactionActivateHandlerTest {
 
     private final SecretKey jwtSecretKey = new SecretsConfigurations().ecommerceSigningKey(STRONG_KEY);
 
+    private final UUID userId = UUID.randomUUID();
+
     private final TransactionActivateHandler handler = new TransactionActivateHandler(
             paymentRequestInfoRedisTemplateWrapper,
             transactionEventActivatedStoreRepository,
@@ -152,7 +154,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -302,7 +305,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -437,7 +441,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -551,7 +556,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         /* preconditions */
@@ -641,7 +647,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoCached = new PaymentRequestInfo(
@@ -711,7 +718,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoBeforeActivation = new PaymentRequestInfo(
@@ -825,7 +833,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoBeforeActivation = new PaymentRequestInfo(
@@ -939,7 +948,8 @@ class TransactionActivateHandlerTest {
                         ).toList()
                 ),
                 Transaction.ClientId.CHECKOUT.name(),
-                transactionId
+                transactionId,
+                userId
         );
 
         PaymentRequestInfo paymentRequestInfoActivation = new PaymentRequestInfo(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -187,7 +187,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -279,7 +280,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -374,7 +376,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -505,7 +508,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -641,7 +645,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -783,7 +788,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -880,7 +886,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -966,7 +973,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1057,7 +1065,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1158,7 +1167,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1259,7 +1269,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1363,7 +1374,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1468,7 +1480,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1573,7 +1586,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1677,7 +1691,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1808,7 +1823,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -1944,7 +1960,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2088,7 +2105,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 clientId,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2254,7 +2272,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2350,7 +2369,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 clientId,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData("orderId", correlationId)
+                new NpgTransactionGatewayActivationData("orderId", correlationId),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2479,7 +2499,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2616,7 +2637,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 clientId,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2719,7 +2741,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2834,7 +2857,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -2966,7 +2990,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -3098,7 +3123,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()
@@ -3230,7 +3256,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                TransactionTestUtils.npgTransactionGatewayActivationData()
+                TransactionTestUtils.npgTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         RequestAuthorizationRequestDto authorizationRequest = new RequestAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionUpdateAuthorizationHandlerTest.java
@@ -277,7 +277,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
@@ -107,7 +107,8 @@ class TransactionsActivationProjectionHandlerTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 idCart,
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new NpgTransactionGatewayActivationData(orderId, null)
+                new NpgTransactionGatewayActivationData(orderId, null),
+                TransactionTestUtils.USER_ID
         );
 
         it.pagopa.ecommerce.commons.documents.v2.Transaction transactionDocument = it.pagopa.ecommerce.commons.documents.v2.Transaction

--- a/src/test/java/it/pagopa/transactions/controllers/v2/TransactionsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/v2/TransactionsControllerTest.java
@@ -42,7 +42,8 @@ import javax.crypto.SecretKey;
 import java.net.URI;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -116,7 +117,8 @@ class TransactionsControllerTest {
                                             newTransactionRequestDto,
                                             clientIdDto,
                                             UUID.randomUUID(),
-                                            transactionId
+                                            transactionId,
+                                            UUID.randomUUID()
                                     )
                     )
                     .thenReturn(Mono.just(response));
@@ -139,12 +141,24 @@ class TransactionsControllerTest {
                     );
 
             ResponseEntity<NewTransactionResponseDto> responseEntity = transactionsController
-                    .newTransaction(clientIdDto, UUID.randomUUID(), Mono.just(newTransactionRequestDto), mockExchange)
+                    .newTransaction(
+                            clientIdDto,
+                            UUID.randomUUID(),
+                            Mono.just(newTransactionRequestDto),
+                            UUID.randomUUID(),
+                            mockExchange
+                    )
                     .block();
 
             // Verify mock
             Mockito.verify(transactionsService, Mockito.times(1))
-                    .newTransaction(newTransactionRequestDto, clientIdDto, UUID.randomUUID(), transactionId);
+                    .newTransaction(
+                            newTransactionRequestDto,
+                            clientIdDto,
+                            UUID.randomUUID(),
+                            transactionId,
+                            UUID.randomUUID()
+                    );
 
             // Verify status code and response
             assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
@@ -377,7 +391,7 @@ class TransactionsControllerTest {
     void shouldHandleTransactionCreatedWithMailCaseInsensitive(String email) {
         Mockito.when(jwtTokenUtils.generateToken(any(SecretKey.class), anyInt(), any(Claims.class)))
                 .thenReturn(Either.right(""));
-        Mockito.when(transactionsService.newTransaction(any(), any(), any(), any()))
+        Mockito.when(transactionsService.newTransaction(any(), any(), any(), any(), any()))
                 .thenReturn(Mono.just(new NewTransactionResponseDto()));
         NewTransactionRequestDto newTransactionRequestDto = new NewTransactionRequestDto()
                 .addPaymentNoticesItem(
@@ -403,7 +417,7 @@ class TransactionsControllerTest {
     void shouldReturnBadRequestForInvalidMail() {
         Mockito.when(jwtTokenUtils.generateToken(any(SecretKey.class), anyInt(), any(Claims.class)))
                 .thenReturn(Either.right(""));
-        Mockito.when(transactionsService.newTransaction(any(), any(), any(), any()))
+        Mockito.when(transactionsService.newTransaction(any(), any(), any(), any(), any()))
                 .thenReturn(Mono.just(new NewTransactionResponseDto()));
         NewTransactionRequestDto newTransactionRequestDto = new NewTransactionRequestDto()
                 .addPaymentNoticesItem(

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandlerTest.java
@@ -59,7 +59,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString(),
                 transaction.getTransactionActivatedData().getIdCart(),
-                null
+                null,
+                TransactionTestUtils.USER_ID
         );
 
         expectedDocument.setPaymentGateway(null);
@@ -98,7 +99,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
                 paymentTokenValidity,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         /*
@@ -148,7 +150,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString(),
                 transaction.getTransactionActivatedData().getIdCart(),
-                "rrn"
+                "rrn",
+                TransactionTestUtils.USER_ID
         );
 
         expectedDocument.setPaymentGateway(null);
@@ -187,7 +190,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
                 paymentTokenValidity,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         /*
@@ -230,7 +234,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString(),
                 transaction.getTransactionActivatedData().getIdCart(),
-                "rrn"
+                "rrn",
+                TransactionTestUtils.USER_ID
         );
 
         expectedDocument.setPaymentGateway(null);
@@ -266,7 +271,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
                 paymentTokenValidity,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         /*
@@ -309,7 +315,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString(),
                 transaction.getTransactionActivatedData().getIdCart(),
-                "rrn"
+                "rrn",
+                TransactionTestUtils.USER_ID
         );
         String authorizationErrorCode = "authorization error code";
 
@@ -344,7 +351,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
                 paymentTokenValidity,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         /*
@@ -387,7 +395,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate().toString(),
                 transaction.getTransactionActivatedData().getIdCart(),
-                "rrn"
+                "rrn",
+                TransactionTestUtils.USER_ID
         );
 
         expectedDocument.setPaymentGateway(null);
@@ -423,7 +432,8 @@ class AuthorizationUpdateProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getTransactionActivatedData().getIdCart(),
                 paymentTokenValidity,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/CancellationRequestProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/CancellationRequestProjectionHandlerTests.java
@@ -46,7 +46,8 @@ public class CancellationRequestProjectionHandlerTests {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
                 transaction.getIdCart(),
-                transaction.getRrn()
+                transaction.getRrn(),
+                TransactionTestUtils.USER_ID
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/ClosureRequestedProjectionHandlerTests.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/ClosureRequestedProjectionHandlerTests.java
@@ -2,7 +2,6 @@ package it.pagopa.transactions.projections.handlers.v2;
 
 import it.pagopa.ecommerce.commons.documents.v2.Transaction;
 import it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent;
-import it.pagopa.ecommerce.commons.documents.v2.TransactionUserCanceledEvent;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v2.TransactionTestUtils;
 import it.pagopa.transactions.exceptions.TransactionNotFoundException;
@@ -47,7 +46,8 @@ public class ClosureRequestedProjectionHandlerTests {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
                 transaction.getIdCart(),
-                transaction.getRrn()
+                transaction.getRrn(),
+                TransactionTestUtils.USER_ID
         );
 
         Mockito.when(transactionsViewRepository.findById(transaction.getTransactionId()))

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/TransactionUserReceiptProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/TransactionUserReceiptProjectionHandlerTest.java
@@ -43,7 +43,8 @@ class TransactionUserReceiptProjectionHandlerTest {
                 Transaction.ClientId.CHECKOUT,
                 transaction.getCreationDate(),
                 transaction.getIdCart(),
-                "rrn"
+                "rrn",
+                TransactionTestUtils.USER_ID
         );
         expectedDocument.setSendPaymentResultOutcome(TransactionUserReceiptData.Outcome.OK);
 
@@ -92,7 +93,8 @@ class TransactionUserReceiptProjectionHandlerTest {
                 transaction.getClientId(),
                 transaction.getCreationDate().toString(),
                 transaction.getTransactionActivatedData().getIdCart(),
-                null
+                null,
+                TransactionTestUtils.USER_ID
         );
         expectedDocument.setSendPaymentResultOutcome(TransactionUserReceiptData.Outcome.KO);
 

--- a/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTest.java
@@ -367,7 +367,8 @@ class TransactionServiceTest {
                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT,
                 "idCart",
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                null
         );
 
         /*

--- a/src/test/java/it/pagopa/transactions/services/v2/CircuitBreakerTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/CircuitBreakerTest.java
@@ -182,7 +182,8 @@ class CircuitBreakerTest {
                                 transactionRequestDto,
                                 clientIdDto,
                                 UUID.randomUUID(),
-                                new TransactionId(transactionActivatedEvent.getTransactionId())
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
                         )
                 )
                 .expectError(thrownException.getClass())
@@ -241,7 +242,8 @@ class CircuitBreakerTest {
                                 transactionRequestDto,
                                 clientIdDto,
                                 UUID.randomUUID(),
-                                new TransactionId(transactionActivatedEvent.getTransactionId())
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
                         )
                 )
                 .expectError(NodoErrorException.class)
@@ -296,7 +298,8 @@ class CircuitBreakerTest {
                                 transactionRequestDto,
                                 clientIdDto,
                                 UUID.randomUUID(),
-                                new TransactionId(transactionActivatedEvent.getTransactionId())
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
                         )
                 )
                 .expectError(CallNotPermittedException.class)

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTest.java
@@ -12,9 +12,9 @@ import it.pagopa.ecommerce.commons.domain.v2.TransactionActivated;
 import it.pagopa.ecommerce.commons.v2.TransactionTestUtils;
 import it.pagopa.generated.transactions.v2.server.model.*;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
-import it.pagopa.transactions.utils.*;
+import it.pagopa.transactions.utils.TransactionsUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis;
 import reactor.core.publisher.Hooks;
@@ -106,7 +106,8 @@ class TransactionServiceTest {
                 Transaction.ClientId.CHECKOUT,
                 "idCart",
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         /*
@@ -125,7 +126,8 @@ class TransactionServiceTest {
                                 transactionRequestDto,
                                 clientIdDto,
                                 UUID.randomUUID(),
-                                new TransactionId(transactionActivatedEvent.getTransactionId())
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
                         )
                 )
                 .expectNextMatches(

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
@@ -606,7 +606,8 @@ class TransactionServiceTests {
                 Transaction.ClientId.CHECKOUT,
                 transactionDocument.getIdCart(),
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
-                new EmptyTransactionGatewayActivationData()
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
         );
 
         UpdateAuthorizationRequestDto updateAuthorizationRequest = new UpdateAuthorizationRequestDto()
@@ -662,7 +663,8 @@ class TransactionServiceTests {
                 Transaction.ClientId.CHECKOUT,
                 ZonedDateTime.now().toString(),
                 transactionDocument.getIdCart(),
-                transactionDocument.getRrn()
+                transactionDocument.getRrn(),
+                transactionDocument.getUserId()
         );
 
         /* preconditions */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to save user id if received into POST transaction `x-user-id` header
<!--- Describe your changes in detail -->

#### Motivation and Context
This logic is required in order to trace user that perform the transaction for registered payments
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
junit tests + test in DEV environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on pagopa/pagopa-ecommerce-commons#189