### PR TITLE
fix: add span to circuit breaker open

### DIFF
--- a/src/main/java/it/pagopa/transactions/controllers/v1/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v1/TransactionsController.java
@@ -62,7 +62,7 @@ public class TransactionsController implements TransactionsApi {
         }
     )
     public Mono<ResponseEntity<ProblemJsonDto>> openStateHandler(CallNotPermittedException error) {
-        log.error("Error - OPEN circuit breaker");
+        log.error("Error - OPEN circuit breaker", error);
         return Mono.just(
                 new ResponseEntity<>(
                         new ProblemJsonDto()

--- a/src/main/java/it/pagopa/transactions/controllers/v1/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v1/TransactionsController.java
@@ -75,10 +75,7 @@ public class TransactionsController implements TransactionsApi {
                 ignored -> openTelemetryUtils.addErrorSpanWithAttributes(
                         OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_SPAN_NAME
                                 .formatted(error.getCausingCircuitBreakerName()),
-                        Attributes.of(
-                                OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_NAME_ATTRIBUTE_KEY,
-                                error.getCausingCircuitBreakerName()
-                        )
+                        Attributes.empty()
                 )
         );
     }

--- a/src/main/java/it/pagopa/transactions/controllers/v1/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v1/TransactionsController.java
@@ -1,6 +1,7 @@
 package it.pagopa.transactions.controllers.v1;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.opentelemetry.api.common.Attributes;
 import it.pagopa.ecommerce.commons.annotations.Warmup;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
@@ -9,6 +10,7 @@ import it.pagopa.generated.transactions.server.model.*;
 import it.pagopa.transactions.exceptions.*;
 import it.pagopa.transactions.mdcutilities.TransactionTracingUtils;
 import it.pagopa.transactions.services.v1.TransactionsService;
+import it.pagopa.transactions.utils.OpenTelemetryUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
 import it.pagopa.transactions.utils.UUIDUtils;
 import it.pagopa.transactions.utils.UpdateTransactionStatusTracerUtils;
@@ -51,12 +53,15 @@ public class TransactionsController implements TransactionsApi {
     @Autowired
     private UpdateTransactionStatusTracerUtils updateTransactionStatusTracerUtils;
 
+    @Autowired
+    private OpenTelemetryUtils openTelemetryUtils;
+
     @ExceptionHandler(
         {
                 CallNotPermittedException.class
         }
     )
-    public Mono<ResponseEntity<ProblemJsonDto>> openStateHandler() {
+    public Mono<ResponseEntity<ProblemJsonDto>> openStateHandler(CallNotPermittedException error) {
         log.error("Error - OPEN circuit breaker");
         return Mono.just(
                 new ResponseEntity<>(
@@ -65,6 +70,15 @@ public class TransactionsController implements TransactionsApi {
                                 .title("Bad Gateway")
                                 .detail("Upstream service temporary unavailable. Open circuit breaker."),
                         HttpStatus.BAD_GATEWAY
+                )
+        ).doOnNext(
+                ignored -> openTelemetryUtils.addErrorSpanWithAttributes(
+                        OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_SPAN_NAME
+                                .formatted(error.getCausingCircuitBreakerName()),
+                        Attributes.of(
+                                OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_NAME_ATTRIBUTE_KEY,
+                                error.getCausingCircuitBreakerName()
+                        )
                 )
         );
     }

--- a/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
@@ -67,10 +67,7 @@ public class TransactionsController implements V2Api {
                 ignored -> openTelemetryUtils.addErrorSpanWithAttributes(
                         OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_SPAN_NAME
                                 .formatted(error.getCausingCircuitBreakerName()),
-                        Attributes.of(
-                                OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_NAME_ATTRIBUTE_KEY,
-                                error.getCausingCircuitBreakerName()
-                        )
+                        Attributes.empty()
                 )
         );
     }

--- a/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
@@ -54,7 +54,7 @@ public class TransactionsController implements V2Api {
         }
     )
     public Mono<ResponseEntity<ProblemJsonDto>> openStateHandler(CallNotPermittedException error) {
-        log.error("Error - OPEN circuit breaker");
+        log.error("Error - OPEN circuit breaker", error);
         return Mono.just(
                 new ResponseEntity<>(
                         new ProblemJsonDto()

--- a/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
+++ b/src/main/java/it/pagopa/transactions/controllers/v2/TransactionsController.java
@@ -1,6 +1,7 @@
 package it.pagopa.transactions.controllers.v2;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.opentelemetry.api.common.Attributes;
 import it.pagopa.ecommerce.commons.annotations.Warmup;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.exceptions.JWTTokenGenerationException;
@@ -10,6 +11,7 @@ import it.pagopa.generated.transactions.v2.server.model.*;
 import it.pagopa.transactions.exceptions.*;
 import it.pagopa.transactions.mdcutilities.TransactionTracingUtils;
 import it.pagopa.transactions.services.v2.TransactionsService;
+import it.pagopa.transactions.utils.OpenTelemetryUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,12 +45,15 @@ public class TransactionsController implements V2Api {
     @Autowired
     private TransactionsUtils transactionsUtils;
 
+    @Autowired
+    private OpenTelemetryUtils openTelemetryUtils;
+
     @ExceptionHandler(
         {
                 CallNotPermittedException.class
         }
     )
-    public Mono<ResponseEntity<ProblemJsonDto>> openStateHandler() {
+    public Mono<ResponseEntity<ProblemJsonDto>> openStateHandler(CallNotPermittedException error) {
         log.error("Error - OPEN circuit breaker");
         return Mono.just(
                 new ResponseEntity<>(
@@ -57,6 +62,15 @@ public class TransactionsController implements V2Api {
                                 .title("Bad Gateway")
                                 .detail("Upstream service temporary unavailable. Open circuit breaker."),
                         HttpStatus.BAD_GATEWAY
+                )
+        ).doOnNext(
+                ignored -> openTelemetryUtils.addErrorSpanWithAttributes(
+                        OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_SPAN_NAME
+                                .formatted(error.getCausingCircuitBreakerName()),
+                        Attributes.of(
+                                OpenTelemetryUtils.CIRCUIT_BREAKER_OPEN_NAME_ATTRIBUTE_KEY,
+                                error.getCausingCircuitBreakerName()
+                        )
                 )
         );
     }

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -36,8 +36,6 @@ public class OpenTelemetryUtils {
             .longKey("paymentTokenLeftTimeSec");
 
     public static final String CIRCUIT_BREAKER_OPEN_SPAN_NAME = "Circuit Breaker [%s] open";
-    public static final AttributeKey<String> CIRCUIT_BREAKER_OPEN_NAME_ATTRIBUTE_KEY = AttributeKey
-            .stringKey("circuitBreakerName");
 
     private final Tracer openTelemetryTracer;
 

--- a/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/OpenTelemetryUtils.java
@@ -35,6 +35,10 @@ public class OpenTelemetryUtils {
     public static final AttributeKey<Long> REPEATED_ACTIVATION_PAYMENT_TOKEN_LEFT_TIME_ATTRIBUTE_KEY = AttributeKey
             .longKey("paymentTokenLeftTimeSec");
 
+    public static final String CIRCUIT_BREAKER_OPEN_SPAN_NAME = "Circuit Breaker [%s] open";
+    public static final AttributeKey<String> CIRCUIT_BREAKER_OPEN_NAME_ATTRIBUTE_KEY = AttributeKey
+            .stringKey("circuitBreakerName");
+
     private final Tracer openTelemetryTracer;
 
     /**

--- a/src/test/java/it/pagopa/transactions/controllers/v1/TransactionsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/v1/TransactionsControllerTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.controllers.v1;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.domain.Claims;
 import it.pagopa.ecommerce.commons.domain.PaymentToken;
@@ -12,6 +13,7 @@ import it.pagopa.generated.transactions.model.CtFaultBean;
 import it.pagopa.generated.transactions.server.model.*;
 import it.pagopa.transactions.exceptions.*;
 import it.pagopa.transactions.services.v1.TransactionsService;
+import it.pagopa.transactions.utils.OpenTelemetryUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
 import it.pagopa.transactions.utils.UUIDUtils;
 import it.pagopa.transactions.utils.UpdateTransactionStatusTracerUtils;
@@ -88,6 +90,9 @@ class TransactionsControllerTest {
 
     @MockBean
     private UpdateTransactionStatusTracerUtils updateTransactionStatusTracerUtils;
+
+    @MockBean
+    private OpenTelemetryUtils openTelemetryUtils;
 
     @Mock
     ServerWebExchange mockExchange;
@@ -660,7 +665,9 @@ class TransactionsControllerTest {
     @Test
     void shouldReturnErrorCircuitBreakerOpen() {
 
-        ResponseEntity error = transactionsController.openStateHandler().block();
+        ResponseEntity error = transactionsController.openStateHandler(
+                Mockito.mock(CallNotPermittedException.class)
+        ).block();
 
         // Verify status code and response
         assertEquals(HttpStatus.BAD_GATEWAY, error.getStatusCode());

--- a/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTests.java
@@ -33,10 +33,7 @@ import it.pagopa.transactions.exceptions.*;
 import it.pagopa.transactions.projections.handlers.v1.TransactionsActivationProjectionHandler;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
-import it.pagopa.transactions.utils.AuthRequestDataUtils;
-import it.pagopa.transactions.utils.TransactionsUtils;
-import it.pagopa.transactions.utils.UUIDUtils;
-import it.pagopa.transactions.utils.UpdateTransactionStatusTracerUtils;
+import it.pagopa.transactions.utils.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -230,6 +227,9 @@ class TransactionServiceTests {
 
     @MockBean
     private UpdateTransactionStatusTracerUtils updateTransactionStatusTracerUtils;
+
+    @MockBean
+    private OpenTelemetryUtils openTelemetryUtils;
 
     final String TRANSACTION_ID = TransactionTestUtils.TRANSACTION_ID;
 

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
@@ -33,10 +33,7 @@ import it.pagopa.transactions.exceptions.*;
 import it.pagopa.transactions.projections.handlers.v2.TransactionsActivationProjectionHandler;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
-import it.pagopa.transactions.utils.AuthRequestDataUtils;
-import it.pagopa.transactions.utils.TransactionsUtils;
-import it.pagopa.transactions.utils.UUIDUtils;
-import it.pagopa.transactions.utils.UpdateTransactionStatusTracerUtils;
+import it.pagopa.transactions.utils.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -229,6 +226,9 @@ class TransactionServiceTests {
 
     @MockBean
     private UpdateTransactionStatusTracerUtils updateTransactionStatusTracerUtils;
+
+    @MockBean
+    private OpenTelemetryUtils openTelemetryUtils;
 
     final String TRANSACTION_ID = TransactionTestUtils.TRANSACTION_ID;
     final String USER_ID = TransactionTestUtils.USER_ID;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR add a opentelemetry span when the circuit breaker is OPEN.

#### List of Changes
- add span to opened circuit breaker error handler
<!--- Describe your changes in detail -->

#### Motivation and Context
In many cases, during NPG PROD sessions, elastic reports trace without any span info when the response error is caused by an opened circuit breaker. It's useful to distinguish when an error is caused by circuit breaker or not.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.