### PR TITLE
[CHK-2931] feat: add client id and transaction id to cancel return page

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -170,7 +170,7 @@ microservice-chart:
     SEND_PAYMENT_RESULT_FOR_TX_EXPIRED_ENABLED: "true"
     SESSION_URL_BASEPATH: "https://dev.checkout.pagopa.it"
     SESSION_URL_OUTCOME_SUFFIX: "/ecommerce-fe/esito#clientId={clientId}&transactionId={transactionId}&sessionToken={sessionToken}"
-    SESSION_URL_CANCEL_SUFFIX: "/ecommerce-fe/cancel"
+    SESSION_URL_CANCEL_SUFFIX: "/ecommerce-fe/cancel#clientId={clientId}&transactionId={transactionId}"
     SESSION_URL_NOTIFICATION_URL: "https://api.dev.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}"
     JWT_NPG_NOTIFICATION_VALIDITY_TIME: "900"
     REDIRECT_PAYMENT_TYPE_CODE_LIST: "BPPIITRRXXX-RBPR,BPPIITRRXXX-RBPP,BPPIITRRXXX-RBPB,PPAYITR1XXX-RBPB,CHECKOUT-PPAYITR1XXX-RBPP,IO-PPAYITR1XXX-RBPP,PPAYITR1XXX-RBPR,RBPS,RPIC"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -166,7 +166,7 @@ microservice-chart:
     SEND_PAYMENT_RESULT_FOR_TX_EXPIRED_ENABLED: "true"
     SESSION_URL_BASEPATH: "https://checkout.pagopa.it"
     SESSION_URL_OUTCOME_SUFFIX: "/ecommerce-fe/esito#clientId={clientId}&transactionId={transactionId}&sessionToken={sessionToken}"
-    SESSION_URL_CANCEL_SUFFIX: "/ecommerce-fe/cancel"
+    SESSION_URL_CANCEL_SUFFIX: "/ecommerce-fe/cancel#clientId={clientId}&transactionId={transactionId}"
     SESSION_URL_NOTIFICATION_URL: "https://api.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}"
     JWT_NPG_NOTIFICATION_VALIDITY_TIME: "900"
     REDIRECT_PAYMENT_TYPE_CODE_LIST: ""

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -163,7 +163,7 @@ microservice-chart:
     SEND_PAYMENT_RESULT_FOR_TX_EXPIRED_ENABLED: "true"
     SESSION_URL_BASEPATH: "https://uat.checkout.pagopa.it"
     SESSION_URL_OUTCOME_SUFFIX: "/ecommerce-fe/esito#clientId={clientId}&transactionId={transactionId}&sessionToken={sessionToken}"
-    SESSION_URL_CANCEL_SUFFIX: "/ecommerce-fe/cancel"
+    SESSION_URL_CANCEL_SUFFIX: "/ecommerce-fe/cancel#clientId={clientId}&transactionId={transactionId}"
     SESSION_URL_NOTIFICATION_URL: "https://api.uat.platform.pagopa.it/ecommerce/npg/notifications/v1/sessions/{orderId}/outcomes?sessionToken={sessionToken}"
     JWT_NPG_NOTIFICATION_VALIDITY_TIME: "900"
     REDIRECT_PAYMENT_TYPE_CODE_LIST: "BPPIITRRXXX-RBPR,BPPIITRRXXX-RBPP,BPPIITRRXXX-RBPB,PPAYITR1XXX-RBPB,CHECKOUT-PPAYITR1XXX-RBPP,IO-PPAYITR1XXX-RBPP,PPAYITR1XXX-RBPR,RBPS,RPIC"

--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -338,7 +338,7 @@ public class PaymentGatewayClient {
                                     outcomeJwtToken
                             );
                             URI merchantUrl = returnUrlBasePath;
-                            URI cancelUrl = returnUrlBasePath.resolve(npgSessionUrlConfig.cancelSuffix());
+                            URI cancelUrl = generateCancelUrl(clientId, authorizationData.transactionId());
 
                             URI notificationUrl = UriComponentsBuilder
                                     .fromHttpUrl(npgSessionUrlConfig.notificationUrl())
@@ -804,6 +804,23 @@ public class PaymentGatewayClient {
                                 transactionId.value(),
                                 "sessionToken",
                                 sessionToken
+                        )
+                );
+    }
+
+    private URI generateCancelUrl(
+                                  String clientId,
+                                  TransactionId transactionId
+    ) {
+        URI baseURI = URI.create(npgSessionUrlConfig.basePath());
+        return UriComponentsBuilder
+                .fromUri(baseURI.resolve(npgSessionUrlConfig.cancelSuffix()))
+                .build(
+                        Map.of(
+                                "clientId",
+                                clientId,
+                                "transactionId",
+                                transactionId.value()
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -794,8 +794,9 @@ public class PaymentGatewayClient {
                                    TransactionId transactionId,
                                    String sessionToken
     ) {
+        URI baseURI = URI.create(npgSessionUrlConfig.basePath());
         return UriComponentsBuilder
-                .fromUriString(npgSessionUrlConfig.basePath().concat(npgSessionUrlConfig.outcomeSuffix()))
+                .fromUri(baseURI.resolve(npgSessionUrlConfig.outcomeSuffix()))
                 .build(
                         Map.of(
                                 "clientId",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
  * add client id and transaction id to cancel return page

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds the transaction id and client id as fragment parameters to the cancel page on `ecommerce-fe`.
For context see also pagopa/pagopa-ecommerce-fe#36

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.