### PR TITLE
fix: add cache to avoid multiple subscription make multiple queries

### DIFF
--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -1173,7 +1173,7 @@ public class TransactionsService {
                                                                                    UUID xUserId
     ) {
         return eventsRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
-                .cache(Duration.ofSeconds(10))
+                .cache()
                 .collectList()
                 .filter(Predicate.not(List::isEmpty))
                 .filterWhen(
@@ -1201,7 +1201,7 @@ public class TransactionsService {
         Flux<? extends BaseTransactionEvent<?>> events = eventsRepository
                 .findByTransactionIdOrderByCreationDateAsc(transactionId.value())
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId.value())))
-                .cache(Duration.ofSeconds(10));
+                .cache();
 
         Mono<ZonedDateTime> authorizationRequestedCreationDate = events
                 .filter(
@@ -1532,7 +1532,7 @@ public class TransactionsService {
                                                    AddUserReceiptRequestDto addUserReceiptRequest
     ) {
         return eventsRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
-                .cache(Duration.ofSeconds(10))
+                .cache()
                 .collectList()
                 .filter(Predicate.not(List::isEmpty))
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId)))

--- a/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
+++ b/src/main/java/it/pagopa/transactions/services/v1/TransactionsService.java
@@ -3,7 +3,6 @@ package it.pagopa.transactions.services.v1;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.opentelemetry.api.common.Attributes;
-import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionView;
 import it.pagopa.ecommerce.commons.documents.PaymentTransferInformation;
@@ -46,6 +45,7 @@ import reactor.util.function.Tuple4;
 import reactor.util.function.Tuples;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.Predicate;
@@ -1173,6 +1173,7 @@ public class TransactionsService {
                                                                                    UUID xUserId
     ) {
         return eventsRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
+                .cache(Duration.ofSeconds(10))
                 .collectList()
                 .filter(Predicate.not(List::isEmpty))
                 .filterWhen(
@@ -1200,7 +1201,7 @@ public class TransactionsService {
         Flux<? extends BaseTransactionEvent<?>> events = eventsRepository
                 .findByTransactionIdOrderByCreationDateAsc(transactionId.value())
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId.value())))
-                .cache();
+                .cache(Duration.ofSeconds(10));
 
         Mono<ZonedDateTime> authorizationRequestedCreationDate = events
                 .filter(
@@ -1531,6 +1532,7 @@ public class TransactionsService {
                                                    AddUserReceiptRequestDto addUserReceiptRequest
     ) {
         return eventsRepository.findByTransactionIdOrderByCreationDateAsc(transactionId)
+                .cache(Duration.ofSeconds(10))
                 .collectList()
                 .filter(Predicate.not(List::isEmpty))
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId)))

--- a/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -353,7 +354,8 @@ public class TransactionsUtils {
         return eventStoreRepository.findByTransactionIdOrderByCreationDateAsc(transactionId.value())
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId.value())))
                 .reduce(initialValue, accumulator)
-                .cast(clazz);
+                .cast(clazz)
+                .cache(Duration.ofSeconds(10));
     }
 
     public <A, T> Mono<T> reduceEvents(

--- a/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
+++ b/src/main/java/it/pagopa/transactions/utils/TransactionsUtils.java
@@ -355,7 +355,7 @@ public class TransactionsUtils {
                 .switchIfEmpty(Mono.error(new TransactionNotFoundException(transactionId.value())))
                 .reduce(initialValue, accumulator)
                 .cast(clazz)
-                .cache(Duration.ofSeconds(10));
+                .cache();
     }
 
     public <A, T> Mono<T> reduceEvents(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
add cache to eventstore query returned flux in order to avoid multiple queries to be performed in case of same mono subscription 
<!--- Describe your changes in detail -->

#### Motivation and Context
cold mono causes a query to be performed for each mono subscription:
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.