### PR TITLE
[CHK-3094] fix(redirect): truncate `paName` field to 70 chars

### DIFF
--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -738,7 +738,7 @@ public class PaymentGatewayClient {
         if (paName == null || paName.length() <= 70) {
             return paName;
         } else {
-            return paName.substring(0, 69) + "…";
+            return paName.substring(0, 67) + "...";
         }
     }
 

--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -663,7 +664,7 @@ public class PaymentGatewayClient {
                                             redirectMethodsDescriptions.get(idPaymentMethod)
                                     )
                                     .idPaymentMethod(idPaymentMethod.toString())
-                                    .paName(paName);// optional
+                                    .paName(shortenRedirectPaName(paName));// optional
                             Either<RedirectConfigurationException, URI> pspConfiguredUrl = redirectKeysConfig
                                     .getRedirectUrlForPsp(
                                             touchpoint.name(),
@@ -731,6 +732,14 @@ public class PaymentGatewayClient {
                         }
                 );
 
+    }
+
+    private String shortenRedirectPaName(@Nullable String paName) {
+        if (paName == null || paName.length() <= 70) {
+            return paName;
+        } else {
+            return paName.substring(0, 69) + "…";
+        }
     }
 
     private String encodeMdcFields(AuthorizationRequestData authorizationData) {

--- a/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
+++ b/src/test/java/it/pagopa/transactions/client/PaymentGatewayClientTest.java
@@ -2640,7 +2640,7 @@ class PaymentGatewayClientTest {
     ) {
         String pspId = "pspId";
         String longPaName = it.pagopa.ecommerce.commons.v2.TransactionTestUtils.COMPANY_NAME.repeat(6) + "abcde";
-        String expectedPaName = it.pagopa.ecommerce.commons.v2.TransactionTestUtils.COMPANY_NAME.repeat(6) + "abc…";
+        String expectedPaName = it.pagopa.ecommerce.commons.v2.TransactionTestUtils.COMPANY_NAME.repeat(6) + "a...";
 
         assertTrue(longPaName.length() > 70);
         assertEquals(70, expectedPaName.length());
@@ -2868,7 +2868,7 @@ class PaymentGatewayClientTest {
                 .description(transaction.getPaymentNotices().get(0).transactionDescription().value())
                 .touchpoint(RedirectUrlRequestDto.TouchpointEnum.CHECKOUT)
                 .paymentMethod(mappedPaymentMethodDescription)
-                .paName(it.pagopa.ecommerce.commons.v2.TransactionTestUtils.COMPANY_NAME);
+                .paName(null);
 
         String urlBack = UriComponentsBuilder
                 .fromHttpUrl(sessionUrlConfig.basePath().concat(sessionUrlConfig.outcomeSuffix()))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * truncate `paName` field to 70 chars

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes a discrepancy between Checkout Redirect `paName` length (max length 70) and Nodo's `activate` `companyName` field (max length 140).
Now, a `companyName` field that is longer than 70 chars gets truncated to 67 chars plus an ellipsis `...`.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on pagopa/pagopa-mock-ec#67