### PR TITLE
CHK-4809: fix concurrent processing of closure requested event

### DIFF
--- a/src/main/java/it/pagopa/transactions/commands/data/ClosureRequestedEventData.java
+++ b/src/main/java/it/pagopa/transactions/commands/data/ClosureRequestedEventData.java
@@ -1,0 +1,11 @@
+package it.pagopa.transactions.commands.data;
+
+import it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent;
+
+import java.time.Duration;
+
+public record ClosureRequestedEventData(
+        Duration visibilityTimeout,
+        TransactionClosureRequestedEvent transactionClosureRequestedEvent
+) {
+}

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
@@ -2,6 +2,8 @@ package it.pagopa.transactions.commands.handlers.v2;
 
 import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
+import it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent;
+import it.pagopa.ecommerce.commons.domain.v2.TransactionAuthorizationCompleted;
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.queues.QueueEvent;
@@ -17,7 +19,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import java.time.Duration;
@@ -41,75 +42,69 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
         this.transactionEventSendClosureRequestRepository = transactionEventSendClosureRequestRepository;
     }
 
+    @Override
     public Mono<BaseTransactionEvent<?>> handle(TransactionClosureRequestCommand command) {
-        return transactionsUtils.reduceV2Events(command.getEvents())
-                .flatMap(transaction -> {
-                    TransactionStatusDto status = transaction.getStatus();
-
-                    // 1. Validazione Stato
-                    if (!isValidStatus(status)) {
-                        log.error("Error: requesting async closure for transaction in state {}", status);
-                        return Mono.error(new AlreadyProcessedException(transaction.getTransactionId()));
-                    }
-
-                    // 2. Definizione dell'evento e del timeout (Logica di business estratta)
-                    return saveEventIfNeeded(transaction, command)
-                            .flatMap(tuple -> sendToQueue(tuple.getT2(), tuple.getT1()));
-                });
-    }
-
-    private boolean isValidStatus(TransactionStatusDto status) {
-        return Set.of(TransactionStatusDto.AUTHORIZATION_COMPLETED, TransactionStatusDto.CLOSURE_REQUESTED)
-                .contains(status);
-    }
-
-    private Mono<Tuple2<Duration, BaseTransactionEvent<?>>> saveEventIfNeeded(
-                                                                              BaseTransaction transaction,
-                                                                              TransactionClosureRequestCommand command
-    ) {
-        if (transaction.getStatus() == TransactionStatusDto.AUTHORIZATION_COMPLETED) {
-            var transactionClosureRequestedEvent = new it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent(
-                    transaction.getTransactionId().value()
-            );
-            return transactionEventSendClosureRequestRepository.save(transactionClosureRequestedEvent)
-                    .map(e -> Tuples.of(Duration.ZERO, e));
-        }
-
-        log.info(
-                "event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} already present. Processing it.",
-                transaction.getTransactionId()
+        Mono<BaseTransaction> transaction = transactionsUtils.reduceV2Events(
+                command.getEvents()
         );
 
-        var lastEvent = (BaseTransactionEvent<?>) command.getEvents().getLast();
-        return Mono.just(Tuples.of(Duration.ofSeconds(30), lastEvent));
-    }
+        Mono<? extends BaseTransaction> alreadyProcessedError = transaction
+                .doOnNext(t -> log.error("Error: requesting async closure for transaction in state {}", t.getStatus()))
+                .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getTransactionId())));
 
