### PR TITLE
feat: [CHK-3109] Handle payment notice IUV

### DIFF
--- a/api-spec/v2.1/transactions-api.yaml
+++ b/api-spec/v2.1/transactions-api.yaml
@@ -132,6 +132,9 @@ components:
         isAllCCP:
           type: boolean
           description: Flag for poste psp enabling in gec request
+        creditorReferenceId:
+          type: string
+          description: Creditor notice number's
       required:
         - rptId
         - amount

--- a/api-spec/v2/transactions-api.yaml
+++ b/api-spec/v2/transactions-api.yaml
@@ -132,6 +132,9 @@ components:
         isAllCCP:
           type: boolean
           description: Flag for poste psp enabling in gec request
+        creditorReferenceId:
+          type: string
+          description: Creditor notice number's
       required:
         - rptId
         - amount

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>1.23.1</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.24.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
         <mock-web-server.version>4.11.0</mock-web-server.version>
@@ -559,8 +559,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-3107-iuv-payment-notice</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -559,8 +559,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-3107-iuv-payment-notice</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/client/EcommercePaymentMethodsClient.java
+++ b/src/main/java/it/pagopa/transactions/client/EcommercePaymentMethodsClient.java
@@ -1,5 +1,6 @@
 package it.pagopa.transactions.client;
 
+import it.pagopa.ecommerce.commons.documents.v2.Transaction;
 import it.pagopa.generated.ecommerce.paymentmethods.v1.dto.PatchSessionRequestDto;
 import it.pagopa.generated.ecommerce.paymentmethods.v1.dto.PaymentMethodResponseDto;
 import it.pagopa.generated.ecommerce.paymentmethods.v1.dto.SessionPaymentMethodResponseDto;
@@ -57,7 +58,12 @@ public class EcommercePaymentMethodsClient {
                                                            String paymentMethodId,
                                                            String xClientId
     ) {
-        return ecommercePaymentMethodsWebClientV1.getPaymentMethod(paymentMethodId, xClientId)
+        // payment methods only support CHECKOUT and IO.
+        final var client = Transaction.ClientId.fromString(xClientId) == Transaction.ClientId.IO
+                ? Transaction.ClientId.IO
+                : Transaction.ClientId.CHECKOUT;
+
+        return ecommercePaymentMethodsWebClientV1.getPaymentMethod(paymentMethodId, client.name())
                 .doOnError(
                         WebClientResponseException.class,
                         EcommercePaymentMethodsClient::logWebClientException

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
@@ -194,7 +194,8 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                     transactionId.value(),
                                                                     paymentTokenTimeout,
                                                                     newTransactionRequestDto.idCard(),
-                                                                    partialPaymentRequestInfo.dueDate()
+                                                                    partialPaymentRequestInfo.dueDate(),
+                                                                    Transaction.ClientId.valueOf(command.getClientId())
                                                             )
                                                             .doOnSuccess(
                                                                     p -> {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
@@ -145,6 +145,7 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                                                 .generateRandomStringToIdempotencyKey()
                                                                                 ),
                                                                                 new ArrayList<>(TRANSFER_LIST_MAX_SIZE),
+                                                                                null,
                                                                                 null
                                                                         );
                                                                         paymentRequestInfoRedisTemplateWrapper
@@ -376,7 +377,8 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                 )
                         ).toList(),
                         paymentRequestInfo.isAllCCP(),
-                        paymentRequestInfo.paName()
+                        paymentRequestInfo.paName(),
+                        paymentRequestInfo.creditorReferenceId()
                 )
         ).toList();
     }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
@@ -194,9 +194,7 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                     transactionId.value(),
                                                                     paymentTokenTimeout,
                                                                     newTransactionRequestDto.idCard(),
-                                                                    partialPaymentRequestInfo.dueDate(),
-                                                                    Transaction.ClientId
-                                                                            .fromString(command.getClientId())
+                                                                    partialPaymentRequestInfo.dueDate()
                                                             )
                                                             .doOnSuccess(
                                                                     p -> {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandler.java
@@ -5,6 +5,7 @@ import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
 import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.PaymentTransferInformation;
+import it.pagopa.ecommerce.commons.documents.v2.Transaction;
 import it.pagopa.ecommerce.commons.domain.*;
 import it.pagopa.ecommerce.commons.queues.QueueEvent;
 import it.pagopa.ecommerce.commons.queues.TracingUtils;
@@ -193,7 +194,9 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                     transactionId.value(),
                                                                     paymentTokenTimeout,
                                                                     newTransactionRequestDto.idCard(),
-                                                                    partialPaymentRequestInfo.dueDate()
+                                                                    partialPaymentRequestInfo.dueDate(),
+                                                                    Transaction.ClientId
+                                                                            .fromString(command.getClientId())
                                                             )
                                                             .doOnSuccess(
                                                                     p -> {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
@@ -151,7 +151,7 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                                 ),
                                                                                 new ArrayList<>(TRANSFER_LIST_MAX_SIZE),
                                                                                 null,
-                                                                                null
+                                                                                paymentNotice.creditorReferenceId()
                                                                         );
                                                                         paymentRequestInfoRedisTemplateWrapper
                                                                                 .save(

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
@@ -150,6 +150,7 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                                                 .generateRandomStringToIdempotencyKey()
                                                                                 ),
                                                                                 new ArrayList<>(TRANSFER_LIST_MAX_SIZE),
+                                                                                null,
                                                                                 null
                                                                         );
                                                                         paymentRequestInfoRedisTemplateWrapper
@@ -393,7 +394,8 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                 )
                         ).toList(),
                         paymentRequestInfo.isAllCCP(),
-                        paymentRequestInfo.paName()
+                        paymentRequestInfo.paName(),
+                        paymentRequestInfo.creditorReferenceId()
                 )
         ).toList();
     }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandler.java
@@ -5,6 +5,7 @@ import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
 import it.pagopa.ecommerce.commons.documents.PaymentNotice;
 import it.pagopa.ecommerce.commons.documents.PaymentTransferInformation;
+import it.pagopa.ecommerce.commons.documents.v2.Transaction;
 import it.pagopa.ecommerce.commons.documents.v2.activation.EmptyTransactionGatewayActivationData;
 import it.pagopa.ecommerce.commons.documents.v2.activation.NpgTransactionGatewayActivationData;
 import it.pagopa.ecommerce.commons.domain.Claims;
@@ -198,7 +199,9 @@ public class TransactionActivateHandler extends TransactionActivateHandlerCommon
                                                                     transactionId.value(),
                                                                     paymentTokenTimeout,
                                                                     newTransactionRequestDto.idCard(),
-                                                                    partialPaymentRequestInfo.dueDate()
+                                                                    partialPaymentRequestInfo.dueDate(),
+                                                                    Transaction.ClientId
+                                                                            .fromString(command.getClientId())
                                                             )
                                                             .doOnSuccess(
                                                                     p -> {

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
@@ -166,7 +166,7 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                         .getTransactionGatewayActivationData() instanceof NpgTransactionGatewayActivationData transactionGatewayActivationData
                                         ? transactionGatewayActivationData.getCorrelationId()
                                         : null,
-                                tx.getClientId().name(),
+                                tx.getClientId().getEffectiveClient().name(),
                                 Optional.ofNullable(tx.getTransactionActivatedData().getUserId())
                                         .map(UUID::fromString).orElse(null)
                         )
@@ -181,7 +181,7 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                 .flatMap(
                         tx -> redirectionAuthRequestPipeline(
                                 authorizationRequestData,
-                                tx.getClientId(),
+                                tx.getClientId().getEffectiveClient(),
                                 Optional.ofNullable(tx.getTransactionActivatedData().getUserId())
                                         .map(UUID::fromString).orElse(null)
                         )

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v1/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v1/AuthorizationUpdateProjectionHandler.java
@@ -72,7 +72,8 @@ public class AuthorizationUpdateProjectionHandler
                                                                         )
                                                                 ).toList(),
                                                         paymentNotice.isAllCCP(),
