### PR TITLE
[CHK-3291] Save last payment method by user

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -12,7 +12,7 @@ resources:
     - repository: pagopaEcommerceLocal
       type: github
       name: pagopa/pagopa-ecommerce-local 
-      ref: main
+      ref: CHK-3299-user-stats-service
       endpoint: 'io-azure-devops-github-ro'
 
 stages:

--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -12,7 +12,7 @@ resources:
     - repository: pagopaEcommerceLocal
       type: github
       name: pagopa/pagopa-ecommerce-local 
-      ref: CHK-3299-user-stats-service
+      ref: main
       endpoint: 'io-azure-devops-github-ro'
 
 stages:

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <pagopa-ecommerce-commons.version>1.27.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>1.28.0</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.5.0</ecs-logging-version>
         <mock-web-server.version>4.11.0</mock-web-server.version>

--- a/pom.xml
+++ b/pom.xml
@@ -536,8 +536,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>tag</scmVersionType>
-                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
+                    <scmVersionType>branch</scmVersionType>
+                    <scmVersion>CHK-3285-set-wallet-details-nullable</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -536,8 +536,8 @@
                 <configuration>
                     <skipCheckoutIfExists>false</skipCheckoutIfExists>
                     <connectionUrl>scm:git:https://github.com/pagopa/pagopa-ecommerce-commons.git</connectionUrl>
-                    <scmVersionType>branch</scmVersionType>
-                    <scmVersion>CHK-3285-set-wallet-details-nullable</scmVersion>
+                    <scmVersionType>tag</scmVersionType>
+                    <scmVersion>${pagopa-ecommerce-commons.version}</scmVersion>
                     <goals>install -DskipTests</goals>
                 </configuration>
                 <executions>

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
@@ -327,10 +327,6 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                                                     e.getData()
                                                                             .getPaymentGateway()
                                                             )