-    private Mono<BaseTransactionEvent<?>> sendToQueue(
-                                                      BaseTransactionEvent<?> event,
-                                                      Duration visibilityTimeout
-    ) {
-        return tracingUtils.traceMono(
-                this.getClass().getSimpleName(),
-                tracingInfo -> transactionClosureQueueAsyncClient.sendMessageWithResponse(
-                        new QueueEvent<>(event, tracingInfo),
-                        visibilityTimeout,
-                        Duration.ofSeconds(transientQueuesTTLSeconds)
-                )
-        )
-                .doOnNext(
-                        response -> log.info(
-                                "Generated and processed event {} for transactionId {}",
-                                event.getClass().getSimpleName(),
-                                event.getTransactionId()
-                        )
-                )
-                .doOnError(
-                        e -> log.error(
-                                "Error processing event for transactionId {} - {}",
-                                event.getTransactionId(),
-                                e.getMessage()
-                        )
-                )
-                .thenReturn(event);
+        return transaction.filter(
+                t -> Set.of(TransactionStatusDto.AUTHORIZATION_COMPLETED, TransactionStatusDto.CLOSURE_REQUESTED)
+                        .contains(t.getStatus())
+        ).switchIfEmpty(alreadyProcessedError)
+                .flatMap(
+                        t -> Mono.just(t)
+                                .filter(tr -> tr.getStatus() == TransactionStatusDto.AUTHORIZATION_COMPLETED)
+                                .cast(TransactionAuthorizationCompleted.class)
+                                .flatMap(trx -> {
+                                    it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent transactionClosureRequestedEvent = new it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent(
+                                            trx.getTransactionId().value()
+                                    );
+
+                                    return transactionEventSendClosureRequestRepository
+                                            .save(transactionClosureRequestedEvent)
+                                            .map(e -> Tuples.of(Duration.ZERO, e));
+                                })
+                                .switchIfEmpty(
+                                        Mono.just(command.getEvents().getLast())
+                                                .cast(TransactionClosureRequestedEvent.class)
+                                                .doOnNext(
+                                                        evt -> log.info(
+                                                                "event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} already present. Processing it.",
+                                                                evt.getTransactionId()
+                                                        )
+                                                )
+                                                .map(e -> Tuples.of(Duration.ofSeconds(30), e))
+                                )
+                ).flatMap(
+                        visibilityTimeout_event -> tracingUtils.traceMono(
+                                this.getClass().getSimpleName(),
+                                tracingInfo -> transactionClosureQueueAsyncClient
+                                        .sendMessageWithResponse(
+                                                new QueueEvent<>(visibilityTimeout_event.getT2(), tracingInfo),
+                                                visibilityTimeout_event.getT1(),
+                                                Duration.ofSeconds(transientQueuesTTLSeconds)
+                                        )
+                        ).thenReturn(visibilityTimeout_event.getT2())
+                                .doOnError(
+                                        exception -> log.error(
+                                                "Error to generate or processing event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} - error {}",
+                                                visibilityTimeout_event.getT2().getTransactionId(),
+                                                exception.getMessage()
+                                        )
+                                )
+                                .doOnNext(
+                                        evt -> log.info(
+                                                "Generated and processed event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {}",
+                                                visibilityTimeout_event.getT2().getTransactionId()
+                                        )
+                                )
+
+                );
+
     }
 }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
@@ -2,8 +2,6 @@ package it.pagopa.transactions.commands.handlers.v2;
 
 import it.pagopa.ecommerce.commons.client.QueueAsyncClient;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
-import it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent;
-import it.pagopa.ecommerce.commons.domain.v2.TransactionAuthorizationCompleted;
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.queues.QueueEvent;
@@ -19,6 +17,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import java.time.Duration;
@@ -42,69 +41,75 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
         this.transactionEventSendClosureRequestRepository = transactionEventSendClosureRequestRepository;
     }
 