-                                                        new CompanyName(paymentNotice.getCompanyName())
+                                                        new CompanyName(paymentNotice.getCompanyName()),
+                                                        paymentNotice.getCreditorReferenceId()
                                                 )
                                         ).toList(),
                                 transactionDocument.getEmail(),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v1/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v1/TransactionsActivationProjectionHandler.java
@@ -42,7 +42,8 @@ public class TransactionsActivationProjectionHandler
                                 )
                         ).toList(),
                         paymentNoticeData.isAllCCP(),
-                        new CompanyName(paymentNoticeData.getCompanyName())
+                        new CompanyName(paymentNoticeData.getCompanyName()),
+                        paymentNoticeData.getCreditorReferenceId()
                 )
         ).toList();
         Confidential<Email> email = event.getData().getEmail();

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationUpdateProjectionHandler.java
@@ -96,7 +96,8 @@ public class AuthorizationUpdateProjectionHandler
                                                                         )
                                                                 ).toList(),
                                                         paymentNotice.isAllCCP(),
-                                                        new CompanyName(paymentNotice.getCompanyName())
+                                                        new CompanyName(paymentNotice.getCompanyName()),
+                                                        paymentNotice.getCreditorReferenceId()
                                                 )
                                         ).toList(),
                                 transactionDocument.getEmail(),

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v2/TransactionsActivationProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v2/TransactionsActivationProjectionHandler.java
@@ -42,7 +42,8 @@ public class TransactionsActivationProjectionHandler
                                 )
                         ).toList(),
                         paymentNoticeData.isAllCCP(),
-                        new CompanyName(paymentNoticeData.getCompanyName())
+                        new CompanyName(paymentNoticeData.getCompanyName()),
+                        paymentNoticeData.getCreditorReferenceId()
                 )
         ).toList();
         Confidential<Email> email = event.getData().getEmail();

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -274,6 +274,7 @@ public class TransactionsService {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -658,7 +659,8 @@ public class TransactionsService {
                                                                     )
                                                             ).toList(),
                                                     paymentNotice.isAllCCP(),
