### PR TITLE
[PIDM-134] Handle retry on add user receipt

### DIFF
--- a/src/main/java/it/pagopa/transactions/exceptions/InvalidStatusException.java
+++ b/src/main/java/it/pagopa/transactions/exceptions/InvalidStatusException.java
@@ -1,0 +1,7 @@
+package it.pagopa.transactions.exceptions;
+
+public class InvalidStatusException extends RuntimeException {
+    public InvalidStatusException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/commands/handlers/v2/TransactionRequestUserReceiptHandlerTest.java
@@ -10,7 +10,6 @@ import it.pagopa.ecommerce.commons.domain.PaymentNotice;
 import it.pagopa.ecommerce.commons.domain.v2.TransactionActivated;
 import it.pagopa.ecommerce.commons.domain.v2.TransactionEventCode;
 import it.pagopa.ecommerce.commons.generated.npg.v1.dto.OperationResultDto;
-import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.queues.QueueEvent;
 import it.pagopa.ecommerce.commons.queues.TracingUtils;
 import it.pagopa.ecommerce.commons.queues.TracingUtilsTests;
@@ -808,7 +807,7 @@ class TransactionRequestUserReceiptHandlerTest {
 
         /* test */
         StepVerifier.create(updateStatusHandler.handle(requestStatusCommand))
-                .expectErrorMatches(error -> error instanceof InvalidStatusException)
+                .expectErrorMatches(InvalidStatusException.class::isInstance)
                 .verify();
 
         Mockito.verify(userReceiptDataEventRepository, Mockito.times(0)).save(any());
@@ -864,7 +863,7 @@ class TransactionRequestUserReceiptHandlerTest {
 
         /* test */
         StepVerifier.create(updateStatusHandler.handle(requestStatusCommand))
-                .expectErrorMatches(error -> error instanceof AlreadyProcessedException)
+                .expectErrorMatches(AlreadyProcessedException.class::isInstance)
                 .verify();
 
         Mockito.verify(userReceiptDataEventRepository, Mockito.times(0)).save(any());
@@ -978,7 +977,7 @@ class TransactionRequestUserReceiptHandlerTest {
 
         /* test */
         StepVerifier.create(updateStatusHandler.handle(requestStatusCommand))
-                .expectErrorMatches(error -> error instanceof AlreadyProcessedException)
+                .expectErrorMatches(AlreadyProcessedException.class::isInstance)
                 .verify();
 
         verify(updateTransactionStatusTracerUtils, times(0)).traceStatusUpdateOperation(

--- a/src/test/java/it/pagopa/transactions/services/v1/CircuitBreakerTest.java
+++ b/src/test/java/it/pagopa/transactions/services/v1/CircuitBreakerTest.java
@@ -505,7 +505,7 @@ class CircuitBreakerTest {
 
     @Test
     @Order(3)
-    void shouldOpenCircuitBreakerForInvalidStatusExceptionPerformingRetry() {
+    void shouldPerformRetryForInvalidStatusExceptionOnAddUserReceipt() {
         Retry retry = retryRegistry.retry("addUserReceipt");
         long expectedFailedCallsWithoutRetryAttempt = retry.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt();
         long expectedFailedCallsWithRetryAttempt = retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt() + 1;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Adds a retry policy when addUserReceipt is invoked while the transaction state is CLOSURE_REQUESTED
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The addUserReceipt function might be invoked before the eventDispatcher has updated the transaction state. Retrying could help prevent disruptions in the event flow.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test and local integration test
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.