### PR TITLE
fix: double profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
 COPY src src
 COPY api-spec api-spec
 COPY eclipse-style.xml eclipse-style.xml
+ENV ACTIVE_PROFILE=k8s
 RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
     ./mvnw compile spring-boot:process-aot install -DskipTests
 
@@ -50,7 +51,6 @@ RUN java \
 -XX:ArchiveClassesAtExit=../cds.jsa \
 -Dspring.context.exit=onRefresh \
 -Dspring.config.location=/workspace/app/application-tests.properties \
--Dspring-boot.run.jvmArguments="-Dspring.profiles.active=k8s" \
 org.springframework.boot.loader.launch.JarLauncher
 
 FROM eclipse-temurin:21-jre-alpine@sha256:8728e354e012e18310faa7f364d00185277dec741f4f6d593af6c61fc0eb15fd

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN java \
 -XX:ArchiveClassesAtExit=../cds.jsa \
 -Dspring.context.exit=onRefresh \
 -Dspring.config.location=/workspace/app/application-tests.properties \
+-Dspring-boot.run.jvmArguments="-DACTIVE_PROFILE=k8s" \
 org.springframework.boot.loader.launch.JarLauncher
 
 FROM eclipse-temurin:21-jre-alpine@sha256:8728e354e012e18310faa7f364d00185277dec741f4f6d593af6c61fc0eb15fd

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN java \
 -XX:ArchiveClassesAtExit=../cds.jsa \
 -Dspring.context.exit=onRefresh \
 -Dspring.config.location=/workspace/app/application-tests.properties \
--Dspring-boot.run.jvmArguments="-DACTIVE_PROFILE=k8s" \
+-Dspring-boot.run.jvmArguments="-Dspring.profiles.active=k8s" \
 org.springframework.boot.loader.launch.JarLauncher
 
 FROM eclipse-temurin:21-jre-alpine@sha256:8728e354e012e18310faa7f364d00185277dec741f4f6d593af6c61fc0eb15fd


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Add `ENV ACTIVE_PROFILE=k8s` to use this profile during the process-aot compile 

<!--- Describe your changes in detail -->

#### Motivation and Context
During the `./mvnw compile spring-boot:process-aot install -DskipTests`, the `local` profile is use and added as default, causing the application to always log using also this profile setting, and duplicate all the logs if the env variable `ACTIVE_PROFILE` is different.
The solution introduced add the env variable ACTIVE_PROFILE setted as `k8s`, that is the profile used in our cluster deployment, to force the application to use it always.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.