### PR TITLE
fix: [PIDM-2191] Use paymentTypeCode for PaymentMethod resolution

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -57,7 +57,7 @@ resources:
     - repository: pagopaCheckoutTests
       type: github
       name: pagopa/pagopa-checkout-tests
-      ref: main
+      ref: PIDM-1970-fix-checkout-integration
       endpoint: 'io-azure-devops-github-ro'
     - repository: pagopaEcommerceTests
       type: github

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -57,7 +57,7 @@ resources:
     - repository: pagopaCheckoutTests
       type: github
       name: pagopa/pagopa-checkout-tests
-      ref: PIDM-1970-fix-checkout-integration
+      ref: main
       endpoint: 'io-azure-devops-github-ro'
     - repository: pagopaEcommerceTests
       type: github

--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -309,11 +309,11 @@
       "sha256": "T-tKHPs6GEvPXxmeIJk13plEsYto0MD0PmBqrJ3lH78="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.9.0",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
-      "sha256": "iE9aid_2YF5vGHvOrod9K7Gk6Lnw2zuRJA7Y4gJ3UA8="
+      "version": "3.9.0",
+      "sha256": "Y6_BCEWtaphqnJFqM1zKgw06F_Fv0v5pWSJ0Uclf7t0="
     },
     {
       "id": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.18.3",
@@ -1695,11 +1695,11 @@
       "sha256": "deQif7fcX5fD1Gic0cJDn02wvRjOovokLEZWzZPFmao="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.9.0",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
-      "sha256": "n7kv5ZA7u0RlPDQehf83z4Tp4UEwMboQgucEj6Xut9A="
+      "version": "3.9.0",
+      "sha256": "bZISyIWoxtMC6KhPj7rbt88-bz4zYO2tm6HZFgR1rzk="
     },
     {
       "id": "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.119.Final",

--- a/dep-sha256.json
+++ b/dep-sha256.json
@@ -309,11 +309,11 @@
       "sha256": "T-tKHPs6GEvPXxmeIJk13plEsYto0MD0PmBqrJ3lH78="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0",
+      "id": "it.pagopa:pagopa-ecommerce-commons:jar:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0",
-      "sha256": "Yv-MOKcTkPf_jgoVZnktlBkThfBAzzCR8eQ7tX2q76I="
+      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "sha256": "iE9aid_2YF5vGHvOrod9K7Gk6Lnw2zuRJA7Y4gJ3UA8="
     },
     {
       "id": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.18.3",
@@ -1695,11 +1695,11 @@
       "sha256": "deQif7fcX5fD1Gic0cJDn02wvRjOovokLEZWzZPFmao="
     },
     {
-      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0",
+      "id": "it.pagopa:pagopa-ecommerce-commons:test-jar:tests:3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
       "artifactId": "pagopa-ecommerce-commons",
       "groupId": "it.pagopa",
-      "version": "3.8.0",
-      "sha256": "LsJGsMZ7DZ_tvKuvM-B5uZFqP0dUnJC5VOAbpxKaPU4="
+      "version": "3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd",
+      "sha256": "n7kv5ZA7u0RlPDQehf83z4Tp4UEwMboQgucEj6Xut9A="
     },
     {
       "id": "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.119.Final",

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <java.version>21</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.13</jacoco.version>
-        <pagopa-ecommerce-commons.version>3.8.0</pagopa-ecommerce-commons.version>
-        <spotless.version>2.28.0</spotless.version>
+        <pagopa-ecommerce-commons.version>3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd</pagopa-ecommerce-commons.version>
+		<spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.7.0</ecs-logging-version>
         <mock-web-server.version>5.3.2</mock-web-server.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <java.version>21</java.version>
         <spring-cloud-azure.version>4.0.0</spring-cloud-azure.version>
         <jacoco.version>0.8.13</jacoco.version>
-        <pagopa-ecommerce-commons.version>3.8.0-PIDM-2191-add-type-code-payment-method-SNAPSHOT-9224dcd</pagopa-ecommerce-commons.version>
+        <pagopa-ecommerce-commons.version>3.9.0</pagopa-ecommerce-commons.version>
 		<spotless.version>2.28.0</spotless.version>
         <ecs-logging-version>1.7.0</ecs-logging-version>
         <mock-web-server.version>5.3.2</mock-web-server.version>

--- a/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
+++ b/src/main/java/it/pagopa/transactions/client/PaymentGatewayClient.java
@@ -176,7 +176,7 @@ public class PaymentGatewayClient {
                             Either<NpgApiKeyConfigurationException, String> buildApiKey = isApmPayment
                                     ? npgApiKeyConfiguration.getApiKeyForPaymentMethod(
                                             NpgClient.PaymentMethod
-                                                    .valueOf(authorizationData.paymentMethodName()),
+                                                    .fromMethodTypeCode(authorizationData.paymentTypeCode()),
                                             authorizationData.pspId()
                                     )
                                     : Either.right(npgApiKeyConfiguration.getDefaultApiKey());
@@ -193,7 +193,7 @@ public class PaymentGatewayClient {
                                                     orderId,
                                                     null,
                                                     NpgClient.PaymentMethod
-                                                            .valueOf(authorizationData.paymentMethodName()),
+                                                            .fromMethodTypeCode(authorizationData.paymentTypeCode()),
                                                     apiKey,
                                                     isWalletPayment ? authorizationData.contractId().orElseThrow(
                                                             () -> new InternalServerErrorException(
@@ -218,7 +218,7 @@ public class PaymentGatewayClient {
                                                     orderId,
                                                     null,
                                                     NpgClient.PaymentMethod
-                                                            .valueOf(authorizationData.paymentMethodName()),
+                                                            .fromMethodTypeCode(authorizationData.paymentTypeCode()),
                                                     apiKey,
                                                     authorizationData.contractId().orElseThrow(
                                                             () -> new InternalServerErrorException(

--- a/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
+++ b/src/main/java/it/pagopa/transactions/commands/handlers/TransactionRequestAuthorizationHandlerCommon.java
@@ -95,7 +95,7 @@ public abstract class TransactionRequestAuthorizationHandlerCommon
                     .getOrderId(), correlationId, clientId, Optional.ofNullable(userId))
             ;
             case WalletAuthRequestDetailsDto ignored -> {
-                NpgClient.PaymentMethod npgPaymentMethod = NpgClient.PaymentMethod.valueOf(authorizationData.paymentMethodName());
+                NpgClient.PaymentMethod npgPaymentMethod = NpgClient.PaymentMethod.fromMethodTypeCode(authorizationData.paymentTypeCode());
                 if (npgPaymentMethod.equals(NpgClient.PaymentMethod.CARDS)) {
                     yield walletNpgCardsPaymentFlow(authorizationData, correlationId, clientId, lang, userId);
                 } else {


### PR DESCRIPTION
depends on pagopa/pagopa-checkout-tests#132

#### List of Changes

- Replaced all occurrences of` NpgClient.PaymentMethod.valueOf(authorizationData.paymentMethodName())` with `NpgClient.PaymentMethod.fromMethodTypeCode(authorizationData.paymentTypeCode())`

#### Motivation and Context

The paymentTypeCode (e.g. "PPAL", "CP") is a stable identifier already available in AuthorizationRequestData and is not affected by localization like paymentMethodName. The new fromMethodTypeCode method in pagopa-ecommerce-commons resolves the enum by this code.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.