### PR TITLE
CHK-4108: add fees to outcome info

### DIFF
--- a/api-spec/v1/transactions-api.yaml
+++ b/api-spec/v1/transactions-api.yaml
@@ -768,6 +768,10 @@ components:
           description: "`0` - Success `1` - Generic error `2` - Authorization error `3` - Invalid data `4` - Timeout `5` - Unsupported circuit `6` - Missing data `7` - Invalid card: expired card etc `8` - Canceled by the user `9` - Double transaction `10` - Excessive amount `11` - Order not present `12` - Invalid method `13` - Retriable KO `14` - Invalid session `17` - Taken in charge `25` - PSP Error `99` - Backend Error `116` - Balance not available `117` - CVV Error `121` - Limit exceeded"
         totalAmount:
           $ref: '#/components/schemas/AmountEuroCents'
+          description: "The total amount paid for the payment notice"
+        fees:
+          $ref: '#/components/schemas/AmountEuroCents'
+          description: "The total fees paid for the payment notice"
         isFinalStatus:
           type: boolean
           description: "A flag that describe the outcome as final or not. If true, the outcome will not change in the future and the client can interrupt polling"

--- a/src/main/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationRequestProjectionHandler.java
+++ b/src/main/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationRequestProjectionHandler.java
@@ -39,6 +39,7 @@ public class AuthorizationRequestProjectionHandler
                     transactionDocument.setPaymentGateway(data.paymentGatewayId());
                     transactionDocument.setPaymentTypeCode(data.paymentTypeCode());
                     transactionDocument.setPspId(data.pspId());
+                    transactionDocument.setFeeTotal(data.fee());
                     return transactionsViewRepository.save(transactionDocument);
                 });
     }

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -273,7 +273,8 @@ public class TransactionsService {
                     TransactionOutcomeInfoDto.OutcomeEnum outcome = evaluateOutcome(transaction.getStatus(), transaction.getSendPaymentResultOutcome(), transaction.getPaymentGateway(), transaction.getGatewayAuthorizationStatus(), transaction.getAuthorizationErrorCode());
                                 return new TransactionOutcomeInfoDto()
                                 .outcome(outcome)
-                                .totalAmount(outcome == TransactionOutcomeInfoDto.OutcomeEnum.NUMBER_0 ? transaction.getPaymentNotices().stream().mapToInt(it.pagopa.ecommerce.commons.documents.PaymentNotice::getAmount).sum() + Optional.ofNullable(transaction.getFeeTotal()).orElse(0) : null)
+                                .totalAmount(outcome == TransactionOutcomeInfoDto.OutcomeEnum.NUMBER_0  ? transaction.getPaymentNotices().stream().mapToInt(it.pagopa.ecommerce.commons.documents.PaymentNotice::getAmount).sum() : null)
+                                .fees(outcome == TransactionOutcomeInfoDto.OutcomeEnum.NUMBER_0  ?  + Optional.ofNullable(transaction.getFeeTotal()).orElse(0) : null)
                                 .isFinalStatus(evaluateFinalStatus(transaction.getStatus(), transaction.getClosureErrorData(), Optional.ofNullable(transaction.getGatewayAuthorizationStatus())));
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + baseTransactionView);

--- a/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationRequestProjectionHandlerTest.java
+++ b/src/test/java/it/pagopa/transactions/projections/handlers/v2/AuthorizationRequestProjectionHandlerTest.java
@@ -36,11 +36,13 @@ class AuthorizationRequestProjectionHandlerTest {
                 ZonedDateTime.now()
         );
 
+        Integer fee = 50;
+
         AuthorizationRequestData authorizationData = new AuthorizationRequestData(
                 new TransactionId(initialDocument.getTransactionId()),
                 null,
                 initialDocument.getEmail(),
-                0,
+                fee,
                 null,
                 TransactionTestUtils.PSP_ID,
                 TransactionTestUtils.PAYMENT_TYPE_CODE,
@@ -63,7 +65,7 @@ class AuthorizationRequestProjectionHandlerTest {
         Transaction expectedDocument = new Transaction(
                 initialDocument.getTransactionId(),
                 initialDocument.getPaymentNotices(),
-                initialDocument.getFeeTotal(),
+                fee,
                 initialDocument.getEmail(),
                 TransactionStatusDto.AUTHORIZATION_REQUESTED,
                 initialDocument.getClientId(),


### PR DESCRIPTION
Handing fees in transaction view and in outcome info

#### List of Changes

- When ecommerce handle auth-request it saves the fee values in the view
- This value is used by outcome info to show final message for checkout outcome api

#### Motivation and Context

Split values on outcome info

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.