### PR TITLE
[CHK-2728] feat(redirect): pass `paName` in auth request if there is only one notice

### DIFF
--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -550,6 +550,18 @@ public class PaymentGatewayClient {
 
                             RedirectPaymentMethodId idPaymentMethod = RedirectPaymentMethodId
                                     .fromPaymentTypeCode(authorizationData.paymentTypeCode());
+
+                            /*
+                             * `paName` is shown to users on the payment gateway redirect page. If there is
+                             * only one payment notice we use its `companyName` as `paName`, otherwise there
+                             * would be an ambiguity, so we don't pass it into the authorization request
+                             */
+                            String paName = null;
+
+                            if (authorizationData.paymentNotices().size() == 1) {
+                                paName = authorizationData.paymentNotices().get(0).companyName().value();
+                            }
+
                             RedirectUrlRequestDto request = new RedirectUrlRequestDto()
                                     .amount(
                                             authorizationData
@@ -586,7 +598,7 @@ public class PaymentGatewayClient {
                                             redirectMethodsDescriptions.get(idPaymentMethod)
                                     )
                                     .idPaymentMethod(idPaymentMethod.toString())
-                                    .paName(null);// optional
+                                    .paName(paName);// optional
                             Either<RedirectConfigurationException, URI> pspConfiguredUrl = getRedirectUrlForPsp(
                                     authorizationData.pspId(),
                                     authorizationData.paymentTypeCode()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * pass `paName` in auth request if there is only one notice

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR adds the optional `paName` parameter in Redirect's authorization requests when there is only one payment notice.
This parameter is then shown on the PSP frontend: we pass it only when there aren't multiple payment notices to avoid ambiguities.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

To do in UAT environment

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.