### PR TITLE
[MAIN-4] Remove redundant query param

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -334,10 +334,8 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                                                     );
 
                                             yield gdiCheckPathWithFragment.map(
-                                                    path -> appendTimestampAsQueryParam(
-                                                            URI.create(checkoutBasePath)
-                                                                    .resolve(path)
-                                                    ).toString()
+                                                    path -> URI.create(checkoutBasePath)
+                                                            .resolve(path).toString()
                                             );
 
                                         }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Fix double query param in auth-request call
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
During the authorization phase, the transaction service generated an authorization URL containing two query parameters with the same key. This PR aims to eliminate this duplication.

#### How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.