-                                                    new CompanyName(paymentNotice.getCompanyName())
+                                                    new CompanyName(paymentNotice.getCompanyName()),
+                                                    paymentNotice.getCreditorReferenceId()
                                             )
                                     ).toList(),
                                     transactionsUtils.getEmail(transactionDocument),

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -1434,7 +1434,9 @@ public class TransactionsService {
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
+                                return NewTransactionResponseDto.ClientIdEnum.fromValue(
+                                        Transaction.ClientId.fromString(clientId).getEffectiveClient().name()
+                                );
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -417,7 +417,7 @@ public class TransactionsService {
                     .feeTotal(transaction.getFeeTotal())
                     .clientId(
                             TransactionInfoDto.ClientIdEnum.valueOf(
-                                    transaction.getClientId().toString()
+                                    transaction.getClientId().getEffectiveClient().toString()
                             )
                     )
                     .status(transactionsUtils.convertEnumerationV1(transaction.getStatus()))

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -518,7 +518,7 @@ public class TransactionsService {
                                                             transactionId,
                                                             new CalculateFeeRequestDto()
                                                                     .touchpoint(
-                                                                            clientId
+                                                                            transactionsUtils.getEffectiveClientId(transaction)
                                                                     )
                                                                     .bin(
                                                                             paymentSessionData.cardBin()

--- a/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
@@ -87,6 +87,7 @@ public class TransactionsService {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()

--- a/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
@@ -16,6 +16,7 @@ import it.pagopa.transactions.exceptions.InvalidRequestException;
 import it.pagopa.transactions.projections.handlers.v2.TransactionsActivationProjectionHandler;
 import it.pagopa.transactions.utils.ConfidentialMailUtils;
 import it.pagopa.transactions.utils.TransactionsUtils;
+import it.pagopa.transactions.utils.WispDeprecation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -143,6 +144,12 @@ public class TransactionsService {
                                                         .rptId(paymentNotice.rptId().value())
                                                         .paymentToken(paymentNotice.paymentToken().value())
                                                         .isAllCCP(paymentNotice.isAllCCP())
+                                                        .creditorReferenceId(
+                                                                WispDeprecation.extractCreditorReferenceId(
+                                                                        transaction,
+                                                                        paymentNotice
+                                                                ).orElse(null)
+                                                        )
                                                         .transferList(
                                                                 paymentNotice.transferList().stream().map(
                                                                         paymentTransferInfo -> new TransferDto()
@@ -181,7 +188,9 @@ public class TransactionsService {
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
+                                return NewTransactionResponseDto.ClientIdEnum.fromValue(
+                                        WispDeprecation.adaptClientId(value)
+                                );
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2/TransactionsService.java
@@ -176,7 +176,7 @@ public class TransactionsService {
                                 .authToken(authToken)
                                 .status(transactionsUtils.convertEnumerationV2(transaction.getStatus()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .clientId(convertClientId(transaction.getClientId().name()))
+                                .clientId(convertClientId(transaction.getClientId().getEffectiveClient().name()))
                                 .idCart(transaction.getTransactionActivatedData().getIdCart())
                 );
     }
@@ -188,9 +188,7 @@ public class TransactionsService {
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(
-                                        WispDeprecation.adaptClientId(value)
-                                );
+                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
@@ -12,6 +12,7 @@ import it.pagopa.transactions.commands.handlers.v2.TransactionActivateHandler;
 import it.pagopa.transactions.exceptions.InvalidRequestException;
 import it.pagopa.transactions.projections.handlers.v2.TransactionsActivationProjectionHandler;
 import it.pagopa.transactions.utils.TransactionsUtils;
+import it.pagopa.transactions.utils.WispDeprecation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -135,6 +136,12 @@ public class TransactionsService {
                                                         .rptId(paymentNotice.rptId().value())
                                                         .paymentToken(paymentNotice.paymentToken().value())
                                                         .isAllCCP(paymentNotice.isAllCCP())
+                                                        .creditorReferenceId(
+                                                                WispDeprecation.extractCreditorReferenceId(
+                                                                        transaction,
+                                                                        paymentNotice
+                                                                ).orElse(null)
+                                                        )
                                                         .transferList(
                                                                 paymentNotice.transferList().stream().map(
                                                                         paymentTransferInfo -> new TransferDto()
@@ -173,7 +180,9 @@ public class TransactionsService {
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
+                                return NewTransactionResponseDto.ClientIdEnum.fromValue(
+                                        WispDeprecation.adaptClientId(value)
+                                );
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
@@ -168,7 +168,7 @@ public class TransactionsService {
                                 .authToken(authToken)
                                 .status(transactionsUtils.convertEnumerationV2_1(transaction.getStatus()))
                                 // .feeTotal()//TODO da dove prendere le fees?
-                                .clientId(convertClientId(transaction.getClientId().name()))
+                                .clientId(convertClientId(transaction.getClientId().getEffectiveClient().name()))
                                 .idCart(transaction.getTransactionActivatedData().getIdCart())
                 );
     }
@@ -180,9 +180,7 @@ public class TransactionsService {
                 .map(
                         value -> {
                             try {
-                                return NewTransactionResponseDto.ClientIdEnum.fromValue(
-                                        WispDeprecation.adaptClientId(value)
-                                );
+                                return NewTransactionResponseDto.ClientIdEnum.fromValue(value);
                             } catch (IllegalArgumentException e) {
                                 log.error("Unknown input origin ", e);
                                 throw new InvalidRequestException("Unknown input origin", e);

--- a/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v2_1/TransactionsService.java
@@ -79,6 +79,7 @@ public class TransactionsService {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -95,14 +95,14 @@ public class NodoOperations {
                 });
     }
 
-    public Mono<PaymentRequestInfo> activatePaymentRequest(
-                                                           RptId rptId,
-                                                           IdempotencyKey idempotencyKey,
-                                                           Integer amount,
-                                                           String transactionId,
-                                                           Integer paymentTokenTimeout,
-                                                           String idCart,
-                                                           String dueDate
+    private Mono<PaymentRequestInfo> activatePaymentRequest(
+                                                            RptId rptId,
+                                                            IdempotencyKey idempotencyKey,
+                                                            Integer amount,
+                                                            String transactionId,
+                                                            Integer paymentTokenTimeout,
+                                                            String idCart,
+                                                            String dueDate
     ) {
 
         final BigDecimal amountAsBigDecimal = BigDecimal.valueOf(amount.doubleValue() / 100)

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -163,7 +163,8 @@ public class NodoOperations {
                                                         transfer.getTransferCategory()
                                                 )
                                         ).toList(),
-                                isAllCCP(response, allCCPOnTransferIbanEnabled)
+                                isAllCCP(response, allCCPOnTransferIbanEnabled),
+                                response.getCreditorReferenceId()
                         )
                 );
     }

--- a/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
@@ -484,6 +484,15 @@ public class TransactionsUtils {
         };
     }
 
+    public String getEffectiveClientId(BaseTransactionView baseTransactionView) {
+        return switch (baseTransactionView) {
+            case it.pagopa.ecommerce.commons.documents.v1.Transaction t -> t.getClientId().toString();
+            case it.pagopa.ecommerce.commons.documents.v2.Transaction t -> t.getClientId().getEffectiveClient().toString();
+            default ->
+                    throw new NotImplementedException("Handling for transaction document: [%s] not implemented yet".formatted(baseTransactionView.getClass()));
+        };
+    }
+
     public String getClientId(BaseTransactionView baseTransactionView) {
         return switch (baseTransactionView) {
             case it.pagopa.ecommerce.commons.documents.v1.Transaction t -> t.getClientId().toString();

--- a/src/main/java/it/pagopa/transactions/utils/WispDeprecation.java
+++ b/src/main/java/it/pagopa/transactions/utils/WispDeprecation.java
@@ -1,0 +1,49 @@
+package it.pagopa.transactions.utils;
+
+import it.pagopa.ecommerce.commons.documents.v2.Transaction;
+import it.pagopa.ecommerce.commons.domain.PaymentNotice;
+import it.pagopa.ecommerce.commons.domain.v2.TransactionActivated;
+
+import java.util.Optional;
+
+public final class WispDeprecation {
+
+    private WispDeprecation() {
+    }
+
+    public static Optional<String> extractCreditorReferenceId(
+                                                              TransactionActivated transaction,
+                                                              PaymentNotice paymentNotice
+    ) {
+        return extractCreditorReferenceId(transaction.getClientId(), paymentNotice.creditorReferenceId());
+    }
+
+    public static Optional<String> extractCreditorReferenceId(
+                                                              it.pagopa.ecommerce.commons.documents.v2.Transaction transaction,
+                                                              it.pagopa.ecommerce.commons.documents.PaymentNotice paymentNotice
+    ) {
+        return extractCreditorReferenceId(
+                transaction.getClientId(),
+                paymentNotice.getCreditorReferenceId()
+        );
+    }
+
+    private static Optional<String> extractCreditorReferenceId(
+                                                               Transaction.ClientId clientId,
+                                                               String creditorReferenceId
+    ) {
+        return switch (clientId) {
+            case WISP_REDIRECT -> Optional.ofNullable(creditorReferenceId);
+            case CHECKOUT, CHECKOUT_CART, IO -> Optional.empty();
+        };
+    }
+
+    // TODO: WISP replace with effectiveClient method
+    public static String adaptClientId(String clientId) {
+        if (clientId.equals(Transaction.ClientId.WISP_REDIRECT.name())) {
+            return Transaction.ClientId.CHECKOUT.name();
+        } else {
+            return clientId;
+        }
+    }
+}

--- a/src/main/java/it/pagopa/transactions/utils/WispDeprecation.java
+++ b/src/main/java/it/pagopa/transactions/utils/WispDeprecation.java
@@ -18,16 +18,6 @@ public final class WispDeprecation {
         return extractCreditorReferenceId(transaction.getClientId(), paymentNotice.creditorReferenceId());
     }
 
-    public static Optional<String> extractCreditorReferenceId(
-                                                              it.pagopa.ecommerce.commons.documents.v2.Transaction transaction,
-                                                              it.pagopa.ecommerce.commons.documents.PaymentNotice paymentNotice
-    ) {
-        return extractCreditorReferenceId(
-                transaction.getClientId(),
-                paymentNotice.getCreditorReferenceId()
-        );
-    }
-
     private static Optional<String> extractCreditorReferenceId(
                                                                Transaction.ClientId clientId,
                                                                String creditorReferenceId
@@ -36,14 +26,5 @@ public final class WispDeprecation {
             case WISP_REDIRECT -> Optional.ofNullable(creditorReferenceId);
             case CHECKOUT, CHECKOUT_CART, IO -> Optional.empty();
         };
-    }
-
-    // TODO: WISP replace with effectiveClient method
-    public static String adaptClientId(String clientId) {
-        if (clientId.equals(Transaction.ClientId.WISP_REDIRECT.name())) {
-            return Transaction.ClientId.CHECKOUT.name();
-        } else {
-            return clientId;
-        }
     }
 }

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -2685,7 +2685,8 @@ class PaymentGatewayClientTest {
                                         )
                                 ),
                                 false,
-                                new CompanyName(longPaName)
+                                new CompanyName(longPaName),
+                                null
                         )
                 ),
                 EMAIL,

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -192,7 +192,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -253,7 +254,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -347,7 +349,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -449,7 +452,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -526,7 +530,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -615,7 +620,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -693,7 +699,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -771,7 +778,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -876,7 +884,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -974,7 +983,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1080,7 +1090,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1172,7 +1183,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1272,7 +1284,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1332,7 +1345,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1401,7 +1415,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1565,7 +1580,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1678,7 +1694,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1780,7 +1797,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -1883,7 +1901,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -2059,7 +2078,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -2224,7 +2244,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -2368,7 +2389,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -2657,7 +2679,8 @@ class PaymentGatewayClientTest {
                                         )
                                 ),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         ),
                         new it.pagopa.ecommerce.commons.domain.PaymentNotice(
                                 new PaymentToken("paymentToken"),
@@ -2674,7 +2697,8 @@ class PaymentGatewayClientTest {
                                         )
                                 ),
                                 false,
-                                new CompanyName("companyName2")
+                                new CompanyName("companyName2"),
+                                null
                         )
                 ),
                 EMAIL,
@@ -3145,7 +3169,8 @@ class PaymentGatewayClientTest {
                                 new PaymentContextCode(null),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName("companyName")
+                                new CompanyName("companyName"),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandlerTest.java
@@ -526,7 +526,9 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
-        Mockito.when(nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate)))
+        Mockito.when(
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate), any())
+        )
                 .thenReturn(Mono.error(new InvalidNodoResponseException("Invalid payment token received")));
 
         /* run test */
@@ -620,7 +622,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoAfterActivation));
         Mockito.when(
@@ -739,7 +741,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoAfterActivation));
         Mockito.when(
@@ -843,7 +845,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoActivation));
         Mockito.when(

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionActivateHandlerTest.java
@@ -149,6 +149,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -169,7 +170,8 @@ class TransactionActivateHandlerTest {
                 transactionActivatedTime.toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, AMOUNT, null)),
-                false
+                false,
+                null
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent();
@@ -186,6 +188,7 @@ class TransactionActivateHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(rptId.getFiscalCode(), false, null, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -282,6 +285,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -302,7 +306,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, AMOUNT, null)),
-                false
+                false,
+                null
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent();
@@ -319,6 +324,7 @@ class TransactionActivateHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(rptId.getFiscalCode(), false, null, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -399,6 +405,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -491,6 +498,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -511,7 +519,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.value().substring(0, 11), false, amount, null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */
@@ -563,6 +572,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -583,7 +593,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, null, null)),
-                false
+                false,
+                null
         );
 
         PaymentRequestInfo paymentRequestInfoAfterActivation = new PaymentRequestInfo(
@@ -597,7 +608,8 @@ class TransactionActivateHandlerTest {
                 ZonedDateTime.now().toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */
@@ -679,6 +691,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -699,7 +712,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, null, null)),
-                false
+                false,
+                null
         );
 
         PaymentRequestInfo paymentRequestInfoAfterActivation = new PaymentRequestInfo(
@@ -713,7 +727,8 @@ class TransactionActivateHandlerTest {
                 ZonedDateTime.now().toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */
@@ -795,6 +810,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -815,7 +831,8 @@ class TransactionActivateHandlerTest {
                 ZonedDateTime.now().toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionRequestAuthorizationHandlerTest.java
@@ -151,7 +151,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -238,7 +239,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -344,7 +346,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -449,7 +452,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -559,7 +563,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -657,7 +662,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -743,7 +749,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -834,7 +841,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionSendClosureHandlerTest.java
@@ -137,6 +137,7 @@ class TransactionSendClosureHandlerTest {
                         null,
                         List.of(new PaymentTransferInformation("77777777777", false, 100, null)),
                         false,
+                        null,
                         null
                 )
         );
@@ -162,7 +163,8 @@ class TransactionSendClosureHandlerTest {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 )
                         .toList(),
@@ -284,6 +286,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -511,6 +514,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -747,6 +751,7 @@ class TransactionSendClosureHandlerTest {
                         null,
                         List.of(new PaymentTransferInformation("77777777777", false, 100, null)),
                         false,
+                        null,
                         null
                 )
         );
@@ -1015,6 +1020,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -1288,6 +1294,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -1576,6 +1583,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -1816,6 +1824,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -2037,6 +2046,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -2303,6 +2313,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );
@@ -2583,6 +2594,7 @@ class TransactionSendClosureHandlerTest {
                                 )
                         ),
                         false,
