### PR TITLE
[CHK-3119] feat: map `WISP_REDIRECT` client id when creating transactions to `CHECKOUT_CART`

### DIFF
--- a/api-spec/v2.1/transactions-api.yaml
+++ b/api-spec/v2.1/transactions-api.yaml
@@ -278,7 +278,7 @@ components:
         - IO
         - CHECKOUT
         - CHECKOUT_CART
-        - WISP
+        - WISP_REDIRECT
     UserId:
       description: unique user identifier
       type: string

--- a/api-spec/v2.1/transactions-api.yaml
+++ b/api-spec/v2.1/transactions-api.yaml
@@ -278,6 +278,7 @@ components:
         - IO
         - CHECKOUT
         - CHECKOUT_CART
+        - WISP
     UserId:
       description: unique user identifier
       type: string

--- a/pom.xml
+++ b/pom.xml
@@ -559,8 +559,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-3104-wisp-dismantling-client-id</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>1.23.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.23.1</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
         <mock-web-server.version>4.11.0</mock-web-server.version>
@@ -559,8 +559,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-3104-wisp-dismantling-client-id</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -1372,7 +1372,7 @@ public class TransactionsService {
                                 .authToken(authToken)
                                 .status(transactionsUtils.convertEnumerationV1(transaction.getStatus()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .clientId(convertClientId(transaction.getClientId().name()))
+                                .clientId(convertClientId(transaction.getClientId()))
                                 .idCart(transaction.getTransactionActivatedData().getIdCart())
                 );
     }
@@ -1420,19 +1420,36 @@ public class TransactionsService {
                                 .authToken(authToken)
                                 .status(transactionsUtils.convertEnumerationV1(transaction.getStatus()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .clientId(convertClientId(transaction.getClientId().name()))
+                                .clientId(convertClientId(transaction.getClientId()))
                                 .idCart(transaction.getTransactionActivatedData().getIdCart())
                 );
     }
 
     public NewTransactionResponseDto.ClientIdEnum convertClientId(
-                                                                  String clientId
+                                                                  it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId
     ) {
-        return Optional.ofNullable(clientId).filter(Objects::nonNull)
+        return Optional.ofNullable(clientId)
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
+                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value.name());
+                            } catch (IllegalArgumentException e) {
+                                log.error("Unknown input origin ", e);
+                                throw new InvalidRequestException("Unknown input origin", e);
+                            }
+                        }
+                ).orElseThrow(() -> new InvalidRequestException("Null value as input origin"));
+    }
+
+    public NewTransactionResponseDto.ClientIdEnum convertClientId(
+                                                                  it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId clientId
+    ) {
+        return Optional.ofNullable(clientId)
+                .map(
+                        value -> {
+                            try {
+                                return NewTransactionResponseDto.ClientIdEnum
+                                        .fromValue(value.getEffectiveClient().name());
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
@@ -168,19 +168,20 @@ public class TransactionsService {
                                 .authToken(authToken)
                                 .status(transactionsUtils.convertEnumerationV2(transaction.getStatus()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .clientId(convertClientId(transaction.getClientId().name()))
+                                .clientId(convertClientId(transaction.getClientId()))
                                 .idCart(transaction.getTransactionActivatedData().getIdCart())
                 );
     }
 
     public NewTransactionResponseDto.ClientIdEnum convertClientId(
-                                                                  String clientId
+                                                                  Transaction.ClientId clientId
     ) {
-        return Optional.ofNullable(clientId).filter(Objects::nonNull)
+        return Optional.ofNullable(clientId)
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
+                                return NewTransactionResponseDto.ClientIdEnum
+                                        .fromValue(value.getEffectiveClient().name());
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);
@@ -188,5 +189,4 @@ public class TransactionsService {
                         }
                 ).orElseThrow(() -> new InvalidRequestException("Null value as input origin"));
     }
-
 }

--- a/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
@@ -168,7 +168,7 @@ public class TransactionsService {
     public NewTransactionResponseDto.ClientIdEnum convertClientId(
                                                                   Transaction.ClientId clientId
     ) {
-        return Optional.ofNullable(clientId).filter(Objects::nonNull)
+        return Optional.ofNullable(clientId)
                 .map(
                         value -> {
                             try {

--- a/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
@@ -172,10 +172,8 @@ public class TransactionsService {
                 .map(
                         value -> {
                             try {
-                                return switch (clientId) {
-                                    case WISP -> NewTransactionResponseDto.ClientIdEnum.CHECKOUT_CART;
-                                    default -> NewTransactionResponseDto.ClientIdEnum.fromValue(clientId.name());
-                                };
+                                return NewTransactionResponseDto.ClientIdEnum
+                                        .fromValue(clientId.getEffectiveClient().name());
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
@@ -160,19 +160,22 @@ public class TransactionsService {
                                 .authToken(authToken)
                                 .status(transactionsUtils.convertEnumerationV2_1(transaction.getStatus()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .clientId(convertClientId(transaction.getClientId().name()))
+                                .clientId(convertClientId(transaction.getClientId()))
                                 .idCart(transaction.getTransactionActivatedData().getIdCart())
                 );
     }
 
     public NewTransactionResponseDto.ClientIdEnum convertClientId(
-                                                                  String clientId
+                                                                  Transaction.ClientId clientId
     ) {
         return Optional.ofNullable(clientId).filter(Objects::nonNull)
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
+                                return switch (clientId) {
+                                    case WISP -> NewTransactionResponseDto.ClientIdEnum.CHECKOUT_CART;
+                                    default -> NewTransactionResponseDto.ClientIdEnum.fromValue(clientId.name());
+                                };
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTests.java
@@ -38,6 +38,10 @@ import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import it.pagopa.transactions.utils.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
@@ -59,6 +63,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -1169,13 +1174,43 @@ class TransactionServiceTests {
         verify(paymentRequestInfoRedisTemplateWrapper, times(0)).deleteById(any());
     }
 
+    static Stream<Arguments> v2ClientIdMapping() {
+        return Stream.of(
+                Arguments.of("IO", it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.IO),
+                Arguments.of("CHECKOUT", it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT),
+                Arguments.of(
+                        "CHECKOUT_CART",
+                        it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.CHECKOUT_CART
+                ),
+                Arguments.of(
+                        "CHECKOUT_CART",
+                        it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.WISP_REDIRECT
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(Transaction.ClientId.class)
+    void shouldConvertClientIdSuccessfully(Transaction.ClientId clientId) {
+        assertEquals(clientId.name(), transactionsServiceV1.convertClientId(clientId).toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("v2ClientIdMapping")
+    void shouldConvertV2ClientIdSuccessfully(
+                                             String expected,
+                                             it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId clientId
+    ) {
+        assertEquals(expected, transactionsServiceV1.convertClientId(clientId).toString());
+    }
+
     @Test
-    void shouldConvertClientIdSuccessfully() {
-        for (it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId : it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId
-                .values()) {
-            assertEquals(clientId.toString(), transactionsServiceV1.convertClientId(clientId.name()).toString());
-        }
-        assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(null));
+    void shouldRejectNullClientId() {
+        assertThrows(
+                InvalidRequestException.class,
+                () -> transactionsServiceV1
+                        .convertClientId((it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId) null)
+        );
     }
 
     @Test
@@ -1183,7 +1218,7 @@ class TransactionServiceTests {
         it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId clientId = Mockito
                 .mock(it.pagopa.ecommerce.commons.documents.v1.Transaction.ClientId.class);
         Mockito.when(clientId.toString()).thenReturn("InvalidClientID");
-        assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(clientId.name()));
+        assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(clientId));
     }
 
     @Test

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
@@ -38,6 +38,10 @@ import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
 import it.pagopa.transactions.repositories.TransactionsViewRepository;
 import it.pagopa.transactions.utils.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
@@ -57,6 +61,7 @@ import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -1244,20 +1249,12 @@ class TransactionServiceTests {
     }
 
     @Test
-    void shouldConvertClientIdSuccessfully() {
-        for (Transaction.ClientId clientId : Transaction.ClientId
-                .values()) {
-            assertEquals(clientId.toString(), transactionsServiceV1.convertClientId(clientId.name()).toString());
-        }
-        assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(null));
-    }
-
-    @Test
     void shouldThrowsInvalidRequestExceptionForInvalidClientID() {
         Transaction.ClientId clientId = Mockito
                 .mock(Transaction.ClientId.class);
         Mockito.when(clientId.toString()).thenReturn("InvalidClientID");
-        assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(clientId.name()));
+        Mockito.when(clientId.getEffectiveClient()).thenReturn(clientId);
+        assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(clientId));
     }
 
     @Test

--- a/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
@@ -142,7 +142,7 @@ class TransactionServiceTest {
 
     @Test
     void shouldHandleNewTransactionTransactionActivatedMappingWISPClientIdToCheckoutCarts() {
-        ClientIdDto clientIdDto = ClientIdDto.WISP;
+        ClientIdDto clientIdDto = ClientIdDto.WISP_REDIRECT;
         UUID TEST_SESSION_TOKEN = UUID.randomUUID();
         UUID TEST_CPP = UUID.randomUUID();
         UUID TRANSACTION_ID = UUID.randomUUID();
@@ -197,7 +197,7 @@ class TransactionServiceTest {
                 TransactionTestUtils.EMAIL,
                 "faultCode",
                 "faultCodeString",
-                Transaction.ClientId.WISP,
+                Transaction.ClientId.WISP_REDIRECT,
                 "idCart",
                 TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
                 new EmptyTransactionGatewayActivationData(),

--- a/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
@@ -140,4 +140,101 @@ class TransactionServiceTest {
 
     }
 
+    @Test
+    void shouldHandleNewTransactionTransactionActivatedMappingWISPClientIdToCheckoutCarts() {
+        ClientIdDto clientIdDto = ClientIdDto.WISP;
+        UUID TEST_SESSION_TOKEN = UUID.randomUUID();
+        UUID TEST_CPP = UUID.randomUUID();
+        UUID TRANSACTION_ID = UUID.randomUUID();
+
+        NewTransactionRequestDto transactionRequestDto = new NewTransactionRequestDto()
+                .emailToken(TransactionTestUtils.EMAIL.opaqueData())
+                .addPaymentNoticesItem(new PaymentNoticeInfoDto().rptId(TransactionTestUtils.RPT_ID).amount(100));
+
+        TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
+        transactionActivatedData.setEmail(TransactionTestUtils.EMAIL);
+        transactionActivatedData
+                .setPaymentNotices(
+                        List.of(
+                                new PaymentNotice(
+                                        TransactionTestUtils.PAYMENT_TOKEN,
+                                        null,
+                                        "dest",
+                                        0,
+                                        TEST_CPP.toString(),
+                                        List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
+                                        false,
+                                        null
+                                )
+                        )
+                );
+
+        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
+                new TransactionId(TRANSACTION_ID).value(),
+                transactionActivatedData
+        );
+
+        Tuple2<Mono<BaseTransactionEvent<?>>, String> response = Tuples
+                .of(
+                        Mono.just(transactionActivatedEvent),
+                        TEST_SESSION_TOKEN.toString()
+                );
+
+        TransactionActivated transactionActivated = new TransactionActivated(
+                new TransactionId(TRANSACTION_ID),
+                Arrays.asList(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
+                                new PaymentToken(TransactionTestUtils.PAYMENT_TOKEN),
+                                new RptId(TransactionTestUtils.RPT_ID),
+                                new TransactionAmount(0),
+                                new TransactionDescription("desc"),
+                                new PaymentContextCode(TEST_CPP.toString()),
+                                List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
+                                false,
+                                new CompanyName(null)
+                        )
+                ),
+                TransactionTestUtils.EMAIL,
+                "faultCode",
+                "faultCodeString",
+                Transaction.ClientId.WISP,
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
+        );
+
+        /*
+         * Preconditions
+         */
+        Mockito.when(transactionActivateHandlerv2.handle(any()))
+                .thenReturn(Mono.just(response));
+        Mockito.when(transactionsActivationProjectionHandlerv2.handle(transactionActivatedEvent))
+                .thenReturn(Mono.just(transactionActivated));
+        Mockito.when(transactionsUtils.convertEnumerationV2_1(any()))
+                .thenCallRealMethod();
+        Hooks.onOperatorDebug();
+        StepVerifier
+                .create(
+                        transactionsService.newTransaction(
+                                transactionRequestDto,
+                                clientIdDto,
+                                UUID.randomUUID(),
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
+                        )
+                )
+                .expectNextMatches(
+                        res -> res.getPayments().get(0).getRptId()
+                                .equals(transactionRequestDto.getPaymentNotices().get(0).getRptId())
+                                && res.getIdCart().equals("idCart")
+                                && res.getStatus().equals(TransactionStatusDto.ACTIVATED)
+                                && res.getClientId()
+                                        .equals(NewTransactionResponseDto.ClientIdEnum.CHECKOUT_CART)
+                                && !res.getTransactionId().isEmpty()
+                                && !res.getAuthToken().isEmpty()
+                )
+                .verifyComplete();
+
+    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR includes the groundwork from pagopa/pagopa-ecommerce-commons#214
The returned field `clientId` is mapped to `CHECKOUT_CART` in order to make the new `WISP` client backward compatible with the current API

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on pagopa/pagopa-ecommerce-commons#214