### PR TITLE
[PIDM-2143] chore: remove unused commons-lang 2.6 dependency

### DIFF
--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -309,11 +309,11 @@
       "sha256": "T-tKHPs6GEvPXxmeIJk13plEsYto0MD0PmBqrJ3lH78="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0",
+      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0",
-      "sha256": "Yv-MOKcTkPf_jgoVZnktlBkThfBAzzCR8eQ7tX2q76I="
+      "version": "3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
+      "sha256": "jJviNQxZQp2z0IqASCZgDhomBi1N-qM20O7x6fWytc8="
     },
     {
       "id": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.18.3",
@@ -328,13 +328,6 @@
       "groupId": "commons-codec",
       "version": "1.17.2",
       "sha256": "QUgzJyhJDO8Ssp2sTDhfRpgvBChRMsb6Ua1yZ9fceos="
-    },
-    {
-      "id": "commons-lang:commons-lang:jar:2.6",
-      "artifactId": "commons-lang",
-      "groupId": "commons-lang",
-      "version": "2.6",
-      "sha256": "UPEbCfh3wpTVbyRGP0fSj5Kc9QRPZIZhwPDPuumi9Jw="
     },
     {
       "id": "io.vavr:vavr:jar:0.10.4",
@@ -1695,11 +1688,11 @@
       "sha256": "deQif7fcX5fD1Gic0cJDn02wvRjOovokLEZWzZPFmao="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0",
+      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0",
-      "sha256": "LsJGsMZ7DZ_tvKuvM-B5uZFqP0dUnJC5VOAbpxKaPU4="
+      "version": "3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
+      "sha256": "2rKzukwwFtKRJFW_5308z542BEC5w9AU1k_wWA8qim8="
     },
     {
       "id": "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.119.Final",

--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -330,6 +330,13 @@
       "sha256": "QUgzJyhJDO8Ssp2sTDhfRpgvBChRMsb6Ua1yZ9fceos="
     },
     {
+      "id": "commons-lang:commons-lang:jar:2.6",
+      "artifactId": "commons-lang",
+      "groupId": "commons-lang",
+      "version": "2.6",
+      "sha256": "UPEbCfh3wpTVbyRGP0fSj5Kc9QRPZIZhwPDPuumi9Jw="
+    },
+    {
       "id": "io.vavr:vavr:jar:0.10.4",
       "artifactId": "vavr",
       "groupId": "io.vavr",
@@ -1392,13 +1399,6 @@
       "groupId": "com.fasterxml.jackson.core",
       "version": "2.18.3",
       "sha256": "BWvE0-XlPOghRQ-pez-eD43eElz22miENTux8JWC4dk="
-    },
-    {
-      "id": "commons-lang:commons-lang:jar:2.6",
-      "artifactId": "commons-lang",
-      "groupId": "commons-lang",
-      "version": "2.6",
-      "sha256": "UPEbCfh3wpTVbyRGP0fSj5Kc9QRPZIZhwPDPuumi9Jw="
     },
     {
       "id": "org.jacoco:jacoco-maven-plugin:jar:0.8.13",

--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -309,11 +309,11 @@
       "sha256": "T-tKHPs6GEvPXxmeIJk13plEsYto0MD0PmBqrJ3lH78="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
+      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.1",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
-      "sha256": "jJviNQxZQp2z0IqASCZgDhomBi1N-qM20O7x6fWytc8="
+      "version": "3.8.1",
+      "sha256": "afcVTLpqdu9VG2pI_ceqZPEV9eRxTy03THQAgTde1_8="
     },
     {
       "id": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.18.3",
@@ -1688,11 +1688,11 @@
       "sha256": "deQif7fcX5fD1Gic0cJDn02wvRjOovokLEZWzZPFmao="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
+      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.1",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb",
-      "sha256": "2rKzukwwFtKRJFW_5308z542BEC5w9AU1k_wWA8qim8="
+      "version": "3.8.1",
+      "sha256": "oiCdNwFuUaqGyZC36f9GjBoXqn2gUkilCMjWuFS-mog="
     },
     {
       "id": "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.119.Final",

--- a/pom.xml
+++ b/pom.xml
@@ -183,12 +183,6 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>${jacoco.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <java.version>21</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.13</jacoco.version>
-        <pagopa-ecommerce-commons.version>3.8.0</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.7.0</ecs-logging-version>
         <mock-web-server.version>5.3.2</mock-web-server.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <java.version>21</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.13</jacoco.version>
-        <pagopa-ecommerce-commons.version>3.8.0-PIDM-2143-aggiornamento-commons-lang-SNAPSHOT-a79babb</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>3.8.1</pagopa-ecommerce-commons.version>
         <spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.7.0</ecs-logging-version>
         <mock-web-server.version>5.3.2</mock-web-server.version>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Removed commons-lang:commons-lang:2.6 dependency from pom.xml

#### Motivation and Context

commons-lang 2.6 is affected by security vulnerability. Codebase analysis confirmed the library is not actively used in the project, so it has been removed entirely rather than upgraded.

#### How Has This Been Tested?

- Verified via IntelliJ Find Usages that no class or method from commons-lang is imported or used in the source code
- Verified that the project compiles correctly after removal via ./mvnw compile

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.