### PR TITLE
feat(convention): CHK-3531 use creditorRefernceId in tranfer for convention

### DIFF
--- a/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
+++ b/src/main/java/it/pagopa/transactions/utils/NodoOperations.java
@@ -35,7 +35,6 @@ public class NodoOperations {
     private static final String ALPHANUMERICS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final String IBANAPPOGGIO = "IBANAPPOGGIO";
-    private static final String CONVENTION_TRANSFER_FISCAL_CODE = "66666666666";
 
     NodeForPspClient nodeForPspClient;
 
@@ -196,7 +195,8 @@ public class NodoOperations {
                                 new IdempotencyKey(idempotencyKey),
                                 getPaymentTransferInfoList(
                                         response.getTransferList().getTransfer(),
-                                        response.getMetadata()
+                                        response.getMetadata(),
+                                        response.getCreditorReferenceId()
                                 ),
                                 isAllCCP(response, allCCPOnTransferIbanEnabled),
                                 response.getCreditorReferenceId()
@@ -270,12 +270,14 @@ public class NodoOperations {
      * included in the resulting list (for more details see CHK-3525).
      * </p>
      *
-     * @param transferPSPV2List a list of {@link CtTransferPSPV2} objects containing
-     *                          the payment transfer data to be processed.
-     * @param metadata          an instance of {@link CtMetadata} containing
-     *                          relevant metadata for processing the transfers,
-     *                          which may include conventions for adding additional
-     *                          transfers.
+     * @param transferPSPV2List   a list of {@link CtTransferPSPV2} objects
+     *                            containing the payment transfer data to be
+     *                            processed.
+     * @param metadata            an instance of {@link CtMetadata} containing
+     *                            relevant metadata for processing the transfers,
+     *                            which may include conventions for adding
+     *                            additional transfers.
+     * @param creditorReferenceId paFiscalCode for transfer related to convention
      * @return a list of {@link PaymentTransferInfo} objects, each representing
      *         detailed information about a payment transfer, including any
      *         additional transfers specified by the metadata.
@@ -284,7 +286,8 @@ public class NodoOperations {
      */
     private List<PaymentTransferInfo> getPaymentTransferInfoList(
                                                                  List<CtTransferPSPV2> transferPSPV2List,
-                                                                 CtMetadata metadata
+                                                                 CtMetadata metadata,
+                                                                 String creditorReferenceId
     ) {
         List<PaymentTransferInfo> baseTransferList = transferPSPV2List.stream()
                 .map(
@@ -311,7 +314,7 @@ public class NodoOperations {
                                 baseTransferList.stream(),
                                 Stream.of(
                                         new PaymentTransferInfo(
-                                                CONVENTION_TRANSFER_FISCAL_CODE,
+                                                creditorReferenceId,
                                                 false,
                                                 0,
                                                 value

--- a/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
+++ b/src/test/java/it/pagopa/transactions/utils/NodoOperationsTest.java
@@ -1989,7 +1989,7 @@ class NodoOperationsTest {
         activatePaymentRes.setTotalAmount(amountBigDec);
         activatePaymentRes.setPaymentDescription("Description");
         activatePaymentRes.setOutcome(StOutcome.OK);
-        activatePaymentRes.setCreditorReferenceId(null);
+        activatePaymentRes.setCreditorReferenceId("66666666666");
         activatePaymentRes.setTransferList(objectFactoryUtil.createCtTransferListPSPV2());
         CtMetadata metadata = objectFactoryUtil.createCtMetadata();
         CtMapEntry metadataEntry = objectFactoryUtil.createCtMapEntry();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- use creditorReferenceId in transfer for convention

#### Motivation and Context

The goal of this PR is to use `creditorReferenceId` instead `66666666666` in transfer only for convention (response metadata activatePaymentNotice).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.