-    @Override
     public Mono<BaseTransactionEvent<?>> handle(TransactionClosureRequestCommand command) {
-        Mono<BaseTransaction> transaction = transactionsUtils.reduceV2Events(
-                command.getEvents()
+        return transactionsUtils.reduceV2Events(command.getEvents())
+                .flatMap(transaction -> {
+                    TransactionStatusDto status = transaction.getStatus();
+
+                    // 1. Validazione Stato
+                    if (!isValidStatus(status)) {
+                        log.error("Error: requesting async closure for transaction in state {}", status);
+                        return Mono.error(new AlreadyProcessedException(transaction.getTransactionId()));
+                    }
+
+                    // 2. Definizione dell'evento e del timeout (Logica di business estratta)
+                    return saveEventIfNeeded(transaction, command)
+                            .flatMap(tuple -> sendToQueue(tuple.getT2(), tuple.getT1()));
+                });
+    }
+
+    private boolean isValidStatus(TransactionStatusDto status) {
+        return Set.of(TransactionStatusDto.AUTHORIZATION_COMPLETED, TransactionStatusDto.CLOSURE_REQUESTED)
+                .contains(status);
+    }
+
+    private Mono<Tuple2<Duration, BaseTransactionEvent<?>>> saveEventIfNeeded(
+                                                                              BaseTransaction transaction,
+                                                                              TransactionClosureRequestCommand command
+    ) {
+        if (transaction.getStatus() == TransactionStatusDto.AUTHORIZATION_COMPLETED) {
+            var transactionClosureRequestedEvent = new it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent(
+                    transaction.getTransactionId().value()
+            );
+            return transactionEventSendClosureRequestRepository.save(transactionClosureRequestedEvent)
+                    .map(e -> Tuples.of(Duration.ZERO, e));
+        }
+
+        log.info(
+                "event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} already present. Processing it.",
+                transaction.getTransactionId()
         );
 
-        Mono<? extends BaseTransaction> alreadyProcessedError = transaction
-                .doOnNext(t -> log.error("Error: requesting async closure for transaction in state {}", t.getStatus()))
-                .flatMap(t -> Mono.error(new AlreadyProcessedException(t.getTransactionId())));
+        var lastEvent = (BaseTransactionEvent<?>) command.getEvents().getLast();
+        return Mono.just(Tuples.of(Duration.ofSeconds(30), lastEvent));
+    }
 
-        return transaction.filter(
-                t -> Set.of(TransactionStatusDto.AUTHORIZATION_COMPLETED, TransactionStatusDto.CLOSURE_REQUESTED)
-                        .contains(t.getStatus())
-        ).switchIfEmpty(alreadyProcessedError)
-                .flatMap(
-                        t -> Mono.just(t)
-                                .filter(tr -> tr.getStatus() == TransactionStatusDto.AUTHORIZATION_COMPLETED)
-                                .cast(TransactionAuthorizationCompleted.class)
-                                .flatMap(trx -> {
-                                    it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent transactionClosureRequestedEvent = new it.pagopa.ecommerce.commons.documents.v2.TransactionClosureRequestedEvent(
-                                            trx.getTransactionId().value()
-                                    );
-
-                                    return transactionEventSendClosureRequestRepository
-                                            .save(transactionClosureRequestedEvent)
-                                            .map(e -> Tuples.of(Duration.ZERO, e));
-                                })
-                                .switchIfEmpty(
-                                        Mono.just(command.getEvents().getLast())
-                                                .cast(TransactionClosureRequestedEvent.class)
-                                                .doOnNext(
-                                                        evt -> log.info(
-                                                                "event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} already present. Processing it.",
-                                                                evt.getTransactionId()
-                                                        )
-                                                )
-                                                .map(e -> Tuples.of(Duration.ofSeconds(30), e))
-                                )
-                ).flatMap(
-                        visibilityTimeout_event -> tracingUtils.traceMono(
-                                this.getClass().getSimpleName(),
-                                tracingInfo -> transactionClosureQueueAsyncClient
-                                        .sendMessageWithResponse(
-                                                new QueueEvent<>(visibilityTimeout_event.getT2(), tracingInfo),
-                                                visibilityTimeout_event.getT1(),
-                                                Duration.ofSeconds(transientQueuesTTLSeconds)
-                                        )
-                        ).thenReturn(visibilityTimeout_event.getT2())
-                                .doOnError(
-                                        exception -> log.error(
-                                                "Error to generate or processing event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} - error {}",
-                                                visibilityTimeout_event.getT2().getTransactionId(),
-                                                exception.getMessage()
-                                        )
-                                )
-                                .doOnNext(
-                                        evt -> log.info(
-                                                "Generated and processed event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {}",
-                                                visibilityTimeout_event.getT2().getTransactionId()
-                                        )
-                                )
-
-                );
-
+    private Mono<BaseTransactionEvent<?>> sendToQueue(
+                                                      BaseTransactionEvent<?> event,
+                                                      Duration visibilityTimeout
+    ) {
+        return tracingUtils.traceMono(
+                this.getClass().getSimpleName(),
+                tracingInfo -> transactionClosureQueueAsyncClient.sendMessageWithResponse(
+                        new QueueEvent<>(event, tracingInfo),
+                        visibilityTimeout,
+                        Duration.ofSeconds(transientQueuesTTLSeconds)
+                )
+        )
+                .doOnNext(
+                        response -> log.info(
+                                "Generated and processed event {} for transactionId {}",
+                                event.getClass().getSimpleName(),
+                                event.getTransactionId()
+                        )
+                )
+                .doOnError(
+                        e -> log.error(
+                                "Error processing event for transactionId {} - {}",
+                                event.getTransactionId(),
+                                e.getMessage()
+                        )
+                )
+                .thenReturn(event);
     }
 }

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
@@ -9,6 +9,7 @@ import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.queues.QueueEvent;
 import it.pagopa.ecommerce.commons.queues.TracingUtils;
 import it.pagopa.transactions.commands.TransactionClosureRequestCommand;
+import it.pagopa.transactions.commands.data.ClosureRequestedEventData;
 import it.pagopa.transactions.commands.handlers.TransactionSendClosureRequestHandlerCommon;
 import it.pagopa.transactions.exceptions.AlreadyProcessedException;
 import it.pagopa.transactions.repositories.TransactionsEventStoreRepository;
@@ -67,7 +68,7 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
 
                                     return transactionEventSendClosureRequestRepository
                                             .save(transactionClosureRequestedEvent)
-                                            .map(e -> Tuples.of(Duration.ZERO, e));
+                                            .map(e -> new ClosureRequestedEventData(Duration.ZERO, e));
                                 })
                                 .switchIfEmpty(
                                         Mono.just(command.getEvents().getLast())
@@ -78,29 +79,34 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
                                                                 evt.getTransactionId()
                                                         )
                                                 )