+                        null,
                         null
                 )
         );

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionUpdateAuthorizationHandlerTest.java
@@ -131,7 +131,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, amount.value(), null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v1/TransactionsActivationProjectionHandlerTest.java
@@ -54,6 +54,7 @@ class TransactionsActivationProjectionHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(paFiscalCode, false, amountInt, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -96,7 +97,8 @@ class TransactionsActivationProjectionHandlerTest {
                                         )
                                 ),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
@@ -36,6 +36,7 @@ import it.pagopa.transactions.utils.ConfidentialMailUtils;
 import it.pagopa.transactions.utils.NodoOperations;
 import it.pagopa.transactions.utils.Queues;
 import it.pagopa.transactions.utils.SpanLabelOpenTelemetry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -122,6 +123,14 @@ class TransactionActivateHandlerTest {
             tokenValidityTimeInSeconds
     );
 
+    @BeforeEach
+    void setup() {
+        Mockito.reset(transactionEventActivatedStoreRepository, confidentialMailUtils);
+        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
+                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
+    }
+
     @Test
     void shouldHandleCommandForNM3CachedPaymentRequestWithNpgWithV2Api() {
         Duration elapsedTimeFromActivation = Duration.ofSeconds(paymentTokenTimeout);
@@ -204,8 +213,7 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
-        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
@@ -224,8 +232,6 @@ class TransactionActivateHandlerTest {
                 )
         )
                 .thenReturn(Either.right("authToken"));
-
-        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
         /* run test */
         Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
@@ -360,8 +366,7 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
-        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
@@ -380,8 +385,6 @@ class TransactionActivateHandlerTest {
                 )
         )
                 .thenReturn(Either.right("authToken"));
-
-        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
         /* run test */
         Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
@@ -501,8 +504,7 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
-        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+
         Mockito.when(
                 transactionActivatedQueueAsyncClient.sendMessageWithResponse(
                         any(QueueEvent.class),
@@ -519,8 +521,6 @@ class TransactionActivateHandlerTest {
                 )
         )
                 .thenReturn(Either.right("authToken"));
-
-        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
         /* run test */
         Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
@@ -782,8 +782,7 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoBeforeActivation));
-        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
@@ -806,7 +805,6 @@ class TransactionActivateHandlerTest {
                 )
         )
                 .thenReturn(Queues.QUEUE_SUCCESSFUL_RESPONSE);
-        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
         /* run test */
         Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
@@ -901,8 +899,7 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoBeforeActivation));
-        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
@@ -925,7 +922,6 @@ class TransactionActivateHandlerTest {
                 )
         )
                 .thenReturn(Queues.QUEUE_SUCCESSFUL_RESPONSE);
-        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
 
         /* run test */
         Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
@@ -1005,8 +1001,7 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.empty());
-        Mockito.when(transactionEventActivatedStoreRepository.save(any()))
-                .thenAnswer(args -> Mono.just(args.getArguments()[0]));
+
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
@@ -1038,7 +1033,115 @@ class TransactionActivateHandlerTest {
         )
                 .thenReturn(Queues.QUEUE_SUCCESSFUL_RESPONSE);
 
-        Mockito.when(confidentialMailUtils.toConfidential(EMAIL_STRING)).thenReturn(Mono.just(EMAIL));
+        /* run test */
+        Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
+                .handle(command).block();
+
+        /* asserts */
+        TransactionActivatedEvent event = (TransactionActivatedEvent) response.getT1().block();
+        Mockito.verify(paymentRequestInfoRedisTemplateWrapper, Mockito.times(1)).findById(rptId.value());
+        assertNotNull(event.getTransactionId());
+        assertNotNull(event.getEventCode());
+        assertNotNull(event.getCreationDate());
+        assertNotNull(event.getId());
+        assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds());
+        assertEquals(Duration.ofSeconds(transientQueueEventsTtlSeconds), durationArgumentCaptor.getValue());
+        assertEquals(dueDate, paymentRequestInfoArgumentCaptor.getValue().dueDate());
+    }
+
+    @Test
+    void shouldActivatePaymentRequestSavingCreditorReferenceId() {
+        final var creditorReferenceId = UUID.randomUUID().toString();
+        final var transactionActivatedEvent = transactionActivateEvent();
+        final var paymentNotice = transactionActivatedEvent.getData().getPaymentNotices().get(0);
+        final var transactionId = new TransactionId(TRANSACTION_ID);
+        final var rptId = new RptId(paymentNotice.getRptId());
+        final var idempotencyKey = new IdempotencyKey("32009090901", "aabbccddee");
+        String paName = "paName";
+        String paTaxcode = rptId.getFiscalCode();
+
+        PaymentNoticeInfoDto paymentNoticeInfoDto = new PaymentNoticeInfoDto()
+                .rptId(rptId.value())
+                .amount(paymentNotice.getAmount());
+
+        NewTransactionRequestDto requestDto = new NewTransactionRequestDto()
+                .addPaymentNoticesItem(paymentNoticeInfoDto)
+                .email(EMAIL_STRING);
+
+        TransactionActivateCommand command = new TransactionActivateCommand(
+                List.of(rptId),
+                new NewTransactionRequestData(
+                        requestDto.getIdCart(),
+                        confidentialDataManager.encrypt(new Email(requestDto.getEmail())),
+                        null,
+                        null,
+                        requestDto.getPaymentNotices().stream().map(
+                                el -> new it.pagopa.ecommerce.commons.domain.PaymentNotice(
+                                        null,
+                                        new RptId(el.getRptId()),
+                                        new TransactionAmount(el.getAmount()),
+                                        null,
+                                        null,
+                                        null,
+                                        false,
+                                        null,
+                                        null
+                                )
+                        ).toList()
+                ),
+                Transaction.ClientId.CHECKOUT.name(),
+                transactionId,
+                userId
+        );
+
+        final var nodoActivateResponse = new PaymentRequestInfo(
+                rptId,
+                paTaxcode,
+                paName,
+                paymentNotice.getDescription(),
+                paymentNotice.getAmount(),
+                dueDate,
+                paymentNotice.getPaymentToken(),
+                ZonedDateTime.now().toString(),
+                idempotencyKey,
+                List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
+                false,
+                creditorReferenceId
+        );
+
+        /* preconditions */
+        Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
+                .thenReturn(Optional.empty());
+        Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
+                .save(paymentRequestInfoArgumentCaptor.capture());
+        Mockito.when(
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null))
+        )
+                .thenReturn(Mono.just(nodoActivateResponse));
+        Mockito.when(
+                nodoOperations.getEcommerceFiscalCode()
+        )
+                .thenReturn("77700000000");
+        Mockito.when(
+                nodoOperations.generateRandomStringToIdempotencyKey()
+        )
+                .thenReturn("aabbccddee");
+        Mockito.when(
+                jwtTokenUtils.generateToken(
+                        eq(jwtSecretKey),
+                        eq(tokenValidityTimeInSeconds),
+                        eq(new Claims(transactionId, null, null, userId))
+                )
+        )
+                .thenReturn(Either.right("authToken"));
+        Mockito.when(
+                transactionActivatedQueueAsyncClient.sendMessageWithResponse(
+                        any(QueueEvent.class),
+                        any(),
+                        durationArgumentCaptor.capture()
+                )
+        )
+                .thenReturn(Queues.QUEUE_SUCCESSFUL_RESPONSE);
 
         /* run test */
         Tuple2<Mono<BaseTransactionEvent<?>>, String> response = handler