-                                                            .filter(
-                                                                    gateway -> gateway
-                                                                            .equals(PaymentGateway.NPG)
-                                                            )
                                                             .flatMap(
                                                                     p -> tracingUtils.traceMono(
                                                                             this.getClass().getSimpleName(),

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandler.java
@@ -10,6 +10,7 @@ import it.pagopa.ecommerce.commons.documents.v2.activation.NpgTransactionGateway
 import it.pagopa.ecommerce.commons.documents.v2.authorization.NpgTransactionGatewayAuthorizationRequestedData;
 import it.pagopa.ecommerce.commons.documents.v2.authorization.RedirectTransactionGatewayAuthorizationRequestedData;
 import it.pagopa.ecommerce.commons.documents.v2.authorization.TransactionGatewayAuthorizationRequestedData;
+import it.pagopa.ecommerce.commons.documents.v2.authorization.WalletInfo;
 import it.pagopa.ecommerce.commons.domain.TransactionId;
 import it.pagopa.ecommerce.commons.domain.v2.TransactionActivated;
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransaction;
@@ -264,12 +265,7 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                     PaymentGateway paymentGateway = authorizationOutputAndPaymentGateway.getT2();
                                     String brand = authorizationRequestData.brand();
                                     TransactionGatewayAuthorizationRequestedData transactionGatewayAuthorizationRequestedData = switch (paymentGateway) {
-                                        /*case VPOS, XPAY -> new PgsTransactionGatewayAuthorizationRequestedData(
-                                                logo,
-                                                PgsTransactionGatewayAuthorizationRequestedData.CardBrand.valueOf(brand)
-                                        );*/
-                                        //TODO: how to handle this case? We should remove this value for enum from document definition, but it should not be safe for old transaction and for helpdesk scope
-                                        case NPG -> new NpgTransactionGatewayAuthorizationRequestedData(
+                                       case NPG -> new NpgTransactionGatewayAuthorizationRequestedData(
                                                 logo,
                                                 brand,
                                                 authorizationRequestData
@@ -290,12 +286,9 @@ public class TransactionRequestAuthorizationHandler extends TransactionRequestAu
                                                                 )
                                                         ),
                                                 authorizationOutput.npgConfirmSessionId().orElse(null),
-                                                /* @formatter:off
-                                                 * FIXME walletInfo set to null: this modification is addressed in
-                                                 * PR: https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/475
-                                                 * @formatter:on
-                                                 */
-                                                null
+                                                authorizationRequestData
+                                                        .authDetails() instanceof WalletAuthRequestDetailsDto ?
+                                                        new WalletInfo(((WalletAuthRequestDetailsDto) authorizationRequestData.authDetails()).getWalletId(), null) : null
                                         );
                                         case REDIRECT -> new RedirectTransactionGatewayAuthorizationRequestedData(
                                                 logo,

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -2943,15 +2943,23 @@ class TransactionRequestAuthorizationHandlerTest {
         when(transactionEventStoreRepository.save(eventStoreCaptor.capture()))
                 .thenAnswer(args -> Mono.just(args.getArguments()[0]));
         when(exclusiveLockDocumentWrapper.saveIfAbsent(any(), any())).thenReturn(true);
+        when(
+                transactionAuthorizationRequestedQueueAsyncClient.sendMessageWithResponse(
+                        any(QueueEvent.class),
+                        any(),
+                        durationArgumentCaptor.capture()
+                )
+        )
+                .thenReturn(Queues.QUEUE_SUCCESSFUL_RESPONSE);
 
         /* test */
         requestAuthorizationHandler.handle(requestAuthorizationCommand).block();
 
         verify(transactionEventStoreRepository, times(1)).save(any());
-        verify(transactionAuthorizationRequestedQueueAsyncClient, times(0)).sendMessageWithResponse(
+        verify(transactionAuthorizationRequestedQueueAsyncClient, times(1)).sendMessageWithResponse(
+                any(QueueEvent.class),
                 any(),
-                any(),
-                any()
+                durationArgumentCaptor.capture()
         );
         TransactionEvent<TransactionAuthorizationRequestData> authorizationRequestedEvent = eventStoreCaptor.getValue();
         TransactionAuthorizationRequestData authRequestedData = authorizationRequestedEvent.getData();
@@ -4063,7 +4071,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 npgTransactionGatewayAuthorizationRequestedData.getSessionId()
         );
         assertEquals(
-                walletId, npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletId()
+                walletId,
+                npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletId()
         );
         assertNull(npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletDetails());
         assertNull(npgTransactionGatewayAuthorizationRequestedData.getConfirmPaymentSessionId());

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestAuthorizationHandlerTest.java
@@ -2289,7 +2289,7 @@ class TransactionRequestAuthorizationHandlerTest {
                                 .concat("&sessionToken=").concat(MOCK_JWT)
                 );
         when(exclusiveLockDocumentWrapper.saveIfAbsent(any(), any())).thenReturn(true);
-        ;
+
         /* test */
         StepVerifier.create(requestAuthorizationHandler.handle(requestAuthorizationCommand))
                 .expectNext(responseDto)
@@ -2304,6 +2304,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 npgTransactionGatewayAuthorizationRequestedData.getSessionId()
         );
         assertNull(npgTransactionGatewayAuthorizationRequestedData.getConfirmPaymentSessionId());
+        assertEquals(walletId, npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletId());
+        assertNull(npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletDetails());
         verify(transactionTemplateWrapper, times(1)).save(any());
         verify(exclusiveLockDocumentWrapper, times(1)).saveIfAbsent(
                 argThat(lockDocument -> {
@@ -2562,6 +2564,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 npgTransactionGatewayAuthorizationRequestedData.getSessionId()
         );
         assertNull(npgTransactionGatewayAuthorizationRequestedData.getConfirmPaymentSessionId());
+        assertEquals(walletId, npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletId());
+        assertNull(npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletDetails());
         verify(transactionTemplateWrapper, times(1)).save(any());
         verify(exclusiveLockDocumentWrapper, times(1)).saveIfAbsent(
                 argThat(lockDocument -> {
@@ -3737,6 +3741,8 @@ class TransactionRequestAuthorizationHandlerTest {
                 npgTransactionGatewayAuthorizationRequestedData.getSessionId()
         );
         assertNull(npgTransactionGatewayAuthorizationRequestedData.getConfirmPaymentSessionId());
+        assertEquals(walletId, npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletId());
+        assertNull(npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletDetails());
         verify(transactionTemplateWrapper, times(1)).save(any());
 
         final var tracingArgument = ArgumentCaptor.forClass(TracingInfo.class);
@@ -4056,6 +4062,10 @@ class TransactionRequestAuthorizationHandlerTest {
                 "sessionId",
                 npgTransactionGatewayAuthorizationRequestedData.getSessionId()
         );
+        assertEquals(
+                walletId, npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletId()
+        );
+        assertNull(npgTransactionGatewayAuthorizationRequestedData.getWalletInfo().getWalletDetails());
         assertNull(npgTransactionGatewayAuthorizationRequestedData.getConfirmPaymentSessionId());
         verify(transactionTemplateWrapper, times(1)).save(any());
 


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-ecommerce-commons/pull/220
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Open auth request expiration queue flux to all auth request events, in order to save last usage method for user from app IO.

#### List of Changes

- write `walletId` in auth request gateway data
- write auth-request event also for nonNPG payment flow to use it in event-dispatcher queue message receiver and save last method used
- update junit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.