-                                                .map(e -> Tuples.of(Duration.ofSeconds(30), e))
+                                                .map(e -> new ClosureRequestedEventData(Duration.ofSeconds(30), e))
                                 )
                 ).flatMap(
-                        visibilityTimeout_event -> tracingUtils.traceMono(
+                        closureRequestedEventData -> tracingUtils.traceMono(
                                 this.getClass().getSimpleName(),
                                 tracingInfo -> transactionClosureQueueAsyncClient
                                         .sendMessageWithResponse(
-                                                new QueueEvent<>(visibilityTimeout_event.getT2(), tracingInfo),
-                                                visibilityTimeout_event.getT1(),
+                                                new QueueEvent<>(
+                                                        closureRequestedEventData.transactionClosureRequestedEvent(),
+                                                        tracingInfo
+                                                ),
+                                                closureRequestedEventData.visibilityTimeout(),
                                                 Duration.ofSeconds(transientQueuesTTLSeconds)
                                         )
-                        ).thenReturn(visibilityTimeout_event.getT2())
+                        ).thenReturn(closureRequestedEventData.transactionClosureRequestedEvent())
                                 .doOnError(
                                         exception -> log.error(
                                                 "Error to generate or processing event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} - error {}",
-                                                visibilityTimeout_event.getT2().getTransactionId(),
+                                                closureRequestedEventData.transactionClosureRequestedEvent()
+                                                        .getTransactionId(),
                                                 exception.getMessage()
                                         )
                                 )
                                 .doOnNext(
                                         evt -> log.info(
                                                 "Generated and processed event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {}",
-                                                visibilityTimeout_event.getT2().getTransactionId()
+                                                closureRequestedEventData.transactionClosureRequestedEvent()
+                                                        .getTransactionId()
                                         )
                                 )
 

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
 
 import java.time.Duration;
 import java.util.Set;
@@ -65,7 +66,8 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
                                     );
 
                                     return transactionEventSendClosureRequestRepository
-                                            .save(transactionClosureRequestedEvent);
+                                            .save(transactionClosureRequestedEvent)
+                                            .map(e -> Tuples.of(Duration.ZERO, e));
                                 })
                                 .switchIfEmpty(
                                         Mono.just(command.getEvents().getLast())
@@ -76,28 +78,29 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
                                                                 evt.getTransactionId()
                                                         )
                                                 )
+                                                .map(e -> Tuples.of(Duration.ofSeconds(30), e))
                                 )
                 ).flatMap(
-                        event -> tracingUtils.traceMono(
+                        visibilityTimeout_event -> tracingUtils.traceMono(
                                 this.getClass().getSimpleName(),
                                 tracingInfo -> transactionClosureQueueAsyncClient
                                         .sendMessageWithResponse(
-                                                new QueueEvent<>(event, tracingInfo),
-                                                Duration.ZERO,
+                                                new QueueEvent<>(visibilityTimeout_event.getT2(), tracingInfo),
+                                                visibilityTimeout_event.getT1(),
                                                 Duration.ofSeconds(transientQueuesTTLSeconds)
                                         )
-                        ).thenReturn(event)
+                        ).thenReturn(visibilityTimeout_event.getT2())
                                 .doOnError(
                                         exception -> log.error(
                                                 "Error to generate or processing event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {} - error {}",
-                                                event.getTransactionId(),
+                                                visibilityTimeout_event.getT2().getTransactionId(),
                                                 exception.getMessage()
                                         )
                                 )
                                 .doOnNext(
                                         evt -> log.info(
                                                 "Generated and processed event TRANSACTION_CLOSURE_REQUESTED_EVENT for transactionId {}",
-                                                evt.getTransactionId()
+                                                visibilityTimeout_event.getT2().getTransactionId()
                                         )
                                 )
 

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
@@ -98,7 +98,7 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
         )
                 .doOnNext(
                         response -> log.info(
-                                "Generated and processed event {} for transactionId {}",
+                                "Processed event {} for transactionId {}",
                                 event.getClass().getSimpleName(),
                                 event.getTransactionId()
                         )

--- a/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/v2/TransactionSendClosureRequestHandler.java
@@ -98,7 +98,7 @@ public class TransactionSendClosureRequestHandler extends TransactionSendClosure
         )
                 .doOnNext(
                         response -> log.info(
-                                "Processed event {} for transactionId {}",
+                                "Generated and processed event {} for transactionId {}",
                                 event.getClass().getSimpleName(),
                                 event.getTransactionId()
                         )


### PR DESCRIPTION
Add 30 seconds visibility timeout to second closure_requested event to avoid concurrent processing

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.