@@ -1054,6 +1157,10 @@ class TransactionActivateHandlerTest {
         assertEquals(paymentTokenTimeout, event.getData().getPaymentTokenValiditySeconds());
         assertEquals(Duration.ofSeconds(transientQueueEventsTtlSeconds), durationArgumentCaptor.getValue());
         assertEquals(dueDate, paymentRequestInfoArgumentCaptor.getValue().dueDate());
+        assertTrue(
+                event.getData().getPaymentNotices().stream()
+                        .anyMatch(it -> it.getCreditorReferenceId().equals(creditorReferenceId))
+        );
     }
 
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
@@ -155,6 +155,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -175,7 +176,8 @@ class TransactionActivateHandlerTest {
                 transactionActivatedTime.toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, AMOUNT, null)),
-                false
+                false,
+                null
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent();
@@ -192,6 +194,7 @@ class TransactionActivateHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(rptId.getFiscalCode(), false, null, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -308,6 +311,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -328,7 +332,8 @@ class TransactionActivateHandlerTest {
                 transactionActivatedTime.toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, AMOUNT, null)),
-                false
+                false,
+                null
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent();
@@ -345,6 +350,7 @@ class TransactionActivateHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(rptId.getFiscalCode(), false, null, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -446,6 +452,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -466,7 +473,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, AMOUNT, null)),
-                false
+                false,
+                null
         );
 
         TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent();
@@ -483,6 +491,7 @@ class TransactionActivateHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(rptId.getFiscalCode(), false, null, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -563,6 +572,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -655,6 +665,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -675,7 +686,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.value().substring(0, 11), false, amount, null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */
@@ -727,6 +739,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -747,7 +760,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, null, null)),
-                false
+                false,
+                null
         );
 
         PaymentRequestInfo paymentRequestInfoAfterActivation = new PaymentRequestInfo(
@@ -761,7 +775,8 @@ class TransactionActivateHandlerTest {
                 ZonedDateTime.now().toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */
@@ -843,6 +858,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -863,7 +879,8 @@ class TransactionActivateHandlerTest {
                 null,
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, null, null)),
-                false
+                false,
+                null
         );
 
         PaymentRequestInfo paymentRequestInfoAfterActivation = new PaymentRequestInfo(
@@ -877,7 +894,8 @@ class TransactionActivateHandlerTest {
                 ZonedDateTime.now().toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */
@@ -959,6 +977,7 @@ class TransactionActivateHandlerTest {
                                         null,
                                         null,
                                         false,
+                                        null,
                                         null
                                 )
                         ).toList()
@@ -979,7 +998,8 @@ class TransactionActivateHandlerTest {
                 ZonedDateTime.now().toString(),
                 idempotencyKey,
                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, paymentNotice.getAmount(), null)),
-                false
+                false,
+                null
         );
 
         /* preconditions */

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionActivateHandlerTest.java
@@ -693,7 +693,9 @@ class TransactionActivateHandlerTest {
         /* preconditions */
         Mockito.when(paymentRequestInfoRedisTemplateWrapper.findById(rptId.value()))
                 .thenReturn(Optional.of(paymentRequestInfoCached));
-        Mockito.when(nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate)))
+        Mockito.when(
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate), any())
+        )
                 .thenReturn(Mono.error(new InvalidNodoResponseException("Invalid payment token received")));
 
         /* run test */
@@ -786,7 +788,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(dueDate), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoAfterActivation));
         Mockito.when(
@@ -903,7 +905,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoAfterActivation));
         Mockito.when(
@@ -1005,7 +1007,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null), any())
         )
                 .thenReturn(Mono.just(paymentRequestInfoActivation));
         Mockito.when(
@@ -1115,7 +1117,7 @@ class TransactionActivateHandlerTest {
         Mockito.doNothing().when(paymentRequestInfoRedisTemplateWrapper)
                 .save(paymentRequestInfoArgumentCaptor.capture());
         Mockito.when(
-                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null))
+                nodoOperations.activatePaymentRequest(any(), any(), any(), any(), any(), any(), eq(null), any())
         )
                 .thenReturn(Mono.just(nodoActivateResponse));
         Mockito.when(
@@ -1162,5 +1164,4 @@ class TransactionActivateHandlerTest {
                         .anyMatch(it -> it.getCreditorReferenceId().equals(creditorReferenceId))
         );
     }
-
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -199,7 +199,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -293,7 +294,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -390,7 +392,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -523,7 +526,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -661,7 +665,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -808,7 +813,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -952,7 +958,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1058,7 +1065,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1146,7 +1154,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1239,7 +1248,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1342,7 +1352,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1452,7 +1463,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1565,7 +1577,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1679,7 +1692,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1793,7 +1807,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -1906,7 +1921,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -2039,7 +2055,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -2177,7 +2194,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -2323,7 +2341,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -2503,7 +2522,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -2609,7 +2629,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,
@@ -2745,7 +2766,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,
@@ -2885,7 +2907,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,
@@ -2996,7 +3019,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,
@@ -3111,7 +3135,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -3245,7 +3270,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -3379,7 +3405,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -3513,7 +3540,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -3651,7 +3679,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -3841,7 +3870,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER
@@ -3943,7 +3973,8 @@ class TransactionRequestAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 new ArrayList<>(),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ), // TODO
                    // TRANSFER

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandlerTest.java
@@ -1065,7 +1065,8 @@ class TransactionRequestUserReceiptHandlerTest {
                                 PAYMENT_CONTEXT_CODE,
                                 List.of(),
                                 false,
-                                COMPANY_NAME
+                                COMPANY_NAME,
+                                CREDITOR_REFERENCE_ID
                         )
                 )
         );
@@ -1155,7 +1156,8 @@ class TransactionRequestUserReceiptHandlerTest {
                                 PAYMENT_CONTEXT_CODE,
                                 List.of(),
                                 false,
-                                COMPANY_NAME
+                                COMPANY_NAME,
+                                CREDITOR_REFERENCE_ID
                         )
                 )
         );

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionUpdateAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionUpdateAuthorizationHandlerTest.java
@@ -269,7 +269,8 @@ class TransactionUpdateAuthorizationHandlerTest {
                                 nullPaymentContextCode,
                                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, amount.value(), null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
@@ -36,7 +36,7 @@ class TransactionsActivationProjectionHandlerTest {
     @Test
     void shouldSaveTransaction() {
         /* preconditions */
-
+        String creditorReferenceId = UUID.randomUUID().toString();
         String transactionIdString = TransactionTestUtils.TRANSACTION_ID;
         String paFiscalCode = "77777777777";
         String rptIdString = paFiscalCode + "111111111111111111";
@@ -59,7 +59,7 @@ class TransactionsActivationProjectionHandlerTest {
                                 List.of(new PaymentTransferInformation(paFiscalCode, false, amountInt, null)),
                                 false,
                                 null,
-                                null
+                                creditorReferenceId
                         )
                 )
         );
@@ -102,7 +102,7 @@ class TransactionsActivationProjectionHandlerTest {
                                 ),
                                 false,
                                 new CompanyName(null),
-                                null
+                                creditorReferenceId
                         )
                 ),
                 email,
