### PR TITLE
feat(nodo-activate): CHK-3531 enrich transfer with conventions

### DIFF
--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -297,16 +297,15 @@ public class NodoOperations {
                 )
                 .toList();
 
-        String conventionValue = Optional.ofNullable(metadata)
+        Optional<String> conventionValue = Optional.ofNullable(metadata)
                 .map(CtMetadata::getMapEntry)
                 .orElse(List.of())
                 .stream()
                 .filter(entry -> "codiceConvenzione".equals(entry.getKey()))
                 .map(CtMapEntry::getValue)
-                .findFirst()
-                .orElse(null);
+                .findFirst();
 
-        return (conventionValue != null)
+        return (conventionValue.isPresent())
                 ? Stream.concat(
                         baseTransferList.stream(),
                         Stream.of(

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -305,19 +305,20 @@ public class NodoOperations {
                 .map(CtMapEntry::getValue)
                 .findFirst();
 
-        return (conventionValue.isPresent())
-                ? Stream.concat(
-                        baseTransferList.stream(),
-                        Stream.of(
-                                new PaymentTransferInfo(
-                                        CONVENTION_TRANSFER_FISCAL_CODE,
-                                        false,
-                                        0,
-                                        conventionValue
+        return conventionValue
+                .map(
+                        value -> Stream.concat(
+                                baseTransferList.stream(),
+                                Stream.of(
+                                        new PaymentTransferInfo(
+                                                CONVENTION_TRANSFER_FISCAL_CODE,
+                                                false,
+                                                0,
+                                                value
+                                        )
                                 )
-                        )
+                        ).toList()
                 )
-                        .toList()
-                : baseTransferList;
+                .orElse(baseTransferList);
     }
 }

--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -24,7 +24,9 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.security.SecureRandom;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Slf4j
 @Component
@@ -33,6 +35,7 @@ public class NodoOperations {
     private static final String ALPHANUMERICS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final String IBANAPPOGGIO = "IBANAPPOGGIO";
+    private static final String CONVENTION_TRANSFER_FISCAL_CODE = "66666666666";
 
     NodeForPspClient nodeForPspClient;
 
@@ -191,15 +194,10 @@ public class NodoOperations {
                                 response.getPaymentToken(),
                                 ZonedDateTime.now().toString(),
                                 new IdempotencyKey(idempotencyKey),
-                                response.getTransferList().getTransfer().stream()
-                                        .map(
-                                                transfer -> new PaymentTransferInfo(
-                                                        transfer.getFiscalCodePA(),
-                                                        transfer.getRichiestaMarcaDaBollo() != null,
-                                                        EuroUtils.euroToEuroCents(transfer.getTransferAmount()),
-                                                        transfer.getTransferCategory()
-                                                )
-                                        ).toList(),
+                                getPaymentTransferInfoList(
+                                        response.getTransferList().getTransfer(),
+                                        response.getMetadata()
+                                ),
                                 isAllCCP(response, allCCPOnTransferIbanEnabled),
                                 response.getCreditorReferenceId()
                         )
@@ -259,5 +257,68 @@ public class NodoOperations {
 
     public String getEcommerceFiscalCode() {
         return nodoConfig.nodoConnectionString().getIdBrokerPSP();
+    }
+
+    /**
+     * Retrieves a list of payment transfer information based on the provided
+     * transfer data and metadata.
+     *
+     * <p>
+     * This method processes a list of transfer objects and associated metadata to
+     * generate a corresponding list of payment transfer information. If the
+     * metadata contains a convention specifying additional transfers, these will be
+     * included in the resulting list (for more details see CHK-3525).
+     * </p>
+     *
+     * @param transferPSPV2List a list of {@link CtTransferPSPV2} objects containing
+     *                          the payment transfer data to be processed.
+     * @param metadata          an instance of {@link CtMetadata} containing
+     *                          relevant metadata for processing the transfers,
+     *                          which may include conventions for adding additional
+     *                          transfers.
+     * @return a list of {@link PaymentTransferInfo} objects, each representing
+     *         detailed information about a payment transfer, including any
+     *         additional transfers specified by the metadata.
+     *
+     * @throws IllegalArgumentException if the input parameters are null or invalid.
+     */
+    private List<PaymentTransferInfo> getPaymentTransferInfoList(
+                                                                 List<CtTransferPSPV2> transferPSPV2List,
+                                                                 CtMetadata metadata
+    ) {
+        List<PaymentTransferInfo> baseTransferList = transferPSPV2List.stream()
+                .map(
+                        transfer -> new PaymentTransferInfo(
+                                transfer.getFiscalCodePA(),
+                                transfer.getRichiestaMarcaDaBollo() != null,
+                                EuroUtils.euroToEuroCents(transfer.getTransferAmount()),
+                                transfer.getTransferCategory()
+                        )
+                )
+                .toList();
+
+        String conventionValue = Optional.ofNullable(metadata)
+                .map(CtMetadata::getMapEntry)
+                .orElse(List.of())
+                .stream()
+                .filter(entry -> "codiceConvenzione".equals(entry.getKey()))
+                .map(CtMapEntry::getValue)
+                .findFirst()
+                .orElse(null);
+
+        return (conventionValue != null)
+                ? Stream.concat(
+                        baseTransferList.stream(),
+                        Stream.of(
+                                new PaymentTransferInfo(
+                                        CONVENTION_TRANSFER_FISCAL_CODE,
+                                        false,
+                                        0,
+                                        conventionValue
+                                )
+                        )
+                )
+                        .toList()
+                : baseTransferList;
     }
 }


### PR DESCRIPTION
depends on https://github.com/pagopa/io-pagopa-node-mock/pull/59
depends on https://github.com/pagopa/pagopa-ecommerce-local/pull/177

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- enrich transfer in activateV2Response

#### Motivation and Context

This PR implements a new feature that enrich payment transfer information based on specified transfer data and associated metadata. The primary goal is to create transfer lists that facilitate the management of conventions, which will be utilized during the fee retrieval process (GEC). 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.