### PR TITLE
fix: move lock before interacting with gateway

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,7 @@ resilience4j.retry:
         - it.pagopa.transactions.exceptions.InvalidNodoResponseException
         - it.pagopa.transactions.exceptions.PaymentMethodNotFoundException
         - it.pagopa.transactions.exceptions.NpgNotRetryableErrorException
+        - it.pagopa.transactions.exceptions.LockNotAcquiredException
     updateTransactionAuthorization:
       maxAttempts: 3
       waitDuration: 2s
@@ -58,6 +59,7 @@ resilience4j.retry:
         - it.pagopa.transactions.exceptions.TransactionAmountMismatchException
         - it.pagopa.transactions.exceptions.NodoErrorException
         - it.pagopa.transactions.exceptions.InvalidNodoResponseException
+        - it.pagopa.transactions.exceptions.LockNotAcquiredException
     cancelTransaction:
       maxAttempts: 3
       waitDuration: 2s

--- a/src/test/java/it/pagopa/transactions/controllers/v1/TransactionsControllerTest.java
+++ b/src/test/java/it/pagopa/transactions/controllers/v1/TransactionsControllerTest.java
@@ -937,7 +937,6 @@ class TransactionsControllerTest {
                                 .orderId("orderId")
                                 .detailType("cards")
                 );
-        Mockito.when(exclusiveLockDocumentWrapper.saveIfAbsent(any(), any())).thenReturn(true);
 
         /* test */
         webTestClient.post()
@@ -975,8 +974,6 @@ class TransactionsControllerTest {
                                 .orderId("orderId")
                                 .detailType("cards")
                 );
-
-        Mockito.when(exclusiveLockDocumentWrapper.saveIfAbsent(any(), any())).thenReturn(true);
 
         /* test */
         webTestClient.post()
@@ -1554,7 +1551,6 @@ class TransactionsControllerTest {
                 ).timestampOperation(OffsetDateTime.now());
 
         Mockito.when(uuidUtils.uuidFromBase64(b64TransactionId)).thenReturn(Either.right(transactionId.uuid()));
-        Mockito.when(exclusiveLockDocumentWrapper.saveIfAbsent(any())).thenReturn(false);
         /* test */
         webTestClient.patch()
                 .uri("/transactions/{transactionId}/auth-requests", b64TransactionId)

--- a/src/test/java/it/pagopa/transactions/services/v1/CircuitBreakerTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/CircuitBreakerTest.java
@@ -14,6 +14,7 @@ import it.pagopa.ecommerce.commons.documents.v1.TransactionActivatedData;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionActivatedEvent;
 import it.pagopa.ecommerce.commons.domain.PaymentToken;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
+import it.pagopa.ecommerce.commons.repositories.ExclusiveLockDocument;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import it.pagopa.generated.transactions.model.CtFaultBean;
 import it.pagopa.generated.transactions.server.model.*;
@@ -95,7 +96,11 @@ class CircuitBreakerTest {
             new NodoErrorException(new CtFaultBean()),
             new InvalidNodoResponseException(""),
             new PaymentMethodNotFoundException("paymentMethodId", "clientId"),
-            new NpgNotRetryableErrorException("", HttpStatus.INTERNAL_SERVER_ERROR)
+            new NpgNotRetryableErrorException("", HttpStatus.INTERNAL_SERVER_ERROR),
+            new LockNotAcquiredException(
+                    new TransactionId(TransactionTestUtils.TRANSACTION_ID),
+                    new ExclusiveLockDocument("id", "holderName")
+            )
     ).collect(Collectors.toMap(exception -> exception.getClass().getCanonicalName(), Function.identity()));
 
     static {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Move lock from ahead to just before call gateway for auth request
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification will leave retry attempts for all errors that could happen before call the payment gateway, acquiring lock for authorization just before communication with gateway is performed 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.