@@ -142,6 +142,10 @@ class TransactionsActivationProjectionHandlerTest {
                 transaction.getPaymentNotices().get(0).rptId()
         );
         assertEquals(
+                transactionResult.getPaymentNotices().get(0).creditorReferenceId(),
+                transaction.getPaymentNotices().get(0).creditorReferenceId()
+        );
+        assertEquals(
                 transactionResult.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken(),
                 transaction.getTransactionActivatedData().getPaymentNotices().get(0).getPaymentToken()
         );
@@ -151,7 +155,6 @@ class TransactionsActivationProjectionHandlerTest {
                 ((NpgTransactionGatewayActivationData) transaction.getTransactionActivatedData()
                         .getTransactionGatewayActivationData()).getOrderId()
         );
-
     }
 
 }

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionsActivationProjectionHandlerTest.java
@@ -58,6 +58,7 @@ class TransactionsActivationProjectionHandlerTest {
                                 null,
                                 List.of(new PaymentTransferInformation(paFiscalCode, false, amountInt, null)),
                                 false,
+                                null,
                                 null
                         )
                 )
@@ -100,7 +101,8 @@ class TransactionsActivationProjectionHandlerTest {
                                         )
                                 ),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,

--- a/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/transactions/documents/TransactionDocumentTest.java
@@ -58,6 +58,7 @@ class TransactionDocumentTest {
                                 "",
                                 List.of(new PaymentTransferInformation(TEST_PAFISCALCODE, false, TEST_AMOUNT, null)),
                                 false,
+                                null,
                                 null
                         )
                 ),
@@ -81,6 +82,7 @@ class TransactionDocumentTest {
                                 "",
                                 List.of(new PaymentTransferInformation(TEST_PAFISCALCODE, false, TEST_AMOUNT, null)),
                                 false,
+                                null,
                                 null
                         )
                 ),
@@ -105,6 +107,7 @@ class TransactionDocumentTest {
                                 "",
                                 List.of(new PaymentTransferInformation(TEST_PAFISCALCODE, false, TEST_AMOUNT, null)),
                                 false,
+                                null,
                                 null
                         )
                 ),
@@ -124,6 +127,7 @@ class TransactionDocumentTest {
                 null,
                 List.of(new PaymentTransferInformation(TEST_PAFISCALCODE, false, TEST_AMOUNT, null)),
                 false,
+                null,
                 null
         );
         differentTransaction.setPaymentNotices(List.of(paymentNotice));
@@ -168,7 +172,8 @@ class TransactionDocumentTest {
                                 nullPaymentContextCode,
                                 List.of(new PaymentTransferInfo(rptId.getFiscalCode(), false, amount.value(), null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 email,

--- a/src/test/java/it/pagopa/transactions/services/v1/CircuitBreakerTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/CircuitBreakerTest.java
@@ -193,6 +193,7 @@ class CircuitBreakerTest {
                                         TEST_CCP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -396,6 +397,7 @@ class CircuitBreakerTest {
                                         TEST_CCP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -458,6 +460,7 @@ class CircuitBreakerTest {
                                         TEST_CCP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )

--- a/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTest.java
@@ -277,6 +277,7 @@ class TransactionServiceTest {
                                         TEST_CPP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -304,7 +305,8 @@ class TransactionServiceTest {
                                 new PaymentContextCode(TEST_CPP.toString()),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,
@@ -370,6 +372,7 @@ class TransactionServiceTest {
                                         TEST_CPP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -397,7 +400,8 @@ class TransactionServiceTest {
                                 new PaymentContextCode(TEST_CPP.toString()),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,

--- a/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/TransactionServiceTests.java
@@ -630,7 +630,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),
@@ -1530,7 +1531,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),
@@ -1670,7 +1672,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),
@@ -1808,7 +1811,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),
@@ -1949,7 +1953,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),
@@ -2416,7 +2421,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),

--- a/src/test/java/it/pagopa/transactions/services/v2/CircuitBreakerTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/CircuitBreakerTest.java
@@ -163,6 +163,7 @@ class CircuitBreakerTest {
                                         TEST_CCP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -219,6 +220,7 @@ class CircuitBreakerTest {
                                         TEST_CCP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -279,6 +281,7 @@ class CircuitBreakerTest {
                                         TEST_CCP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTest.java
@@ -80,6 +80,7 @@ class TransactionServiceTest {
                                         TEST_CPP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -107,7 +108,8 @@ class TransactionServiceTest {
                                 new PaymentContextCode(TEST_CPP.toString()),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTest.java
@@ -156,4 +156,205 @@ class TransactionServiceTest {
 
     }
 
+    @Test
+    void shouldProjectCreditorReferenceIdWhenHandleNewTransactionTransactionActivatedForWispRedirect() {
+        ClientIdDto clientIdDto = ClientIdDto.CHECKOUT_CART;
+        final var creditorReferenceId = UUID.randomUUID().toString();
+        UUID TEST_SESSION_TOKEN = UUID.randomUUID();
+        UUID TEST_CPP = UUID.randomUUID();
+        UUID TRANSACTION_ID = UUID.randomUUID();
+
+        NewTransactionRequestDto transactionRequestDto = new NewTransactionRequestDto()
+                .email(EMAIL_STRING)
+                .addPaymentNoticesItem(new PaymentNoticeInfoDto().rptId(TransactionTestUtils.RPT_ID).amount(100));
+
+        TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
+        transactionActivatedData.setEmail(TransactionTestUtils.EMAIL);
+        transactionActivatedData
+                .setPaymentNotices(
+                        List.of(
+                                new PaymentNotice(
+                                        TransactionTestUtils.PAYMENT_TOKEN,
+                                        null,
+                                        "dest",
+                                        0,
+                                        TEST_CPP.toString(),
+                                        List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
+                                        false,
+                                        null,
+                                        creditorReferenceId
+                                )
+                        )
+                );
+
+        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
+                new TransactionId(TRANSACTION_ID).value(),
+                transactionActivatedData
+        );
+
+        Tuple2<Mono<BaseTransactionEvent<?>>, String> response = Tuples
+                .of(
+                        Mono.just(transactionActivatedEvent),
+                        TEST_SESSION_TOKEN.toString()
+                );
+
+        TransactionActivated transactionActivated = new TransactionActivated(
+                new TransactionId(TRANSACTION_ID),
+                Arrays.asList(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
+                                new PaymentToken(TransactionTestUtils.PAYMENT_TOKEN),
+                                new RptId(TransactionTestUtils.RPT_ID),
+                                new TransactionAmount(0),
+                                new TransactionDescription("desc"),
+                                new PaymentContextCode(TEST_CPP.toString()),
+                                List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
+                                false,
+                                new CompanyName(null),
+                                creditorReferenceId
+                        )
+                ),
+                TransactionTestUtils.EMAIL,
+                "faultCode",
+                "faultCodeString",
+                Transaction.ClientId.WISP_REDIRECT,
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
+        );
+
+        /*
+         * Preconditions
+         */
+        Mockito.when(transactionActivateHandlerV2.handle(any()))
+                .thenReturn(Mono.just(response));
+        Mockito.when(transactionsActivationProjectionHandlerV2.handle(transactionActivatedEvent))
+                .thenReturn(Mono.just(transactionActivated));
+        Mockito.when(transactionsUtils.convertEnumerationV2(any()))
+                .thenCallRealMethod();
+        Hooks.onOperatorDebug();
+        StepVerifier
+                .create(
+                        transactionsService.newTransaction(
+                                transactionRequestDto,
+                                clientIdDto,
+                                UUID.randomUUID(),
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
+                        )
+                )
+                .expectNextMatches(
+                        res -> res.getPayments().get(0).getRptId()
+                                .equals(transactionRequestDto.getPaymentNotices().get(0).getRptId())
+                                && res.getPayments().get(0).getCreditorReferenceId().equals(creditorReferenceId)
+                                && res.getIdCart().equals("idCart")
+                                && res.getStatus().equals(TransactionStatusDto.ACTIVATED)
+                                && res.getClientId()
+                                        .equals(NewTransactionResponseDto.ClientIdEnum.valueOf(clientIdDto.getValue()))
+                                && !res.getTransactionId().isEmpty()
+                                && !res.getAuthToken().isEmpty()
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldNewTransactionTransactionActivatedForCheckoutCart() {
+        ClientIdDto clientIdDto = ClientIdDto.CHECKOUT_CART;
+        final var creditorReferenceId = UUID.randomUUID().toString();
+        UUID TEST_SESSION_TOKEN = UUID.randomUUID();
+        UUID TEST_CPP = UUID.randomUUID();
+        UUID TRANSACTION_ID = UUID.randomUUID();
+
+        NewTransactionRequestDto transactionRequestDto = new NewTransactionRequestDto()
+                .email(EMAIL_STRING)
+                .addPaymentNoticesItem(new PaymentNoticeInfoDto().rptId(TransactionTestUtils.RPT_ID).amount(100));
+
+        TransactionActivatedData transactionActivatedData = new TransactionActivatedData();
+        transactionActivatedData.setEmail(TransactionTestUtils.EMAIL);
+        transactionActivatedData
+                .setPaymentNotices(
+                        List.of(
+                                new PaymentNotice(
+                                        TransactionTestUtils.PAYMENT_TOKEN,
+                                        null,
+                                        "dest",
+                                        0,
+                                        TEST_CPP.toString(),
+                                        List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
+                                        false,
+                                        null,
+                                        creditorReferenceId
+                                )
+                        )
+                );
+
+        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
+                new TransactionId(TRANSACTION_ID).value(),
+                transactionActivatedData
+        );
+
+        Tuple2<Mono<BaseTransactionEvent<?>>, String> response = Tuples
+                .of(
+                        Mono.just(transactionActivatedEvent),
+                        TEST_SESSION_TOKEN.toString()
+                );
+
+        TransactionActivated transactionActivated = new TransactionActivated(
+                new TransactionId(TRANSACTION_ID),
+                Arrays.asList(
+                        new it.pagopa.ecommerce.commons.domain.PaymentNotice(
+                                new PaymentToken(TransactionTestUtils.PAYMENT_TOKEN),
+                                new RptId(TransactionTestUtils.RPT_ID),
+                                new TransactionAmount(0),
+                                new TransactionDescription("desc"),
+                                new PaymentContextCode(TEST_CPP.toString()),
+                                List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
+                                false,
+                                new CompanyName(null),
+                                creditorReferenceId
+                        )
+                ),
+                TransactionTestUtils.EMAIL,
+                "faultCode",
+                "faultCodeString",
+                Transaction.ClientId.CHECKOUT_CART,
+                "idCart",
+                TransactionTestUtils.PAYMENT_TOKEN_VALIDITY_TIME_SEC,
+                new EmptyTransactionGatewayActivationData(),
+                TransactionTestUtils.USER_ID
+        );
+
+        /*
+         * Preconditions
+         */
+        Mockito.when(transactionActivateHandlerV2.handle(any()))
+                .thenReturn(Mono.just(response));
+        Mockito.when(transactionsActivationProjectionHandlerV2.handle(transactionActivatedEvent))
+                .thenReturn(Mono.just(transactionActivated));
+        Mockito.when(transactionsUtils.convertEnumerationV2(any()))
+                .thenCallRealMethod();
+        Hooks.onOperatorDebug();
+        StepVerifier
+                .create(
+                        transactionsService.newTransaction(
+                                transactionRequestDto,
+                                clientIdDto,
+                                UUID.randomUUID(),
+                                new TransactionId(transactionActivatedEvent.getTransactionId()),
+                                UUID.randomUUID()
+                        )
+                )
+                .expectNextMatches(
+                        res -> res.getPayments().get(0).getRptId()
+                                .equals(transactionRequestDto.getPaymentNotices().get(0).getRptId())
+                                && res.getPayments().get(0).getCreditorReferenceId() == null
+                                && res.getIdCart().equals("idCart")
+                                && res.getStatus().equals(TransactionStatusDto.ACTIVATED)
+                                && res.getClientId()
+                                        .equals(NewTransactionResponseDto.ClientIdEnum.valueOf(clientIdDto.getValue()))
+                                && !res.getTransactionId().isEmpty()
+                                && !res.getAuthToken().isEmpty()
+                )
+                .verifyComplete();
+    }
 }

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
@@ -699,7 +699,8 @@ class TransactionServiceTests {
                                         )
                                 ),
                                 paymentNotice.isAllCCP(),
-                                new CompanyName(paymentNotice.getCompanyName())
+                                new CompanyName(paymentNotice.getCompanyName()),
+                                null
                         )
                 ).toList(),
                 transactionDocument.getEmail(),

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
@@ -1248,7 +1248,10 @@ class TransactionServiceTests {
     void shouldConvertClientIdSuccessfully() {
         for (Transaction.ClientId clientId : Transaction.ClientId
                 .values()) {
-            assertEquals(clientId.toString(), transactionsServiceV1.convertClientId(clientId.name()).toString());
+            assertEquals(
+                    clientId.getEffectiveClient().toString(),
+                    transactionsServiceV1.convertClientId(clientId.name()).toString()
+            );
         }
         assertThrows(InvalidRequestException.class, () -> transactionsServiceV1.convertClientId(null));
     }

--- a/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
+++ b/src/test/java/it/pagopa/transactions/services/v2/TransactionServiceTests.java
@@ -23,6 +23,7 @@ import it.pagopa.generated.ecommerce.paymentmethods.v1.dto.PaymentMethodStatusDt
 import it.pagopa.generated.ecommerce.paymentmethods.v1.dto.RangeDto;
 import it.pagopa.generated.ecommerce.paymentmethods.v1.dto.SessionPaymentMethodResponseDto;
 import it.pagopa.generated.ecommerce.paymentmethods.v2.dto.BundleDto;
+import it.pagopa.generated.ecommerce.paymentmethods.v2.dto.CalculateFeeRequestDto;
 import it.pagopa.generated.ecommerce.paymentmethods.v2.dto.CalculateFeeResponseDto;
 import it.pagopa.generated.transactions.server.model.*;
 import it.pagopa.transactions.client.EcommercePaymentMethodsClient;
@@ -1463,4 +1464,93 @@ class TransactionServiceTests {
 
     }
 
+    @ParameterizedTest()
+    @EnumSource(it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.class)
+    void shouldCalculateFeesUsingEffectiveClient(
+                                                 it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId clientId
+    ) {
+        final var authorizationRequest = new RequestAuthorizationRequestDto()
+                .amount(100)
+                .paymentInstrumentId("paymentInstrumentId")
+                .language(RequestAuthorizationRequestDto.LanguageEnum.IT).fee(200)
+                .pspId("PSP_CODE")
+                .isAllCCP(false)
+                .details(
+                        new CardAuthRequestDetailsDto().cvv("123").pan("123456677").expiryDate("0223")
+                                .brand(CardAuthRequestDetailsDto.BrandEnum.VISA).holderName("Name Surname")
+                );
+
+        final var transaction = TransactionTestUtils.transactionDocument(
+                it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto.ACTIVATED,
+                ZonedDateTime.now()
+        );
+        transaction.setClientId(clientId);
+
+        /* preconditions */
+        final var calculateFeeResponseDto = new CalculateFeeResponseDto()
+                .belowThreshold(true)
+                .paymentMethodName("PaymentMethodName")
+                .paymentMethodDescription("PaymentMethodDescription")
+                .paymentMethodStatus(it.pagopa.generated.ecommerce.paymentmethods.v2.dto.PaymentMethodStatusDto.ENABLED)
+                .bundles(
+                        List.of(
+                                new BundleDto()
+                                        .idPsp("PSP_CODE")
+                                        .taxPayerFee(200l)
+                        )
+                );
+
+        final var paymentMethod = new PaymentMethodResponseDto()
+                .name("paymentMethodName")
+                .description("desc")
+                .status(PaymentMethodStatusDto.ENABLED)
+                .id("id")
+                .paymentTypeCode("PO")
+                .addRangesItem(new RangeDto().min(0L).max(100L));
+
+        final var gatewayResponse = new XPayAuthResponseEntityDto()
+                .requestId("requestId")
+                .urlRedirect("http://example.com");
+
+        final var requestAuthorizationResponse = new RequestAuthorizationResponseDto()
+                .authorizationUrl(gatewayResponse.getUrlRedirect());
+
+        final var calculateFeeRequest = ArgumentCaptor.forClass(CalculateFeeRequestDto.class);
+        Mockito.when(ecommercePaymentMethodsClient.calculateFee(any(), any(), calculateFeeRequest.capture(), any()))
+                .thenReturn(
+                        Mono.just(calculateFeeResponseDto)
+                );
+
+        Mockito.when(ecommercePaymentMethodsClient.getPaymentMethod(any(), any())).thenReturn(Mono.just(paymentMethod));
+
+        Mockito.when(repository.findById(TRANSACTION_ID))
+                .thenReturn(Mono.just(transaction));
+
+        Mockito.when(repository.findById(TRANSACTION_ID))
+                .thenReturn(Mono.just(transaction));
+
+        Mockito.when(paymentGatewayClient.requestXPayAuthorization(any())).thenReturn(Mono.just(gatewayResponse));
+
+        Mockito.when(repository.save(any())).thenReturn(Mono.just(transaction));
+
+        Mockito.when(transactionRequestAuthorizationHandlerV2.handle(commandArgumentCaptor.capture()))
+                .thenReturn(Mono.just(requestAuthorizationResponse));
+
+        Mockito.when(transactionsUtils.getPaymentNotices(any())).thenCallRealMethod();
+        Mockito.when(transactionsUtils.getTransactionTotalAmount(any())).thenCallRealMethod();
+        Mockito.when(transactionsUtils.getRptId(any(), anyInt())).thenCallRealMethod();
+        Mockito.when(transactionsUtils.getClientId(any())).thenCallRealMethod();
+        Mockito.when(transactionsUtils.getEffectiveClientId(any())).thenCallRealMethod();
+
+        /* test */
+        transactionsServiceV1
+                .requestTransactionAuthorization(
+                        TRANSACTION_ID,
+                        UUID.fromString(USER_ID),
+                        null,
+                        authorizationRequest
+                ).block();
+
+        assertEquals(clientId.getEffectiveClient().name(), calculateFeeRequest.getValue().getTouchpoint());
+    }
 }

--- a/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
@@ -66,6 +66,7 @@ class TransactionServiceTest {
                                         TEST_CPP.toString(),
                                         List.of(new PaymentTransferInformation("77777777777", false, 0, null)),
                                         false,
+                                        null,
                                         null
                                 )
                         )
@@ -93,7 +94,8 @@ class TransactionServiceTest {
                                 new PaymentContextCode(TEST_CPP.toString()),
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
-                                new CompanyName(null)
+                                new CompanyName(null),
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,

--- a/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v2_1/TransactionServiceTest.java
@@ -397,7 +397,7 @@ class TransactionServiceTest {
                                 List.of(new PaymentTransferInfo("77777777777", false, 100, null)),
                                 false,
                                 new CompanyName(null),
-                                        null
+                                null
                         )
                 ),
                 TransactionTestUtils.EMAIL,

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -133,7 +133,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -242,7 +243,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -342,7 +344,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -421,7 +424,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -511,7 +515,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -590,7 +595,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -682,7 +688,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -782,7 +789,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -882,7 +890,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -982,7 +991,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1082,7 +1092,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1182,7 +1193,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1278,7 +1290,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1374,7 +1387,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1461,7 +1475,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         null,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1517,7 +1532,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 );
 
         Assert.assertThrows(
@@ -1570,7 +1586,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 );
 
         InvalidNodoResponseException exception = Assert.assertThrows(
@@ -1648,7 +1665,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1772,7 +1790,8 @@ class NodoOperationsTest {
                         transactionId,
                         900,
                         idCart,
-                        dueDate
+                        dueDate,
+                        Transaction.ClientId.CHECKOUT
                 )
                 .block();
 
@@ -1861,7 +1880,8 @@ class NodoOperationsTest {
                                 transactionId,
                                 900,
                                 idCart,
-                                dueDate
+                                dueDate,
+                                Transaction.ClientId.CHECKOUT
                         )
         )
                 .expectError(NodoErrorException.class)

--- a/src/test/java/it/pagopa/transactions/utils/TransactionsUtilsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/TransactionsUtilsTest.java
@@ -162,6 +162,18 @@ class TransactionsUtilsTest {
     }
 
     @Test
+    void shouldGetEffectiveClientIdFromTransactionV2() {
+        it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId clientId = it.pagopa.ecommerce.commons.documents.v2.Transaction.ClientId.WISP_REDIRECT;
+        TransactionsUtils utils = new TransactionsUtils(null, null);
+        it.pagopa.ecommerce.commons.documents.v2.Transaction transaction = it.pagopa.ecommerce.commons.v2.TransactionTestUtils
+                .transactionDocument(TransactionStatusDto.ACTIVATED, ZonedDateTime.now());
+        transaction.setClientId(clientId);
+        String result = utils.getEffectiveClientId(transaction);
+        assertNotNull(result);
+        assertEquals(clientId.getEffectiveClient().name(), result);
+    }
+
+    @Test
     void shouldGetClientIdFromTransactionInvalidClass() {
         TransactionsUtils utils = new TransactionsUtils(null, null);
         assertThrows(NotImplementedException.class, () -> utils.getClientId(Mockito.mock(BaseTransactionView.class)));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Depends on https://github.com/pagopa/pagopa-ecommerce-payment-requests-service/pull/111

This PR introduces handling for IUV notice number. Also address some critical point:
- expose only effective client to rest API
- use only IO or CHECKOUT as touchpoints to GET /payment-methods
- use only effective clients as touchpoints for calculate fees
- returns `creditorReferenceId` during transaction activation (only for `WISP_REDIRECT`)

#### List of Changes
- get and save `creditorReferenceId` from Nodo activation during POST /transactions
- remap clientId to IO or CHECKOUT when getting payment method -> [see](https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/558/files#diff-b658409e3962e249360ebea4b1a737fed620afab5ff5cd3064edec397fa05336R62)
- extract `creditorReferenceId` only for `WISP_REDIRECT` client -> [see](https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/558/files#diff-d82b5a1bc392730c24e3b03a7909ba49dec26a6c3b77327d679ac29b7b492e3aR9)
- return `creditorReferenceId` to POST /transactions when client is `WISP_REDIRECT` -> [v2.1](https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/558/files#diff-7e2b904cadc7a364448287b1811ee8948cc58d365e5ac9738901f823e63307a5R139) and [v2](https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/558/files#diff-abe906d3c9a2319ffd7565282f30839392df85e70946283960506e3ae9e9aadcR147)
- calculating fee using effective touchpoint (e.g. `WISP_REDIRECT` becomes `CHECKOUT_CART`) -> [see](https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/558/files#diff-c633b723f784d3debc9f0af7170b95214b0b3684c3b2774924952a3bfa0e351eR521)
- hiding internal client and return only the effective client (e.g. `WISP_REDIRECT` becomes `CHECKOUT_CART`) -> [see](https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/558/files#diff-c633b723f784d3debc9f0af7170b95214b0b3684c3b2774924952a3bfa0e351eR420)

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.